### PR TITLE
feat: dsh-llm-fallbacks — role/model-chain LLM fallbacks for dsh agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Morning Star harness (.mstar/)
+# Principle: process stays local; results are shared with the team.
+# Ignored (process / coordination):
+.mstar/archived/
+.mstar/iterations/
+.mstar/plans/
+.mstar/sdd/
+.mstar/notes.json
+.mstar/status.json
+# Tracked (results): .mstar/AGENTS.md, .mstar/knowledge/, .mstar/specs/
+
+# feature worktrees
+.worktrees/
+
+# build artifacts
+node_modules/
+dist/

--- a/.mstar/knowledge/README.md
+++ b/.mstar/knowledge/README.md
@@ -1,0 +1,7 @@
+# Knowledge
+
+| Document | Source Plan | Description | Status |
+|----------|-------------|-------------|--------|
+| [architecture-patterns/dsh-llm-fallbacks.md](architecture-patterns/dsh-llm-fallbacks.md) | llm-fallbacks-plugin | dsh LLM fallback 双 waterfall 恢复架构（ADR-1..4、链解析、冷却/安全阀、always-cap、状态机、已知限制） | Active |
+| [best-practices/dsh-cordis-plugin-authoring.md](best-practices/dsh-cordis-plugin-authoring.md) | llm-fallbacks-plugin | dsh 第三方 cordis 插件创作 playbook（bundle/client/peer-stubs/构建/settings 坑位） | Active |
+| [workflow-patterns/harness-sandbox-verification.md](workflow-patterns/harness-sandbox-verification.md) | llm-fallbacks-plugin | dsh 沙箱兼容验证模式（scratch DSH_HOME / 只读 git apply --check / 编译级验证） | Active |

--- a/.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md
@@ -1,0 +1,71 @@
+---
+module: dsh-llm-fallbacks
+date: 2026-08-10
+problem_type: architecture_pattern
+category: architecture-patterns
+severity: low
+plan_id: llm-fallbacks-plugin
+applies_when:
+  - 在 dsh 中实现模型/请求级自动恢复或路由切换功能
+  - 需要理解 omp llm-fallbacks 语义如何落到 dsh 事件面
+  - 需要扩展或维护 dsh-llm-fallbacks 插件
+tags:
+  - dsh
+  - llm-fallbacks
+  - agent
+  - fallback-chains
+  - request-error
+---
+
+# dsh LLM fallback 架构：双 waterfall 恢复模式
+
+将 omp 的 retry.modelFallback / retry.fallbackChains 语义移植到 dsh 时的已验证架构（iter-20260810-llm-fallbacks 产物，随实现验证）。
+
+## Context
+
+dsh 的 agent loop 在模型请求失败时派发 agent/request-error waterfall；llm-retry 插件（dsh-base 内置）按 provider 的 retryPolicy 做同模型退避重试，预算耗尽或不可重试码（AUTH/QUOTA）时 next() 委托下游；mode:'always' 时 llm-retry 先委托下游再退避。模型选择经 agent/request waterfall 返回的 LlmCallConfig 决定（seed → waterfall → prepareCall）。失败码 taxonomy：AUTH(401/403)、QUOTA（QUOTA_EXCEEDED_CODE）、RATE_LIMIT(429)、CONTEXT_WINDOW_EXCEEDED 等。
+
+## Guidance
+
+### 核心模式：决策在 request-error、应用在 request（ADR-1/ADR-4）
+
+1. agent/request-error 监听（注册在 llm-retry 之后）：未启用 / code 不在 triggerCodes → next()（always 模式同样透传）；命中候选 → 写每-agent pendingSwitch + cooldown 抑制 + stepFailures 记账 + append fallbacks/switch 事件 → 返回 {kind:'retry'}（拥有恢复，不调 next）。无候选 / 安全阀超限 → next()（原错误语义不变）。
+2. agent/request 监听：await next() 后应用 pendingSwitch（provider/model 覆写、丢弃继承的 reasoningEffort——installModelSelection 的 withoutInheritedEffort 模式）并清除；appliedTurnStep 防重放。
+3. 候选过滤：当前模型 / 冷却中 / 本步已失败 / provider/* 条目目标 provider 无此模型 id（存在性探针，仅 wildcard 条目受探针约束；exact 条目永不探针过滤）。
+
+### 链解析（omp fallbackChains 语义）
+
+specificity：exact provider/model 键 → provider/* 键 → 角色链 → default 链。条目 provider/* = 保留失败模型 id 仅换 provider。角色源顺序：agent.options.role（dsh role patch 后）→ roles.rules 顺序匹配（origin/provider/model）→ roles.default。
+
+### 冷却与安全阀
+
+cooldownMs 内被切离/失败模型不入选；revertPolicy: 'cooldown-expiry' 到期回主、'never' 用 Infinity TTL 会话内不回。每 step 失败模型集合 + maxSwitchesPerStep 双重防护；链耗尽保持原 LlmError 语义。
+
+### mode:'always' 的 cap（ADR-2）
+
+llm-retry always 模式先 next() 委托下游——若在 request-error 直接切换会抢占退避。故 cap 在 agent/request 边界生效：按 (turn, step, provider) 计数已持久化 llm/retry 事件（只计 mode === 'always' 条目）≥ alwaysModeRetryCap 才切换。
+
+### 状态机（每-agent）
+
+Map<agent.id, AgentFallbackState>：pendingSwitch（产生→应用→清除；同 (turn,step) 链式切换靠 writePending 清 appliedTurnStep）、stepFailures（step 推进重置）、cooldown（跨 idle 保留——US-4 跨 turn 回主需要）、agent/disposed 清理、插件 dispose 整体清空（无残留）。
+
+### 已知限制（open residual）
+
+- 活跃 model-selection（installModelSelection 先注册且 selection 活跃）会在 fallback 覆写之上再次应用外层 selection，路由最终指向用户所选模型（切换仍决策/事件化）；协调 seam 需 dsh 核心决策。
+- 失败码默认 ['AUTH','QUOTA','RATE_LIMIT']；5xx/TRANSPORT 等由 llm-retry 先行退避，预算耗尽后同样进入 fallback 决策，无需额外配置。
+
+## Why This Matters
+
+恢复语义归属（request-error 拥有恢复 vs request 路由覆写）分离使插件完全自包含、零侵入 dsh 核心；llm-retry 共存顺序与 always-cap 边界是移植中最易出错的两处，均有测试固化（双插件共存矩阵、mutation-red 验证）。
+
+## When to Apply
+
+- dsh 内任何「失败后换模型/换路由继续」类功能（retry、fallback、模型降级、按负载分流）。
+- 需要理解 fallbacks/switch 事件、fallbacks settings 命名空间或 selector 语法时。
+
+## Examples
+
+- 链配置示例见本插件 docs/configuration.md（仓库内）。
+- 集成测试矩阵：tests/coexist-llm-retry.spec.ts、tests/always-mode.spec.ts、tests/plugin.spec.ts。
+
+*Source: iteration iter-20260810-llm-fallbacks，由 specs/llm-fallbacks-spec.md 提升。*

--- a/.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md
+++ b/.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md
@@ -1,0 +1,65 @@
+---
+module: dsh-plugin-authoring
+date: 2026-08-10
+problem_type: best_practice
+category: best-practices
+severity: low
+plan_id: llm-fallbacks-plugin
+applies_when:
+  - 为 dsh（DeepSeek Harness）编写第三方 cordis 插件
+  - 插件需要 host 半（服务/事件/waterfall）与 web client 半（设置页/面板）
+  - 需要消费 @deepseek-ai/* 包的类型或运行时面
+tags:
+  - dsh
+  - cordis
+  - plugin
+  - bundle
+  - peer-stubs
+  - settings
+---
+
+# dsh 第三方 cordis 插件创作模式（已验证 playbook）
+
+dsh-llm-fallbacks 迭代验证的 dsh 插件创作全流程（bundle 组合层 → host 半 → client 半 → 类型访问 → patch 交付）。
+
+## Context
+
+dsh 插件 = npm 包，package.json 声明 dsh.bundle.patch（指向 bundle/cordis.patch.yml，YAML 数组「insert: id/name/config」），经 `dsh plugin --profile <name> add .` 装入 profile（bundles 列表顺序决定加载顺序；后装 bundle 的行在 llm-retry 等内置行之后插入——waterfall 注册顺序依赖此）。@deepseek-ai/* 包未发布公共 registry（404），运行期由 dsh 宿主 in-box 解析；pnpm-workspace.yaml 需 autoInstallPeers: false。
+
+## Guidance
+
+### 包结构与构建
+
+- exports：主入口、./client、./bundle/cordis.patch.yml、./package.json；files 含 dist 与 bundle。
+- host 半：bun build --target node --external cordis --external '@deepseek-ai/*'（外部化 import 由宿主 in-box 解析）+ bunx tsc（d.ts）。
+- client 半：closure-factory CJS bundle（window.__ModuleLoader__.load 契约），经 dshClient.inject 声明依赖；CSS-modules 需自定义 transform（类名哈希 + style 标签内联注入/卸载）+ NODE_ENV define。
+- prepare 脚本自建（git 安装不跑 build；prepare 需自包含）。
+
+### 类型访问（peer-stubs 模式）
+
+- @deepseek-ai/* 不可安装：建 peer-stubs/@deepseek-ai/<pkg>/（index.d.ts 只声明消费面 + package.json {name, version, private, types}），tsconfig paths 映射（含子路径如 @deepseek-ai/dsh-session/types）。
+- 运行时值 import（如 @deepseek-ai/dsh-settings 的 installSettingsSection）保持 external；vitest 用 resolve.alias 指向测试替身。
+- stub 头部注明镜像的 dsh 源码 commit/日期；dsh 基线漂移会静默破坏类型面（事件形状变更尤其危险）。
+
+### 设置与 UI
+
+- settings 命名空间：installSettingsSection(ctx, settingsNamespace(命名空间名), Config, entry, {setSource, onChange})（参照 agent-default-model）；composition entry 作 base、用户文档作覆盖层。
+- web 设置页：client 半 ctx.slots.inject('settings.section', …) 注册（name/id/order/locale-thunk label）；数据走自有 store（settings.describe/update/replace loopback + expectedRevision 冲突语义）；owner props 为空。
+
+### 关键坑
+
+- Config 类型 + z 类型注解的 schemastery ObjectT 输出键全 required：.default(undefined as unknown as {...}) 的 cast 类型必须与 schema 输出全等，否则 tsc -b 报 TS2345。
+- cordis 插件命名导出约定：Loader 丢弃 namespace（含 inject 元数据）当存在 default export——只用 named exports。
+- 配置字段默认值跨 host/client 重复硬编码会漂移：从单一 defaultFallbacksConfig 派生。
+
+## Why This Matters
+
+每条模式都踩过坑（registry 404、closure-factory 契约、schemastery cast、waterfall 注册顺序），按此 playbook 可绕过全部已知陷阱；验证证据链见迭代 review bundle。
+
+## When to Apply
+
+新 dsh 插件（工具/设置/面板/服务）、或把现有插件从 host-only 扩展到 web client。
+
+## Examples
+
+本仓库 dsh-llm-fallbacks（package.json、scripts/build-client.ts、peer-stubs/、src/client/ 为可运行范例）。

--- a/.mstar/knowledge/workflow-patterns/harness-sandbox-verification.md
+++ b/.mstar/knowledge/workflow-patterns/harness-sandbox-verification.md
@@ -1,0 +1,55 @@
+---
+module: mstar-harness-dsh
+date: 2026-08-10
+problem_type: workflow_issue
+category: workflow-patterns
+severity: low
+plan_id: llm-fallbacks-plugin
+applies_when:
+  - 在 dsh 会话的文件沙箱（workspace-write）下执行迭代/SDD 验证
+  - 需要验证 dsh 插件安装、patch 应用等本应写工作区外路径的操作
+  - 需要只读验证 dsh 运行安装（staging 树）
+tags:
+  - dsh
+  - sandbox
+  - verification
+  - scratch
+  - pnpm-patch
+---
+
+# dsh harness 沙箱兼容验证模式（scratch 环境 + 只读校验）
+
+在 dsh 会话沙箱（工作区外不可写）下完成运行类验证的已验证手法（iter-20260810-llm-fallbacks 全程使用）。
+
+## Context
+
+dsh 会话的文件策略默认 workspace-write：只能写 session workspace 内路径。dsh 运行安装（$DSH_HOME/source/current，staging 树 = dsh-private 同源 git 树 + node_modules + 已构建 lib）与真实 profile（$DSH_HOME/profiles/<name>/）都在工作区外。但 dsh CLI 支持 DSH_HOME 环境变量重定向——验证可在工作区内完整复现。
+
+## Guidance
+
+### 插件安装验证：scratch DSH_HOME
+
+DSH_HOME=<worktree>/.dsh-verify 时执行 `dsh plugin --profile verify add <worktree>` → profile 初始化 + pnpm link + bundles reconcile；再用 `dsh --profile verify --dump-config` → 组合层序（确认插件行在 llm-retry 等内置行之后）。验证后删除 scratch。真实 profile 的装入与 GUI 交互留用户环境执行，文档如实标注。
+
+### patch 验证：沙箱拷贝 + 真实树只读 git apply --check
+
+- patch 生成：把目标源文件复制到工作区临时目录做最小编辑，git diff 导出 pnpm 格式 patch；对真实树 git apply --check（只读）验证可应用 + pre-image blob 一致性。
+- 全流程（apply→verify→revert→verify）在沙箱拷贝（git init 的最小镜像树）上跑；脚本目标解析用 DSH_SOURCE_DIR / DSH_HOME 环境变量，脚本文件本身零本地绝对路径。
+- 编译级验证（不能只 grep）：scratch TS 文件 + tsconfig paths 指向真实树 vendor/schemastery 类型做 tsc --noEmit（red→green 证据链）。
+
+### harness 解析与 worktree
+
+- {HARNESS_DIR} 解析从 session workspace 向上探测 .mstar/.agents/.plans/plans——祖先目录的 ~/.mstar 会兜底命中；解析结果按 workspace 缓存（会话中途初始化项目 harness 不生效）。
+- 迭代 Phase 2 的 feature worktree 可建在 session workspace 内（如 <repo>/.worktrees/<plan-id>，git 允许且子代理沙箱可写）；.worktrees/ 加入 .gitignore。
+
+## Why This Matters
+
+沙箱不是验证的障碍，而是把验证逼到「可复现、可留痕、不污染真实环境」的形态；用户真实环境验收清单随文档交付，避免「已验证」与「待用户」混淆（QC/QA 会逐项核对边界表述）。
+
+## When to Apply
+
+dsh 会话内任何涉及工作区外写入的验证（profile 安装、本体 patch、GUI 契约、真实模型调用）。
+
+## Examples
+
+docs/verification.md（本仓库）：已验/待验清单与用户执行步骤。

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,27 @@
+# CONCEPTS
+
+本仓库（dsh-llm-fallbacks）领域词汇。供 `{KNOWLEDGE_DIR}` 与 AGENTS.md 引用，避免重复定义。
+
+## dsh 插件
+
+### dsh bundle
+一个声明 `dsh.bundle.patch` 的 npm 包：以 `cordis.patch.yml` 组合层向 profile 插入插件行。后装入的 bundle 行插在内置行（如 llm-retry）之后——waterfall 监听注册顺序依赖此。
+*Avoid:* plugin row / patch layer（口语混用时可接受，正式文档用 bundle）
+
+### peer-stubs
+dsh 私有 `@deepseek-ai/*` 包（未发布 registry）的类型访问方案：`peer-stubs/@deepseek-ai/<pkg>/` 内只声明消费面的 `index.d.ts` + `package.json`，经 tsconfig `paths` 映射；运行时值 import 保持 external 由宿主 in-box 解析，测试用 vitest alias 替身。
+
+## LLM fallbacks
+
+### fallback 链（fallback chains）
+`fallbacks.chains` 配置的键→有序 selector 列表。键 specificity：exact `provider/model` → `provider/*` → 角色链 → `default`；条目 `provider/*` 表示保留失败模型 id 仅换 provider（目标 provider 无此 id 则跳过）。
+
+### fallbacks/switch 事件
+插件每次切换模型时追加的持久化会话事件（from/to/role/reason），是「行为可见」承诺的载体：无事件即无切换。
+
+### triggerCodes
+触发 fallback 决策的失败码集合，默认 `['AUTH', 'QUOTA', 'RATE_LIMIT']`（dsh 稳定失败码；注意是 `QUOTA` 不是 `QUOTA_EXCEEDED`）。重试型失败（5xx/TRANSPORT）由 llm-retry 先行退避，预算耗尽后同样进入 fallback 决策。
+
+## 已决歧义
+
+- `QUOTA_EXCEEDED`（omp/常见命名）→ 本插件与 dsh taxonomy 用 `QUOTA`；文档中不要混用。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# dsh-llm-fallbacks
+
+dsh（DeepSeek Harness）的自动模型降级插件：当 root agent 或 subagent 的模型请求持续失败（重试耗尽、权限、配额超限、限流 429）时，按角色/模型 fallback 链自动切换 provider/model，当前 step/turn 在目标模型上继续完成——任务不因模型问题中断。
+
+> 本插件与 omp 的 `retry.modelFallback` / `retry.fallbackChains` 语义对齐（对照见下），dsh 侧以 `fallbacks` settings 命名空间承载配置。
+
+## 能力一览
+
+- **root / subagent 自动降级**：任意 agent 在模型故障下按链切换到下一个可用 provider/model，无需手动换模型。
+- **角色链**：subagent 可走独立于 root 的 fallback 链——显式 `agent.options.role`（需 dsh role patch）→ `roles.rules` 顺序匹配 → `roles.default`，首个命中即停。
+- **链 specificity**：exact `provider/model` 键 → `provider/*` 键 → 角色链 → `default` 链；`provider/*` 条目保留失败模型 id 仅换 provider。
+- **冷却与回主**：被切离/失败的模型在冷却期内不再入选；`revertPolicy: cooldown-expiry` 冷却到期后自动回主模型，`never` 会话内不回。
+- **行为可见**：每次切换追加持久化会话事件 `fallbacks/switch`（from/to/role/reason），配合 info 级日志（候选尝试顺序与跳过原因）与 web 设置页只读状态，无静默换模型。
+- **安全阀**：每 step 的 `maxSwitchesPerStep` 超限后停止切换、保持原错误语义，防止链循环放大延迟；`mode: 'always'` 的 provider 另有重试上限（`alwaysModeRetryCap`）。
+- **无配置回归**：`enabled` 默认开启，但空链 / 未命中触发码 / 角色解析失败时插件完全 no-op——行为与未安装时一致，不产生任何事件。
+
+## 与 omp `retry.modelFallback` / `fallbackChains` 语义对照
+
+| dsh-llm-fallbacks | omp | 语义对照 |
+|---|---|---|
+| `fallbacks.enabled` | `retry.modelFallback` | 功能总开关。dsh 默认 `true`（空链即 no-op）；omp 关闭即不触发 |
+| `fallbacks.chains` | `retry.fallbackChains` | 链配置。键/条目 selector 语法与 specificity（exact → `provider/*` → 角色 → default）一致 |
+| `fallbacks.revertPolicy` | `retry.fallbackRevertPolicy` | `cooldown-expiry` / `never` 语义一致：冷却到期回主 / 会话内不回 |
+| `fallbacks.roles`（default / rules / `agent.options.role`） | 子代理模型 pattern 列表（首个可解析 pattern 为主模型、其余为 fallback；无 `agent:<name>` 链键） | 都以「角色/agent」为链分组维度；dsh 的显式 role 与规则匹配更精确，可让 subagent 独立成链 |
+| `fallbacks.triggerCodes` | 无公开对应配置（按失败类型触发） | dsh 将触发失败码集合开放为可配置项，默认 `['AUTH', 'QUOTA', 'RATE_LIMIT']` |
+| `fallbacks.cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap` | 无公开对应配置（冷却为内置行为） | dsh 侧可配置的冷却时长、单步安全阀、always 模式重试上限 |
+
+> omp 侧语义以 omp 自身文档为准；本表仅列出本插件与之对齐/差异的部分，dsh 侧字段定义见 [docs/configuration.md](docs/configuration.md)。
+
+## 快速开始
+
+### 安装
+
+本地目录安装（推荐开发/验证）：
+
+```sh
+# 1) 在插件仓库目录构建（prepare 自构建需要 bun）
+pnpm install
+# 2) 装入目标 profile（示例为 web）
+dsh plugin --profile web add .
+```
+
+git 安装：
+
+```sh
+dsh plugin --profile web add https://github.com/<owner>/dsh-llm-fallbacks.git
+```
+
+> 两种安装方式与验证步骤详见 [docs/install.md](docs/install.md)（含 bundle 层顺序要求与 `--dump-config` 验证）。
+
+### 最小配置
+
+在 dsh 的设置文档（默认 `$DSH_HOME/settings.yaml`）中添加 `fallbacks:` 分节：
+
+```yaml
+fallbacks:
+  chains:
+    default:            # 角色 default 链：主模型失败后按顺序尝试
+      - anthropic/claude-3-5-sonnet
+      - openai/*
+```
+
+保存并重启 web 会话后生效。插件默认已启用（`enabled: true`），`triggerCodes` 默认覆盖 `AUTH` / `QUOTA` / `RATE_LIMIT`，**未配置任何链时行为与未安装插件完全一致**。更多示例（角色链、provider 通配键、roles 规则）见 [docs/configuration.md](docs/configuration.md)。
+
+## 文档
+
+| 文档 | 内容 |
+|---|---|
+| [docs/install.md](docs/install.md) | profile 安装 / git 安装 / 卸载 / `--dump-config` 验证 |
+| [docs/configuration.md](docs/configuration.md) | `fallbacks` 命名空间全字段、selector 语法、示例 YAML、设置页使用、行为说明 |
+| [docs/dsh-patch.md](docs/dsh-patch.md) | subagent 显式角色 patch 的动机、应用/回滚/验证、dsh 升级后重跑 |
+| [patches/README.md](patches/README.md) | patch 清单与原理（与 docs/dsh-patch.md 配套） |
+
+## 许可
+
+本项目以 **MIT** 许可证发布，全文见 [LICENSE](LICENSE)。版权与许可条款以 LICENSE 文件为准。

--- a/README.md
+++ b/README.md
@@ -58,7 +58,17 @@ fallbacks:
     default:            # 角色 default 链：主模型失败后按顺序尝试
       - anthropic/claude-3-5-sonnet
       - openai/*
+  roles:
+    default: default
+    rules:
+      - origin: subagent   # 所有 subagent → reviewer 角色（走独立链）
+        role: reviewer
 ```
+
+角色是链的分组键：`roles.default` 为兜底角色，`roles.rules` 按 origin/provider/model
+顺序匹配到具体角色（首个命中即停）；显式 `agent.options.role`（subagent 经
+`agentOptions.role` 传入，需 dsh role patch，见 [docs/dsh-patch.md](docs/dsh-patch.md)）
+优先级最高——配置了 `reviewer` 链后，归属该角色的 agent 走独立 fallback 链。
 
 保存并重启 web 会话后生效。插件默认已启用（`enabled: true`），`triggerCodes` 默认覆盖 `AUTH` / `QUOTA` / `RATE_LIMIT`，**未配置任何链时行为与未安装插件完全一致**。更多示例（角色链、provider 通配键、roles 规则）见 [docs/configuration.md](docs/configuration.md)。
 

--- a/bundle/cordis.patch.yml
+++ b/bundle/cordis.patch.yml
@@ -1,0 +1,19 @@
+# The dsh-llm-fallbacks profile-bundle patch: ONE insert of the plugin row over
+# the profile's bundle stack (`dsh.profile.bundles` order — dsh-base first,
+# this bundle after the llm-retry bundle; later layers win per row).
+#
+# Insert position matters for the host waterfall: the profile must list the
+# llm-retry bundle BEFORE dsh-llm-fallbacks, so this plugin's
+# `agent/request-error` listener composes after llm-retry and only intervenes
+# once retry policy is exhausted (normal mode) or delegates downstream first
+# (always mode). See plan Risk table.
+#
+# A patch replaces the targeted row's whole `config` rather than merging into
+# it, so a user-level override must restate every field it keeps. The row
+# ships only neutral defaults; profile-layer (`cordis.patch.yml`) overrides
+# win.
+
+- insert:
+    - id: llm-fallbacks
+      name: 'dsh-llm-fallbacks'
+      config: {}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@
 | `maxSwitchesPerStep` | number | `8` | 单步安全阀：每 step 切换次数上限，超限停止切换、保持原错误语义，防止链循环放大延迟 |
 | `alwaysModeRetryCap` | number | `5` | always 模式重试上限：`retryPolicy.mode === 'always'` 的 provider 在同一请求内重试达到该次数后切换；`0` 禁用 |
 
-> 默认值以 spec §4 为准，与 `src/config.ts` 的 schema 默认值一致；设置页对每个字段展示默认值。
+> 默认值以 spec §4 为准，与 `src/config.ts` 的 schema 默认值一致；设置页对数值字段（`cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）旁显示默认值，其余字段展示当前生效值（未配置时即默认值）。
 
 ## Selector 语法
 
@@ -31,7 +31,7 @@
 - `provider/model` —— 切换到指定模型；
 - `provider/*` —— 保留失败模型 id，仅切换 provider；目标 provider 无此模型 id 时跳过该候选（近匹配模糊解析不在本迭代范围）。
 
-非法/未知 selector（缺分隔符、空段、多余分隔符等）在启动与设置变更时告警，不崩溃、不生效；`*/*` 永不匹配。
+非法/未知 selector（缺分隔符、空段、多余分隔符等）在启动与设置变更时告警，不崩溃、不生效；在 dsh 运行环境（存在模型目录服务）下，`*/*` 永不匹配——作为链键，查找键来自具体失败 provider，`*` 不可能命中；作为条目，目标 provider 无 `*` 模型目录，存在性探针会跳过该候选。
 
 ## 链解析（specificity）
 
@@ -95,7 +95,7 @@ fallbacks:
 ## web 设置页使用说明
 
 - **入口**：web 设置 GUI → Settings → **Fallbacks**（位于 Models 页之后）。
-- **可读标签**：枚举型配置项显示可读标签而非原始枚举值——`RATE_LIMIT` →「限流（429）」、`QUOTA` →「配额超限」、`AUTH` →「权限/认证失败」；`cooldown-expiry` →「冷却到期后回主模型」、`never` →「保持备用模型」。每个字段旁显示默认值。
+- **可读标签**：枚举型配置项显示可读标签而非原始枚举值——`RATE_LIMIT` →「限流（429）」、`QUOTA` →「配额超限」、`AUTH` →「权限/认证失败」；`cooldown-expiry` →「冷却到期后回主模型」、`never` →「保持备用模型」。数值字段旁显示默认值；其余字段展示当前生效值（未配置时即默认值）。
 - **链/角色行编辑**：`chains` 以「键 + 每行一个选择器的多行输入」编辑；`roles.rules` 以行编辑（origin/provider/model/role），空字段不参与匹配。
 - **恢复默认**：一键把该命名空间的用户配置重置为组合默认值。
 - **冲突重载**：保存携带 `expectedRevision`；配置被其它地方修改时保存被拒，页面显示冲突横幅与「重新加载」按钮，避免静默覆盖并发修改。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,133 @@
+# 配置指南（`fallbacks` 命名空间）
+
+插件配置集中在 `fallbacks` settings 命名空间，可在 dsh 设置文档（默认 `$DSH_HOME/settings.yaml`）中编辑，也可在 web 设置 GUI 的 **Fallbacks** 页中编辑——两者读写同一命名空间，GUI 保存带修订号冲突保护。
+
+## 字段总览
+
+| 字段 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `enabled` | boolean | `true` | 总开关。`false` 时插件完全不介入；`true` 但未配置任何链时行为与未安装插件一致（no-op） |
+| `triggerCodes` | string[] | `['AUTH', 'QUOTA', 'RATE_LIMIT']` | 命中这些失败码时进入链决策。可重试型故障（5xx / `RATE_LIMIT` 等）先由 llm-retry 退避重试，预算耗尽后同样进入决策——**无需为 5xx 额外添加 triggerCodes** |
+| `chains` | Record&lt;string, string[]&gt; | `{}` | 链键 → 有序 fallback 选择器列表。键为 `provider/model`、`provider/*` 或角色名；条目为 `provider/model` 或 `provider/*`（见下文 selector 语法） |
+| `roles.default` | string | `'default'` | 角色解析兜底：无显式 role、无规则命中时使用的角色 |
+| `roles.rules` | Array | `[]` | 角色规则：按 `origin`（`root`/`subagent`）、`provider`、`model` 模式匹配到角色，顺序匹配、首个命中即停 |
+| `cooldownMs` | number | `300000` | 冷却时长（毫秒）。被切离/失败的模型在冷却期内不再入选 |
+| `revertPolicy` | `'cooldown-expiry'` \| `'never'` | `'cooldown-expiry'` | 冷却到期后的回主策略：到期回主模型 / 会话内保持备用模型 |
+| `maxSwitchesPerStep` | number | `8` | 单步安全阀：每 step 切换次数上限，超限停止切换、保持原错误语义，防止链循环放大延迟 |
+| `alwaysModeRetryCap` | number | `5` | always 模式重试上限：`retryPolicy.mode === 'always'` 的 provider 在同一请求内重试达到该次数后切换；`0` 禁用 |
+
+> 默认值以 spec §4 为准，与 `src/config.ts` 的 schema 默认值一致；设置页对每个字段展示默认值。
+
+## Selector 语法
+
+**链键**（`chains` 的键）：
+
+- `provider/model` —— 精确匹配：仅当失败请求恰好使用该 provider/model 时命中此链；
+- `provider/*` —— provider 通配：该 provider 下任意模型失败时命中；
+- 角色名（如 `default`、`reviewer`）—— 按角色解析结果命中（见下文角色解析）。
+
+**链条目**（`chains` 的值，有序）：
+
+- `provider/model` —— 切换到指定模型；
+- `provider/*` —— 保留失败模型 id，仅切换 provider；目标 provider 无此模型 id 时跳过该候选（近匹配模糊解析不在本迭代范围）。
+
+非法/未知 selector（缺分隔符、空段、多余分隔符等）在启动与设置变更时告警，不崩溃、不生效；`*/*` 永不匹配。
+
+## 链解析（specificity）
+
+失败发生时按以下优先级取链（首个命中的链键贡献条目，多条命中按优先级合并、条目保持列表内顺序）：
+
+1. exact `provider/model` 键；
+2. `provider/*` 键；
+3. 当前 agent 角色链（角色名作键）；
+4. `default` 链。
+
+候选过滤（命中即跳过）：与当前模型相同、处于冷却期、本 step 已失败、`provider/*` 条目目标 provider 无此模型 id。
+
+## 角色解析
+
+角色是 fallback 链的分组键，解析顺序（首个命中即停）：
+
+1. `agent.options.role` —— 显式角色（subagent 经 dsh role patch 的 `agentOptions.role` 传入，见 [docs/dsh-patch.md](docs/dsh-patch.md)）；
+2. `roles.rules` 顺序匹配（`origin` / `provider` / `model` 模式，字段省略即不约束）；
+3. `roles.default`（默认 `'default'`）。
+
+root agent 与 subagent 均参与；root 走 `roles.default` 或规则。
+
+## 示例 YAML
+
+以下配置演示 default 链、角色链与 provider 通配键（写入 `$DSH_HOME/settings.yaml`）：
+
+```yaml
+fallbacks:
+  enabled: true
+  triggerCodes:
+    - AUTH
+    - QUOTA
+    - RATE_LIMIT
+  chains:
+    default:                     # 角色 default 链：主模型失败后按顺序尝试
+      - anthropic/claude-3-5-sonnet
+      - openai/*
+    reviewer:                    # 角色链：role=reviewer 的 agent 走独立链
+      - openai/gpt-4o-mini
+    deepseek/*:                  # provider 通配键：deepseek 任意模型失败时命中
+      - openai/gpt-4o
+  roles:
+    default: default
+    rules:
+      - origin: subagent         # 所有 subagent → reviewer 角色
+        role: reviewer
+      - provider: deepseek       # deepseek provider 的 agent → reviewer 角色
+        role: reviewer
+  cooldownMs: 300000
+  revertPolicy: cooldown-expiry
+  maxSwitchesPerStep: 8
+  alwaysModeRetryCap: 5
+```
+
+要点：
+
+- 链首条目即主模型之后的第一个降级目标；链内条目即优先级。
+- 切换只改变后续请求的 provider/model 路由，不重置会话上下文与工具状态。
+- 链目标模型需各自已配置密钥与配额（不同 provider 之间成本/额度可能不同）。
+
+## web 设置页使用说明
+
+- **入口**：web 设置 GUI → Settings → **Fallbacks**（位于 Models 页之后）。
+- **可读标签**：枚举型配置项显示可读标签而非原始枚举值——`RATE_LIMIT` →「限流（429）」、`QUOTA` →「配额超限」、`AUTH` →「权限/认证失败」；`cooldown-expiry` →「冷却到期后回主模型」、`never` →「保持备用模型」。每个字段旁显示默认值。
+- **链/角色行编辑**：`chains` 以「键 + 每行一个选择器的多行输入」编辑；`roles.rules` 以行编辑（origin/provider/model/role），空字段不参与匹配。
+- **恢复默认**：一键把该命名空间的用户配置重置为组合默认值。
+- **冲突重载**：保存携带 `expectedRevision`；配置被其它地方修改时保存被拒，页面显示冲突横幅与「重新加载」按钮，避免静默覆盖并发修改。
+- **只读状态块**：显示当前生效配置摘要（启用状态/默认角色/链数/触发码）；「最近切换摘要」当前为占位，运行期验证后接入会话事件读取面（见实现）。
+
+## 行为说明
+
+### 触发条件
+
+`enabled` 为 true、存在匹配链、且失败码 ∈ `triggerCodes`（默认 `AUTH`/`QUOTA`/`RATE_LIMIT`）时进入链决策：
+
+- `AUTH` / `QUOTA` 为不可重试码，不经退避直达本插件；
+- `RATE_LIMIT` 及 5xx 等可重试码先由 llm-retry 退避重试，预算耗尽后委托到本插件；
+- 未命中 triggerCodes 的失败（含 always 模式下的非 triggerCode 失败）一律透传，走 llm-retry 或原错误路径。
+
+### 切换后继续
+
+命中候选 → 记录待应用切换 + 把当前模型压入冷却 + 记账 + 追加 `fallbacks/switch` 事件 → 返回重试 → 下一轮请求在目标模型上构建，当前 step/turn 继续完成，任务不中断。
+
+### 冷却与回主
+
+被切离/失败的模型在 `cooldownMs` 内不再入选（冷却与「本 step 已失败」双重抑制）；`cooldown-expiry` 冷却到期后该模型可重新入选（回主）；`never` 会话内不回（无限冷却）。
+
+### 安全阀与 always 模式
+
+- **安全阀**：每 step 记录失败模型集合与切换计数，`maxSwitchesPerStep` 超限后不再决策，step 以原错误语义结束（原始错误码与 message 原样保留）；step 推进时重置。
+- **always 模式 cap**：`retryPolicy.mode === 'always'` 的 provider 在请求构建边界按 turn/step/provider 统计已持久化的 `llm/retry` 事件数，≥ `alwaysModeRetryCap`（0 禁用）时触发切换（`reason: always-cap`）。llm-retry 的 always 模式先委托下游再退避，cap 之前本插件不抢占（见 spec ADR-2）。
+
+### no-op 不变量
+
+未配置链 / `enabled: false` / 未命中 triggerCodes / 角色解析失败 / 链耗尽 / 安全阀超限：插件一律透传，请求与会话事件流与未安装插件时完全一致，不产生任何 `fallbacks/switch` 事件。
+
+### 与 llm-retry 的关系
+
+本插件**不修改** llm-retry 与 provider 的 `retryPolicy`：fallback 只在 llm-retry 委托/耗尽后介入（bundle 层序保证，见 [docs/install.md](docs/install.md)）；`llm/retry` 事件仅用于 always 模式 cap 计数。插件卸载（HMR/dispose）时监听随 fiber 卸载、每-agent 状态整体清空，无残留状态。

--- a/docs/dsh-patch.md
+++ b/docs/dsh-patch.md
@@ -1,0 +1,68 @@
+# dsh 本体 role patch 指南
+
+`dsh-llm-fallbacks` 的角色解析以 `agent.options.role`（显式角色）为最高优先级来源（`options.role` → `roles.rules` → `roles.default`，见 [docs/configuration.md](docs/configuration.md)）。dsh 本体目前没有该字段，本仓库在 `patches/` 交付两个最小 git patch + 配套脚本（`scripts/apply-dsh-patch.sh` / `revert-dsh-patch.sh` / `verify-dsh-patch.sh`），把改动应用到**本机的 dsh 源码树**（本仓库不携带 dsh 源码）。
+
+## 动机：subagent 显式角色
+
+- 未 patch 时，subagent 由 tool-subagent 派生，继承/覆盖父模型路由，无法精确归属到独立 fallback 链。
+- patch 后，`agentOptions.role` 经 `resolveChildAgentOptions` 的 `{...parent, ...requested, subagentDepth}` spread 直达 child `agent.options.role`——**无需修改任何子代理逻辑**，配置即贯通（已核实源码）。
+- 显式 role 让 subagent 可精确归属独立链（如「代码审查」子代理只降级到审查专用低成本模型），不被父模型的链牵制；不设置 `role` 时行为与 patch 前完全一致。
+
+## 两个 patch 的改动面
+
+| patch 文件 | 目标包 | 改动面 |
+|---|---|---|
+| `@deepseek-ai+dsh-agent@0.0.1.patch` | `@deepseek-ai/dsh-agent` | `AgentOptions`（merge-extensible 创建选项接口，`packages/core/agent/src/runtime-types.ts`）追加可选 `role?: string` + JSDoc，与既有 `provider`/`model`/`maxTokens` 同形。纯类型追加，无运行期行为变化 |
+| `@deepseek-ai+dsh-tool-subagent@0.0.1.patch` | `@deepseek-ai/dsh-tool-subagent` | `Config.agentOptions` schema（`packages/subagent/tool-subagent/src/index.ts`，`z.object({provider, model, maxTokens}).default(undefined)`）追加 `role: z.string()`，并将 `.default(undefined as unknown as {...})` 的 cast 类型同步补 `role: string`（与 schema 输出全等，避免 `default(value: T)` 的 TS2345） |
+
+两个 patch 必须成对：patch 1 提供 `AgentOptions.role` 类型面（插件读取 `agent.options.role` 需要该字段存在），patch 2 让 schema 接受 role（配置可携带）。均为最小改动，不触碰重试/路由逻辑，不改变任何既有默认行为。patch 内容细节见 [patches/README.md](../patches/README.md)。
+
+## 应用 / 回滚 / 验证
+
+所有脚本在**插件仓库目录**下执行；目标 dsh 源码树在运行时解析：
+
+- `$DSH_SOURCE_DIR` 优先，缺省 `${DSH_HOME}/source/current`（即正在运行的 dsh staging 树）；
+- 也可用 `-d/--target DIR` 显式指定。
+
+```sh
+# 1) 先检查（只读，不修改任何文件、不构建）
+scripts/apply-dsh-patch.sh --check
+
+# 2) 应用（git apply --check → apply → 增量构建受影响包）
+scripts/apply-dsh-patch.sh
+
+# 3) 验证（断言 role 标记出现在源码与构建产物中）
+scripts/verify-dsh-patch.sh
+
+# 4) 回滚（先 --check，再执行；回滚后重建）
+scripts/revert-dsh-patch.sh --check
+scripts/revert-dsh-patch.sh
+
+# 5) 回滚后验证（断言 role 标记已消失）
+scripts/verify-dsh-patch.sh --absent
+```
+
+要点：
+
+- **幂等**：已应用的 patch 自动跳过（`apply` 输出 `[skip] 已应用`），已回滚的自动跳过（`revert` 同理），可重复执行。
+- **`--check` 优先**：应用/回滚前先用 `--check` 确认目标树状态，零副作用。
+- **构建步骤**：`apply`/`revert` 会重建受影响包（`pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent` + `pnpm exec tsdown --env.DSH_BUILD_FACE host`）。目标树无 pnpm 环境时脚本明确提示并跳过构建、退出非 0（此时可 `--skip-build` 应用后手动构建）。
+- **验证探针**：agent 检查 `src/runtime-types.ts` 与构建产物 `lib/types/runtime-types.d.ts` 含 `role?: string`；tool-subagent 检查 `src/index.ts` 与构建产物 `lib/types/index.js` 含 `role: z.string()`（探针布局与真实构建产物一致，缺失记为 SKIP）。
+
+## dsh 升级后需重跑
+
+dsh 升级会重置本体改动：`$DSH_HOME/source/current` 指向新的 staging 树后，重新执行 `scripts/apply-dsh-patch.sh`（幂等，已应用则跳过）并 `scripts/verify-dsh-patch.sh` 确认。若升级导致源码上下文偏移、patch 无法应用，脚本会报冲突并提示——此时可能需要按新源码行号重新生成 patch（本仓库交付的 diff 以当前 dsh 版本为基准）。
+
+## 安全说明
+
+- `apply` / `revert` 会在目标树执行**构建**（`pnpm exec tsc` / `tsdown`），即运行该树安装时代码——**仅应对可信的 dsh 源码树运行**；目标树由 `$DSH_SOURCE_DIR` / `$DSH_HOME` 显式指定，请确认其来源可信。
+- patch 内容仅追加可选字段，不改变既有默认行为；`revert` 一键回滚，构建产物随重建还原。
+
+## 在真实 dsh 安装上的应用
+
+**对真实 dsh 安装的 patch 应用需由用户在自身环境执行**：本仓库的验证环境受沙箱约束，无法对运行中的 `$DSH_HOME` 安装写入（包括 apply → build 全流程）。如实说明本仓库已完成、未完成的验证：
+
+- **已验证**：两个 patch 对真实 dsh 源码树 `git apply --check` 通过（只读校验，树保持 untouched）；在沙箱拷贝的 dsh 树镜像上完整跑通 apply → verify → revert → verify 全流程与幂等性；类型正确性经真实 `tsc` 编译验证（cast 修正后 red→green，见任务 6 修复轮）。
+- **未验证**：在真实安装上执行 apply → build（留待用户按上文命令执行；构建产物探针在真实树上的布局已核实）。
+
+应用完成后重启 dsh 会话使 `agent.options.role` 生效。

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,71 @@
+# 安装指南
+
+本文介绍如何把 `dsh-llm-fallbacks` 装入 dsh profile、验证安装与卸载。
+
+## 前置条件
+
+- 可用的 dsh 运行环境（`$DSH_HOME`，默认 `~/.dsh`）。
+- 构建需要 **bun**（`>= 1.2.17`）与 **node**（`>= 22`）——插件的 `prepare` 脚本自构建（`bun run build`）。
+- 目标 profile（如 `web`）可读写，安装后需要重启 dsh 会话。
+
+## 1. 本地目录安装（推荐）
+
+```sh
+# 1) 在插件仓库目录构建（prepare 自构建，产出 dist/）
+pnpm install        # 或显式 pnpm build
+# 2) 装入目标 profile
+dsh plugin --profile web add .
+```
+
+`dsh plugin` 会把参数转发给该 profile 目录下的 pnpm（`add`、`remove`、`why` 等均可用），并将 `dsh-llm-fallbacks` 追加到 profile 的 bundle 层列表（`dsh.profile.bundles`）。
+
+### bundle 层顺序（硬性要求）
+
+dsh 的 profile 由有序 bundle 层组合而成：`@deepseek-ai/dsh-base`（内含 llm-retry 插件）→ `@deepseek-ai/dsh-web-app` → `@mstar-harness/dsh` →（`add` 追加的）`dsh-llm-fallbacks`。
+
+**`dsh-llm-fallbacks` 必须排在 llm-retry（`@deepseek-ai/dsh-base` 层内）之后**：插件的 `agent/request-error` 监听需在 llm-retry 之后组合，才能在重试预算耗尽（normal 模式）或 llm-retry 先委托下游（always 模式）后介入；顺序颠倒会让可重试失败先到达本插件、抢占 llm-retry 的退避。
+
+`add` 默认追加到列表末尾即满足该顺序，无需手工改动；若手动编辑 `$DSH_HOME/profiles/web/package.json` 的 `dsh.profile.bundles`，请保持 `@deepseek-ai/dsh-base` 在本插件之前。
+
+## 2. git 安装
+
+```sh
+dsh plugin --profile web add https://github.com/<owner>/dsh-llm-fallbacks.git
+# 或指定 ref：add https://github.com/<owner>/dsh-llm-fallbacks.git#<branch|tag|commit>
+```
+
+git 安装注意：
+
+- **prepare 自建**：pnpm 在安装 git 依赖时会执行包的 `prepare` 脚本（`bun run build`）自构建，安装机需要具备 bun；构建失败会导致装入未构建的包。
+- **allowBuilds（构建脚本放行）**：pnpm ≥ 10 默认不执行依赖的构建脚本。若安装被策略拦截、或装入后 `--dump-config` 看不到 `llm-fallbacks` 层 / 设置页不出现，请放行本包构建（如 `dsh plugin --profile web approve-builds`，或在该 profile 的 pnpm 配置中把 `dsh-llm-fallbacks` 加入 `onlyBuiltDependencies`）。确切行为以你所用 pnpm 版本的策略为准。
+
+## 3. 验证安装
+
+```sh
+dsh --profile web --dump-config
+```
+
+组合配置树末尾应出现本插件的独立层：
+
+```yaml
+# == dsh-llm-fallbacks
+- id: llm-fallbacks
+  name: dsh-llm-fallbacks
+  config: {}
+```
+
+且其**之前**的层包含 llm-retry（来自 `@deepseek-ai/dsh-base`）——层序即 waterfall 注册顺序（见上文 bundle 层顺序）。
+
+然后**重启 dsh web 会话**（`dsh web` 或重启正在运行的会话），让 host 半与 client 半（设置页）加载：
+
+- web 设置 GUI 的 Settings 中应出现 **Fallbacks** 页（位于 Models 页之后）。
+- 页面可读、可编辑、可保存；未配置任何链时显示默认配置，行为 no-op（详见 [docs/configuration.md](docs/configuration.md)）。
+
+## 4. 卸载
+
+```sh
+dsh plugin --profile web remove dsh-llm-fallbacks
+dsh --profile web --dump-config   # 确认 llm-fallbacks 层已消失
+```
+
+重启 dsh web 会话使卸载生效。卸载后插件不再介入任何请求/错误路径，已持久化的 `fallbacks/switch` 会话事件为历史记录，不受卸载影响。

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,152 @@
+# 验证记录（Task 8 — profile 安装与运行期验证）
+
+本文记录 `dsh-llm-fallbacks` 在**本仓库验证环境（沙箱兼容的 scratch 环境）**下已完成
+的安装/运行契约验证，以及**需要在用户真实 dsh 环境执行**的验证步骤与预期结果。
+
+> 边界声明：本仓库的验证环境受沙箱约束，**无法对运行中的 dsh 安装（真实 `$DSH_HOME`）
+> 做任何写操作**，也无法操作 web 设置 GUI、发起真实模型调用或跨进程观察。因此下文
+> 「已验证」仅覆盖可在工作区内完成的证据（单元/集成测试、scratch profile 装入与
+> `--dump-config` 层序、patch 只读校验与沙箱全流程、构建管线）；「用户待执行」为真实
+> 环境步骤与预期，如实标注，不夸大已验范围。
+
+## 已验证（本迭代证据，T1–T8）
+
+### 1. 测试矩阵（单元 + 集成，133 → 153 全绿）
+
+| 范围 | 文件 | 数量 | 覆盖契约 |
+|---|---|---|---|
+| 单元（T2） | `selectors.spec.ts` / `chains.spec.ts` / `roles.spec.ts` / `cooldown.spec.ts` | 10 / 23 / 10 / 9 | selector 解析与 specificity（exact → `provider/*` → 角色 → default）、`provider/*` 条目保留模型 id 仅换 provider、角色规则顺序匹配、cooldown/revert（惰性过期、never 无限 TTL） |
+| 单元（T3） | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 2 / 20 | 状态机（pendingSwitch 产生→应用→清除、appliedTurnStep 防重放、step 推进重置）、`fallbacks/switch` 事件形状与 JSON 往返、`Config({})` 恒等于默认配置（no-op 基线）、小集成 Step 6 全项 |
+| 集成（T4） | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 16 / 4 / 5 | 端到端重集成、**双插件共存顺序**（normal 先退避、预算耗尽后切换；不可重试码直切）、**always 先委托下游 + cap 在 request 边界**（ADR-2）、冷却/revert 集成、**安全阀**超限后原错误语义、组合顺序互不干扰 |
+| client（T5） | `fallbacks-store.spec.ts` | 20 | 设置页描述符读/写（redactSecrets 面、expectedRevision 冲突保护、settings-conflict 状态）、chain/rule 行编辑往返、controller 生命周期 |
+| 回归 | `skeleton.spec.ts` | 3 | bundle 契约（row id、空 schema 接受、host+client apply 入口） |
+
+结果：**13 files / 153 tests 全绿**（`pnpm test`，vitest run）；`pnpm build`（bun build host →
+`bunx tsc` → bun build client）全绿。no-op 回归不变量（空链 / 未命中 / 链耗尽 / 安全阀
+超限 → 透传、不产生 `fallbacks/switch` 事件）由 T3/T4 测试持久断言。
+
+### 2. bundle 层序（scratch profile `--dump-config` 实证）
+
+在**工作区内 scratch profile**（`DSH_HOME=<插件仓库>/.dsh-verify`，验证后删除）上：
+
+```
+$ dsh plugin --profile verify add <插件仓库>
+  → profile 初始化；`dsh.profile.bundles` = ["@deepseek-ai/dsh-base", "dsh-llm-fallbacks"]
+    （reconcile 追加到列表末尾，符合「add 默认追加」语义）
+$ dsh --profile verify --dump-config
+  # == @deepseek-ai/dsh-base
+  - id: llm-retry            ← llm-retry 位于 dsh-base 层内
+  ...
+  # == dsh-llm-fallbacks
+  - id: llm-fallbacks
+    name: dsh-llm-fallbacks
+    config: {}
+```
+
+`llm-fallbacks` 作为**独立层插在 dsh-base（含 llm-retry）之后**——即 waterfall 注册
+顺序满足「llm-retry 之后介入」的硬性要求（对应 [docs/install.md](docs/install.md)
+bundle 层顺序一节；真实 web profile 层序 `dsh-base → dsh-web-app → @mstar-harness/dsh
+→(add) dsh-llm-fallbacks` 同理，`add` 追加到末尾即满足）。
+
+### 3. patch 可应用 / 可编译（T6 + T8 复验）
+
+- **真实 dsh 源码树只读校验**：两个 patch 对 `$DSH_SOURCE_DIR`（真实 `$DSH_HOME/source/current`）
+  `git apply --check` 均通过（只读，树保持 clean、零写入）；`--reverse --check` 在 pristine
+  树上按预期失败。
+- **沙箱拷贝全流程**（工作区内重建 `.dsh-patch-test/`，pre-image blob 与真实树一致）：
+  `apply --check → apply → verify → 再次 apply（幂等跳过）→ revert → verify --absent →
+  verify（回滚后按预期失败）→ 重应用 + verify（闭环）` 全流程与幂等性复验通过；env 解析
+  （`DSH_SOURCE_DIR` 优先、缺省 `${DSH_HOME}/source/current`）与 `-d/--target` 覆盖生效；
+  坏 env（`DSH_HOME=/nonexistent`）按预期报错退出 1。
+- **类型正确性**（T6 修复轮）：真实 `tsc` 编译验证 cast 修正后 red→green（TS2345 原文
+  复现 → exit 0），`z<Config>` 与 patch 后 `AgentOptions`（含 `role?`）双向可赋值。
+- **构建管线**：`pnpm build`（host bundle + client bundle + tsc 声明）在 T1/T5/T7 各轮全绿。
+
+### 4. 运行契约（以测试证据支撑）
+
+- **切换可见性**：任何切换（含 always-cap 路径）产生 `fallbacks/switch` 事件（T3 事件
+  形状 + T4 集成断言；spec 硬性要求「无事件即无切换」）。
+- **回滚/失败语义**：链耗尽 / 安全阀超限 / 无匹配链 / 角色解析失败 / 未命中 triggerCodes
+  → `next()` 透传，原错误码与 message 原样保留（T3/T4 断言）。
+- **卸载无残留**：`agent/disposed` 删除、`agent/status` idle 防御清理、`ctx.effect`
+  dispose 清空（T3 断言）。
+- **peer-stubs 契约**：`@deepseek-ai/dsh-agent` / `dsh-llm` / `dsh-settings` / `dsh-subagent` /
+  `dsh-tool-subagent` 及 client 半五个包的类型面在 `peer-stubs/` 中镜像，集成测试
+  （`tests/support/harness.ts` + llm-retry-stub + model-selection-stub）按该契约驱动。
+
+## 用户待执行（真实环境步骤与预期）
+
+> 以下步骤需在**真实 dsh 环境**（有 `$DSH_HOME` 安装、可操作 web GUI、可发起真实模型
+> 调用）执行；路径一律以 `$DSH_HOME` / `$DSH_SOURCE_DIR` 表达，不依赖本地绝对路径。
+
+### 1. 真实 profile 装入
+
+```sh
+cd <插件仓库目录>
+pnpm install          # prepare 自构建（需要 bun）
+dsh plugin --profile web add .
+dsh --profile web --dump-config   # 组合树末尾应出现 # == dsh-llm-fallbacks 层
+```
+
+**预期**：`dsh.profile.bundles` 末尾追加 `dsh-llm-fallbacks`（在 `@deepseek-ai/dsh-base`
+之后）；`--dump-config` 中 `llm-fallbacks` 层出现在含 `llm-retry` 的 dsh-base 层之后。
+然后重启 dsh web 会话使 host 半与 client 半加载。
+
+### 2. web 设置页验证
+
+1. 打开 web 设置 GUI → Settings，确认出现 **Fallbacks** 页（位于 Models 页之后）。
+2. 编辑任一字段（如把 `cooldownMs` 改为 `600000`）并保存。
+3. **预期**：保存成功、无冲突横幅；`$DSH_HOME/settings.yaml`（或该 profile 的 settings
+   路径）写入新值；再次进入页面显示已保存的值，revision 正常（并发修改时出现冲突横幅
+   +「重新加载」按钮，不静默覆盖）。
+4. 一键「恢复默认」后确认配置回组合默认值。
+
+### 3. 运行期 fallback 验证（模拟失败）
+
+1. 在 `fallbacks` 命名空间配置 demo 链：`chains.default` 指向一个**备用模型**
+   （如 `openai/gpt-4o-mini`），把主模型（如 `deepseek/deepseek-chat`）的密钥配错或
+   把链指向不存在的 provider，构造**不可重试失败码**（`AUTH` / `QUOTA` 路径，不经退避
+   直达插件）。
+2. 发起一个请求触发失败。
+3. **预期**：
+   - 日志出现本插件 info 级记录（候选尝试顺序与跳过原因）；
+   - 会话事件流追加 `fallbacks/switch`（from/to/role/reason）；
+   - 请求在备用模型上继续，当前 step/turn 不中断。
+4. 可重试码路径（`RATE_LIMIT` / 5xx）：配置 `triggerCodes` 含 `RATE_LIMIT`，观察
+   llm-retry 先退避、预算耗尽后进入链决策——确认层序正确（fallback 未抢占退避）。
+
+### 4. patch 应用后 subagent 显式 role 验证
+
+1. 应用 dsh 本体 patch（真实安装写操作，需用户执行）：
+
+   ```sh
+   cd <插件仓库目录>
+   scripts/apply-dsh-patch.sh --check   # 只读检查
+   scripts/apply-dsh-patch.sh           # git apply → 增量构建
+   scripts/verify-dsh-patch.sh          # 断言 role 标记出现在源码与构建产物
+   ```
+
+2. 重启 dsh 会话，配置 subagent 角色链：`roles.rules` 中把某 subagent（如
+   `origin: subagent` 或按 provider/model 匹配）归属到独立角色链，并在 tool-subagent
+   的 `agentOptions.role` 显式设置该角色。
+3. **预期**：该 subagent 的模型失败走**独立链**（不被父模型链牵制）；`fallbacks/switch`
+   事件与日志中 role 为显式设置值；未设置 role 的 agent 行为与 patch 前一致。
+4. 回滚验证：`scripts/revert-dsh-patch.sh --check` → `scripts/revert-dsh-patch.sh` →
+   `scripts/verify-dsh-patch.sh --absent`（role 标记消失）。
+
+### 5. dsh 升级后重跑 patch
+
+dsh 升级（`$DSH_HOME/source/current` 指向新 staging）会重置本体改动：升级后重新执行
+`scripts/apply-dsh-patch.sh`（幂等，已应用则跳过）并 `scripts/verify-dsh-patch.sh` 确认；
+上下文偏移导致冲突时脚本报错提示，需按新源码行号重新生成 patch（见
+[docs/dsh-patch.md](docs/dsh-patch.md)）。
+
+## 已知限制（沙箱无法覆盖的真实运行面）
+
+| 面 | 未覆盖原因 | 验证归属 |
+|---|---|---|
+| web 设置 GUI 交互（页面出现、编辑保存、冲突重载） | 沙箱无法操作真实 web 会话 | 用户待执行 §2（client 半逻辑已由 T5 20 例测试覆盖） |
+| 真实模型调用与失败注入（AUTH/QUOTA/RATE_LIMIT 触发、切换继续） | 沙箱无真实模型凭据与运行中会话 | 用户待执行 §3（决策逻辑已由 T3/T4 集成测试覆盖） |
+| 跨进程观察（日志、`fallbacks/switch` 会话事件在真实会话中的落地） | 沙箱无法运行真实 dsh 会话 | 用户待执行 §3/§4 |
+| 真实安装上的 patch apply → build | 对运行中 `$DSH_HOME` 的写操作被沙箱拒绝 | 用户待执行 §4（可应用性已只读 `git apply --check` + 沙箱全流程验证） |
+| 升级后 patch 冲突与重新生成 | 依赖真实 dsh 升级事件 | 用户待执行 §5 |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -15,8 +15,8 @@
 
 | 范围 | 文件 | 数量 | 覆盖契约 |
 |---|---|---|---|
-| 单元（T2） | `selectors.spec.ts` / `chains.spec.ts` / `roles.spec.ts` / `cooldown.spec.ts` | 10 / 23 / 10 / 9 | selector 解析与 specificity（exact → `provider/*` → 角色 → default）、`provider/*` 条目保留模型 id 仅换 provider、角色规则顺序匹配、cooldown/revert（惰性过期、never 无限 TTL） |
-| 单元（T3） | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 2 / 20 | 状态机（pendingSwitch 产生→应用→清除、appliedTurnStep 防重放、step 推进重置）、`fallbacks/switch` 事件形状与 JSON 往返、`Config({})` 恒等于默认配置（no-op 基线）、小集成 Step 6 全项 |
+| 单元（T2） | `selectors.spec.ts` / `chains.spec.ts` / `roles.spec.ts` / `cooldown.spec.ts` | 11 / 26 / 10 / 9 | selector 解析与 specificity（exact → `provider/*` → 角色 → default）、`provider/*` 条目保留模型 id 仅换 provider、角色规则顺序匹配、cooldown/revert（惰性过期、never 无限 TTL） |
+| 单元（T3） | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 2 / 30 | 状态机（pendingSwitch 产生→应用→清除、appliedTurnStep 防重放、step 推进重置）、`fallbacks/switch` 事件形状与 JSON 往返、`Config({})` 恒等于默认配置（no-op 基线）、小集成 Step 6 全项 |
 | 集成（T4） | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 16 / 4 / 5 | 端到端重集成、**双插件共存顺序**（normal 先退避、预算耗尽后切换；不可重试码直切）、**always 先委托下游 + cap 在 request 边界**（ADR-2）、冷却/revert 集成、**安全阀**超限后原错误语义、组合顺序互不干扰 |
 | client（T5） | `fallbacks-store.spec.ts` | 20 | 设置页描述符读/写（redactSecrets 面、expectedRevision 冲突保护、settings-conflict 状态）、chain/rule 行编辑往返、controller 生命周期 |
 | 回归 | `skeleton.spec.ts` | 3 | bundle 契约（row id、空 schema 接受、host+client apply 入口） |
@@ -60,7 +60,7 @@ bundle 层顺序一节；真实 web profile 层序 `dsh-base → dsh-web-app →
   坏 env（`DSH_HOME=/nonexistent`）按预期报错退出 1。
 - **类型正确性**（T6 修复轮）：真实 `tsc` 编译验证 cast 修正后 red→green（TS2345 原文
   复现 → exit 0），`z<Config>` 与 patch 后 `AgentOptions`（含 `role?`）双向可赋值。
-- **构建管线**：`pnpm build`（host bundle + client bundle + tsc 声明）在 T1/T5/T7 各轮全绿。
+- **构建管线**：`pnpm build`（host bundle + client bundle + tsc 声明）在 T1/T5 各轮全绿（T6/T7 无构建面变更）。
 
 ### 4. 运行契约（以测试证据支撑）
 

--- a/package.json
+++ b/package.json
@@ -57,11 +57,14 @@
     "@deepseek-ai/dsh-settings": "^0.0.1",
     "@deepseek-ai/dsh-subagent": "^0.0.1",
     "@deepseek-ai/dsh-tool-subagent": "^0.0.1",
-    "cordis": "^4.0.0-rc.7"
+    "cordis": "^4.0.0-rc.7",
+    "react": "^18.2.0"
   },
   "devDependencies": {
+    "@types/react": "~18.3.31",
     "bun-types": "^1.2.17",
     "cordis": "^4.0.0-rc.7",
+    "react": "^18.3.1",
     "schemastery": "^3.18.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"

--- a/package.json
+++ b/package.json
@@ -55,8 +55,6 @@
     "@deepseek-ai/dsh-client-ui-slots": "^0.0.1",
     "@deepseek-ai/dsh-llm": "^0.0.1",
     "@deepseek-ai/dsh-settings": "^0.0.1",
-    "@deepseek-ai/dsh-subagent": "^0.0.1",
-    "@deepseek-ai/dsh-tool-subagent": "^0.0.1",
     "cordis": "^4.0.0-rc.7",
     "react": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "dsh-llm-fallbacks",
+  "description": "Automatic provider/model fallback chains for DeepSeek Harness agents when LLM requests keep failing (retry exhausted, auth, quota, rate limit)",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "default": "./dist/client/index.js"
+    },
+    "./bundle/cordis.patch.yml": "./bundle/cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "bundle"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./bundle/cordis.patch.yml"
+    }
+  },
+  "dshClient": {
+    "inject": [
+      "@deepseek-ai/dsh-client-runtime",
+      "@deepseek-ai/dsh-client-ui-settings",
+      "@deepseek-ai/dsh-client-locale",
+      "@deepseek-ai/dsh-client-connection"
+    ],
+    "platform": "web"
+  },
+  "scripts": {
+    "build": "rm -rf dist && bun build src/index.ts --target node --outdir dist --external cordis --external '@deepseek-ai/*' && bun run build-client && bunx tsc",
+    "build-client": "bun run scripts/build-client.ts",
+    "test": "vitest run",
+    "prepare": "bun run build"
+  },
+  "engines": {
+    "node": ">=22",
+    "bun": ">=1.2.17"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/dsh-agent": "^0.0.1",
+    "@deepseek-ai/dsh-client-connection": "^0.0.1",
+    "@deepseek-ai/dsh-client-locale": "^0.0.1",
+    "@deepseek-ai/dsh-client-runtime": "^0.0.1",
+    "@deepseek-ai/dsh-client-ui-settings": "^0.0.1",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.0.1",
+    "@deepseek-ai/dsh-llm": "^0.0.1",
+    "@deepseek-ai/dsh-settings": "^0.0.1",
+    "@deepseek-ai/dsh-subagent": "^0.0.1",
+    "@deepseek-ai/dsh-tool-subagent": "^0.0.1",
+    "cordis": "^4.0.0-rc.7"
+  },
+  "devDependencies": {
+    "bun-types": "^1.2.17",
+    "cordis": "^4.0.0-rc.7",
+    "schemastery": "^3.18.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/patches/@deepseek-ai+dsh-agent@0.0.1.patch
+++ b/patches/@deepseek-ai+dsh-agent@0.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/core/agent/src/runtime-types.ts b/packages/core/agent/src/runtime-types.ts
+index 3698c05..9118443 100644
+--- a/packages/core/agent/src/runtime-types.ts
++++ b/packages/core/agent/src/runtime-types.ts
+@@ -28,6 +28,8 @@ export interface AgentOptions {
+   model?: string
+   /** Maximum output tokens for each conversation-model request. */
+   maxTokens?: number
++  /** Explicit role label for this agent, used for role-based fallback-chain selection. */
++  role?: string
+ }
+ 
+ /** Options for {@link Agent.cancel}. */

--- a/patches/@deepseek-ai+dsh-tool-subagent@0.0.1.patch
+++ b/patches/@deepseek-ai+dsh-tool-subagent@0.0.1.patch
@@ -1,0 +1,12 @@
+diff --git a/packages/subagent/tool-subagent/src/index.ts b/packages/subagent/tool-subagent/src/index.ts
+index bfb02b1..6712eed 100644
+--- a/packages/subagent/tool-subagent/src/index.ts
++++ b/packages/subagent/tool-subagent/src/index.ts
+@@ -83,6 +83,7 @@ export const Config: z<Config> = z.object({
+     provider: z.string(),
+     model: z.string(),
+     maxTokens: z.number().step(1).min(1).max(Number.MAX_SAFE_INTEGER),
++    role: z.string(),
+   }).default(undefined as unknown as { provider: string; model: string; maxTokens: number }),
+   persona: z.string(),
+   // Preserve omission; Schemastery's `{ allow: [] }` default would deny every tool.

--- a/patches/@deepseek-ai+dsh-tool-subagent@0.0.1.patch
+++ b/patches/@deepseek-ai+dsh-tool-subagent@0.0.1.patch
@@ -1,12 +1,14 @@
 diff --git a/packages/subagent/tool-subagent/src/index.ts b/packages/subagent/tool-subagent/src/index.ts
-index bfb02b1..6712eed 100644
+index bfb02b1..b920a9c 100644
 --- a/packages/subagent/tool-subagent/src/index.ts
 +++ b/packages/subagent/tool-subagent/src/index.ts
-@@ -83,6 +83,7 @@ export const Config: z<Config> = z.object({
+@@ -83,7 +83,8 @@ export const Config: z<Config> = z.object({
      provider: z.string(),
      model: z.string(),
      maxTokens: z.number().step(1).min(1).max(Number.MAX_SAFE_INTEGER),
+-  }).default(undefined as unknown as { provider: string; model: string; maxTokens: number }),
 +    role: z.string(),
-   }).default(undefined as unknown as { provider: string; model: string; maxTokens: number }),
++  }).default(undefined as unknown as { provider: string; model: string; maxTokens: number; role: string }),
    persona: z.string(),
    // Preserve omission; Schemastery's `{ allow: [] }` default would deny every tool.
+   toolFilter: z.object({

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,98 @@
+# dsh 本体 role patch（`patches/`）
+
+`dsh-llm-fallbacks` 需要 subagent 的**显式角色来源**：`agent.options.role` 作为
+fallback 链角色解析的最高优先级来源（spec §3：`options.role` → `roles.rules` →
+`roles.default`）。dsh 本体目前没有该字段，本目录提供最小改动的 git patch + 配套
+脚本（`scripts/apply-dsh-patch.sh` / `revert-dsh-patch.sh` / `verify-dsh-patch.sh`），
+把改动应用到**本机的 dsh 源码树**（本仓库不携带 dsh 源码）。
+
+## Patch 清单
+
+| 文件 | 目标包 | 改动 |
+|------|--------|------|
+| `@deepseek-ai+dsh-agent@0.0.1.patch` | `@deepseek-ai/dsh-agent` | `AgentOptions`（merge-extensible 创建选项接口，`packages/core/agent/src/runtime-types.ts`）追加可选 `role?: string` + JSDoc，与既有 `provider`/`model`/`maxTokens` 同形 |
+| `@deepseek-ai+dsh-tool-subagent@0.0.1.patch` | `@deepseek-ai/dsh-tool-subagent` | `Config.agentOptions` schema（`packages/subagent/tool-subagent/src/index.ts`，`z.object({provider, model, maxTokens}).default(undefined)`）追加 `role: z.string()`（可选字段） |
+
+> 文件名为 pnpm `patchedDependencies` 惯例 `@scope+pkg@version.patch`（版本 0.0.1
+> 与两个包 `package.json` 一致）。本仓库通过 `scripts/*.sh` 直接对 dsh 源码树应用
+> 这些 patch（diff 路径为仓库根相对路径，`git -C "$DSH_SOURCE_DIR" apply` 可直接
+> 使用）；若改用 pnpm `patchedDependencies` 机制，需将 diff 路径前缀调整为包目录
+> 相对路径，本仓库不依赖该机制。
+
+## 为什么需要这两个 patch（diff 内容说明）
+
+1. **`dsh-agent`**：`AgentOptions` 是 dsh 的 merge-extensible agent 创建选项接口
+   （`provider`/`model`/`maxTokens` 同形）。追加 `role?: string` 后，任意 agent
+   均可携带显式角色标签，供角色感知的消费者（如本插件的 fallback 链选择）读取。
+   纯类型追加，无运行期行为变化。
+2. **`dsh-tool-subagent`**：其 `Config.agentOptions` 的 schemastery schema 必须
+   与 `AgentOptions` 类型保持一致——`Config: z<Config>` 的 schema 输出类型需可赋
+   值给 `agentOptions?: AgentOptions`；仅 patch dsh-agent 而不 patch 此 schema 会
+   使 `z<Config>` 类型检查失败。运行时：`resolveChildAgentOptions`
+   （`packages/subagent/subagent/src/child-agent.ts`）的 `{...parent, ...requested,
+   subagentDepth}` spread 会把 `requested` 中的未知字段（含 `role`）透传到 child
+   `agent.options`，因此**无需修改任何子代理逻辑**——patch 应用后
+   `tool-subagent` 设置的 `agentOptions.role` 直达 subagent 的 `agent.options.role`。
+
+两处都是**最小改动**：不触碰重试/路由逻辑，不改变任何既有默认行为；未设置 `role`
+时与 patch 前完全一致。
+
+## 用法
+
+所有脚本的目标目录在**运行时**解析，脚本文件本身不含本地绝对路径：
+
+```sh
+# 目标解析：$DSH_SOURCE_DIR 优先，缺省 ${DSH_HOME}/source/current
+export DSH_SOURCE_DIR=/path/to/dsh-source   # 或仅设置 DSH_HOME
+```
+
+### 应用
+
+```sh
+scripts/apply-dsh-patch.sh            # git apply --check → apply → 增量构建
+scripts/apply-dsh-patch.sh --check    # 只检查是否可应用（不修改任何文件）
+scripts/apply-dsh-patch.sh --skip-build  # 应用但不构建（无 pnpm 环境的场景）
+```
+
+幂等：已应用的 patch 自动跳过。构建步骤 = `tsc -b packages/core/agent
+packages/subagent/tool-subagent`（增量） + `tsdown --env.DSH_BUILD_FACE host`
+（dsh monorepo 无每包 `build` 脚本，这是与仓库一致的构建入口）；若目标树无
+pnpm 环境，脚本打印明确提示、跳过构建并退出非 0。
+
+### 回滚
+
+```sh
+scripts/revert-dsh-patch.sh           # git apply --reverse 两个 patch → 重建
+scripts/revert-dsh-patch.sh --check
+```
+
+### 验证
+
+```sh
+scripts/verify-dsh-patch.sh           # 断言 role 标记已出现（源文件 + 构建产物）
+scripts/verify-dsh-patch.sh --absent  # 断言 role 标记不出现（revert 后）
+```
+
+验证探针（存在即检查，缺失记 SKIP）：
+
+- agent：`src/runtime-types.ts` 与构建产物 `lib/types/runtime-types.d.ts` 含 `role?: string`
+- tool-subagent：`src/index.ts` 与构建产物 `lib/types/index.js` 含 `role: z.string()`
+
+> 说明：`AgentOptions` 编译到 `lib/types/runtime-types.d.ts`（而非 `index.d.ts`，
+> 后者仅 re-export）；tool-subagent 的 d.ts 只以类型引用 `AgentOptions`，`role` 的
+> 文本标记出现在编译后的 schema JS（`lib/types/index.js`）中。探针按此实际布局选取。
+
+## dsh 升级后需重跑
+
+dsh 升级（`$DSH_HOME/source/current` 指向新 staging）会**重置**本体改动：升级后
+重新执行 `scripts/apply-dsh-patch.sh`（脚本幂等，已应用则跳过）并
+`scripts/verify-dsh-patch.sh` 确认；升级导致上下文偏移、patch 无法应用时，脚本会
+报冲突并提示（可能需按新源码行号重新生成 patch，见 `docs/dsh-patch.md`）。
+
+## 安全说明
+
+- `apply`/`revert` 会在目标树执行**构建**（`pnpm exec tsc` / `tsdown`），即运行该
+  树的安装时代码——仅应对可信的 dsh 源码树运行；目标树由 `$DSH_SOURCE_DIR` /
+  `$DSH_HOME` 显式指定，请确认其来源可信。
+- patch 内容仅追加可选字段，不改变既有默认行为；`revert` 一键回滚，构建产物随
+  重建还原。

--- a/patches/README.md
+++ b/patches/README.md
@@ -11,7 +11,7 @@ fallback 链角色解析的最高优先级来源（spec §3：`options.role` →
 | 文件 | 目标包 | 改动 |
 |------|--------|------|
 | `@deepseek-ai+dsh-agent@0.0.1.patch` | `@deepseek-ai/dsh-agent` | `AgentOptions`（merge-extensible 创建选项接口，`packages/core/agent/src/runtime-types.ts`）追加可选 `role?: string` + JSDoc，与既有 `provider`/`model`/`maxTokens` 同形 |
-| `@deepseek-ai+dsh-tool-subagent@0.0.1.patch` | `@deepseek-ai/dsh-tool-subagent` | `Config.agentOptions` schema（`packages/subagent/tool-subagent/src/index.ts`，`z.object({provider, model, maxTokens}).default(undefined)`）追加 `role: z.string()`（可选字段） |
+| `@deepseek-ai+dsh-tool-subagent@0.0.1.patch` | `@deepseek-ai/dsh-tool-subagent` | `Config.agentOptions` schema（`packages/subagent/tool-subagent/src/index.ts`，`z.object({provider, model, maxTokens}).default(undefined)`）追加 `role: z.string()`（可选字段），并将 `.default(undefined)` 的 cast 类型同步补 `role: string`（与 schema 输出全等，见下文） |
 
 > 文件名为 pnpm `patchedDependencies` 惯例 `@scope+pkg@version.patch`（版本 0.0.1
 > 与两个包 `package.json` 一致）。本仓库通过 `scripts/*.sh` 直接对 dsh 源码树应用
@@ -25,10 +25,16 @@ fallback 链角色解析的最高优先级来源（spec §3：`options.role` →
    （`provider`/`model`/`maxTokens` 同形）。追加 `role?: string` 后，任意 agent
    均可携带显式角色标签，供角色感知的消费者（如本插件的 fallback 链选择）读取。
    纯类型追加，无运行期行为变化。
-2. **`dsh-tool-subagent`**：其 `Config.agentOptions` 的 schemastery schema 必须
-   与 `AgentOptions` 类型保持一致——`Config: z<Config>` 的 schema 输出类型需可赋
-   值给 `agentOptions?: AgentOptions`；仅 patch dsh-agent 而不 patch 此 schema 会
-   使 `z<Config>` 类型检查失败。运行时：`resolveChildAgentOptions`
+2. **`dsh-tool-subagent`**：其 `Config.agentOptions` 的 schemastery schema 追加
+   `role: z.string()`，让配置可携带 `agentOptions.role`。两个 patch 必须成对是
+   **功能必要性**：patch 1 提供 `AgentOptions.role` 类型面（插件读取
+   `agent.options.role` 需要该字段存在），patch 2 让 schema 接受 role（配置可
+   携带）。此外还有 **cast 一致性**约束：`.default(undefined as unknown as
+   {...})` 的 cast 类型必须与 schema 输出类型全等——schemastery 的
+   `ObjectT` 输出键全部 required，追加 `role` 后输出含 `role: string`，cast 必须
+   同步补 `role: string`，否则 `default(value: T)` 参数检查报 TS2345（schema
+   输出与 cast 全等是既有代码模式，见 patch 2 中 `toolFilter` 的同类 cast）。
+   运行时：`resolveChildAgentOptions`
    （`packages/subagent/subagent/src/child-agent.ts`）的 `{...parent, ...requested,
    subagentDepth}` spread 会把 `requested` 中的未知字段（含 `role`）透传到 child
    `agent.options`，因此**无需修改任何子代理逻辑**——patch 应用后

--- a/patches/README.md
+++ b/patches/README.md
@@ -43,6 +43,12 @@ fallback 链角色解析的最高优先级来源（spec §3：`options.role` →
 两处都是**最小改动**：不触碰重试/路由逻辑，不改变任何既有默认行为；未设置 `role`
 时与 patch 前完全一致。
 
+> 类型面说明：`@deepseek-ai/dsh-subagent` / `@deepseek-ai/dsh-tool-subagent` 的
+> role 类型面**仅由本目录的 patch 文档承载**，插件本身不直接消费（无 import、无
+> peer-stub、无 tsconfig paths），因此也不在 `package.json` peerDependencies 中
+> 声明；`agent.options.role` 的读取经 `resolveChildAgentOptions` 的 spread 贯通，
+> 类型上以 patch 后 dsh 源码树为准。
+
 ## 用法
 
 所有脚本的目标目录在**运行时**解析，脚本文件本身不含本地绝对路径：

--- a/peer-stubs/@deepseek-ai/dsh-agent/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-agent/index.d.ts
@@ -1,0 +1,81 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-agent` seam consumed by
+ * `dsh-llm-fallbacks`.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — `Agent` / `AgentOptions` / `RequestErrorAction` and the
+ * `agent/request-error` / `agent/request` / `agent/status` / `agent/disposed`
+ * cordis `Events` entries. Mirrors dsh-private commit b8343cb
+ * (2026-08-09 snapshot); keep in sync when the dsh baseline moves.
+ *
+ * `AgentOptions` intentionally omits `role` — the Task 6 patch is not applied
+ * to this snapshot; role resolution flows through the plugin's own loose
+ * `AgentLike` shape instead.
+ */
+import type { LlmCallConfig, LlmFailure, ResolvedRetryPolicy } from '@deepseek-ai/dsh-llm'
+import type { Session, SessionId } from '@deepseek-ai/dsh-session'
+
+/** Merge-extensible agent creation options (mirror of the real surface). */
+export interface AgentOptions {
+  /** Provider route (must have a registered adapter at call time). */
+  provider?: string
+  /** Model id interpreted by the selected provider adapter. */
+  model?: string
+  /** Maximum output tokens for each conversation-model request. */
+  maxTokens?: number
+}
+
+/** An agent's lifecycle state, emitted on every transition as `agent/status`. */
+export type AgentStatus = 'idle' | 'running'
+
+/** Action returned by a listener that owns model-request recovery. */
+export type RequestErrorAction = { kind: 'retry' } | undefined
+
+/** The public live-agent handle (consumed surface only). */
+export interface Agent {
+  /** The single identity shared with the session. */
+  readonly id: SessionId
+  /** The provider route and model this agent's requests use. */
+  readonly options: AgentOptions
+  /** The live session this agent drives; its log is the durable source of truth. */
+  readonly session: Session
+  /** The current lifecycle state, mirrored on every `agent/status` transition. */
+  readonly status: AgentStatus
+}
+
+declare module 'cordis' {
+  interface Events {
+    /**
+     * Replace the frozen call configuration. `await next()` yields the config
+     * the machine would use; return a replacement to switch.
+     * @mode waterfall
+     */
+    'agent/request'(
+      payload: { agent: Agent; turn: number; step: number; signal: AbortSignal },
+      next: () => Promise<LlmCallConfig>,
+    ): Promise<LlmCallConfig>
+    /**
+     * Handle one failed model-request attempt before the loop retries or
+     * closes its step. A listener returns `{ kind: 'retry' }` without calling
+     * `next()` when it owns recovery, or calls `next()` to delegate.
+     * @mode waterfall
+     */
+    'agent/request-error'(
+      payload: {
+        agent: Agent
+        turn: number
+        step: number
+        provider: string
+        failure: LlmFailure
+        retryPolicy: ResolvedRetryPolicy | undefined
+        signal: AbortSignal
+      },
+      next: () => Promise<RequestErrorAction>,
+    ): Promise<RequestErrorAction>
+    /** Agent status changed (`idle` ⇄ `running`). @mode emit */
+    'agent/status'(payload: { agent: Agent; status: AgentStatus }): void
+    /** An agent left the registry. @mode emit */
+    'agent/disposed'(payload: { agent: Agent }): void
+  }
+}

--- a/peer-stubs/@deepseek-ai/dsh-agent/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-agent/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@deepseek-ai/dsh-agent",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "types": "index.d.ts",
+  "description": "Dev-time type-only stub for @deepseek-ai/dsh-agent. The real package is private (not on the npm registry) and ships from the host dsh app at runtime; this stub declares the type surface dsh-llm-fallbacks consumes (Agent / AgentOptions / RequestErrorAction + the agent/request-error, agent/request, agent/status, agent/disposed cordis Events entries). Mirrors dsh-private commit b8343cb (2026-08-09 snapshot)."
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-connection/client.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-connection/client.d.ts
@@ -1,0 +1,6 @@
+/**
+ * `@deepseek-ai/dsh-client-connection/client` subpath mirror: re-exports the
+ * consumed connection/client face (declared in `./index`), like the real
+ * package's `./client` export.
+ */
+export * from './index'

--- a/peer-stubs/@deepseek-ai/dsh-client-connection/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-connection/index.d.ts
@@ -1,0 +1,105 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-client-connection` seam
+ * consumed by the `dsh-llm-fallbacks` client half.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — the settings domain of `IApiClient` (`describe` / `update` /
+ * `replace` / `mutate` with the `expectedRevision` conflict semantics), the
+ * `SettingsNamespaceView` descriptor, and the `ConnectionHandle`. Mirrors
+ * dsh-private commit b8343cb (2026-08-09 snapshot,
+ * `packages/host/apiproxy/lib/types/api/settings.d.ts` +
+ * `packages/client/connection/src/client/index.ts`); keep in sync when the
+ * dsh baseline moves.
+ */
+
+/** One wire error: stable machine code plus message and typed details. */
+export interface RpcError {
+  code: string
+  message: string
+  details?: unknown
+}
+
+/** One schema-declared secret slot inside a redacted namespace value. */
+export interface SettingsSecretView {
+  /** Path from the section root to the removed field. */
+  path: string[]
+  /** Whether the slot currently holds a value (the value itself never rides). */
+  set: boolean
+}
+
+/** Wire view of one registered settings namespace. */
+export interface SettingsNamespaceView {
+  /** Namespace key (`fallbacks`, …). */
+  ns: string
+  /** Serialized schemastery schema envelope (`schema.toJSON()`). */
+  schema: unknown
+  /** Redacted resolved value (schema defaults → composition base → user layer). */
+  value: unknown
+  /** Redacted composition base layer, when the registrant declared one. */
+  base?: unknown
+  /** Redacted raw user section, when one exists. */
+  user?: unknown
+  /** When the owner applies changes. */
+  applies: 'live' | 'restart'
+  /** Every schema-declared secret slot with its configured state. */
+  secrets: SettingsSecretView[]
+  /** Monotonic revision of the raw user section; send back as `expectedRevision` on a write. */
+  revision: number
+}
+
+/** One path-addressed edit carried by `settings.mutate`. */
+export type SettingsPathOpView = {
+  op: 'set'
+  path: string[]
+  value: unknown
+} | {
+  op: 'unset'
+  path: string[]
+}
+
+/** RPC response envelope (rpc.ts mirror, consumed surface). */
+export interface RpcResponse<V> {
+  result: { ok: true; value: V } | { ok: false; error: RpcError }
+}
+
+/** Settings-domain unary methods of `IApiClient` (the map keys settings.* of RpcMethodMap). */
+export interface SettingsApi {
+  /** Describe every registered namespace: redacted layered values plus the serialized schema. */
+  describe(payload: {}, signal?: AbortSignal): Promise<RpcResponse<{
+    writable: boolean
+    hasDocument: boolean
+    namespaces: SettingsNamespaceView[]
+  }>>
+  /** Merge a patch into one namespace's user layer (validate → persist → commit). */
+  update(payload: {
+    ns: string
+    patch: object
+    expectedRevision?: number
+  }, signal?: AbortSignal): Promise<RpcResponse<SettingsNamespaceView>>
+  /** Replace one namespace's user section wholesale (`section: {}` resets to composition defaults). */
+  replace(payload: {
+    ns: string
+    section: object
+    expectedRevision?: number
+  }, signal?: AbortSignal): Promise<RpcResponse<SettingsNamespaceView>>
+  /** Apply path-addressed edits to one namespace's user section. */
+  mutate(payload: {
+    ns: string
+    ops: SettingsPathOpView[]
+    expectedRevision?: number
+  }, signal?: AbortSignal): Promise<RpcResponse<SettingsNamespaceView>>
+}
+
+/** Client consumption face of the contract — the settings domain only (fetch/client.ts mirror). */
+export interface IApiClient {
+  settings: SettingsApi
+}
+
+/** One connection handle the web runtime installs as the `connection` service. */
+export interface ConnectionHandle {
+  /** The payload-direct API client. */
+  readonly api: IApiClient
+  /** Whether this connection talks to the local loopback host. */
+  readonly isLoopback: boolean
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-connection/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-client-connection/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@deepseek-ai/dsh-client-connection",
+  "version": "0.0.1",
+  "private": true,
+  "types": "index.d.ts"
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-locale/client.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-locale/client.d.ts
@@ -1,0 +1,6 @@
+/**
+ * `@deepseek-ai/dsh-client-locale/client` subpath mirror: re-exports the
+ * consumed locale/client face (declared in `./index`), like the real
+ * package's `./client` export.
+ */
+export * from './index'

--- a/peer-stubs/@deepseek-ai/dsh-client-locale/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-locale/index.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-client-locale` seam
+ * consumed by the `dsh-llm-fallbacks` client half.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — `LocaleService` (register/bind), the `locale` Context merge, and the
+ * locale identifier/snapshot types. Mirrors dsh-private commit b8343cb
+ * (2026-08-09 snapshot, `packages/client/locale/src/client/index.ts`); keep
+ * in sync when the dsh baseline moves.
+ */
+import type { Context } from 'cordis'
+import type {
+  LocaleDictOf, LocaleNamespaceMap, TranslateNS,
+} from '@deepseek-ai/dsh-client-ui-slots'
+
+/** Locale identifier: the two shipped locales. */
+export type LocaleId = 'zh' | 'en'
+
+/** Immutable locale state published on every change. */
+export interface LocaleSnapshot {
+  /** Active locale id. */
+  active: LocaleId
+  /** Monotonic change counter. */
+  revision: number
+}
+
+/** Dictionary registry plus locale preference (consumed surface). */
+export class LocaleService {
+  /** Register one namespace's dictionaries; returns the disposer. */
+  register<N extends keyof LocaleNamespaceMap & string>(
+    ns: N, dicts: Record<LocaleId, LocaleDictOf<N>>): () => void
+  /** Bind a namespace to a translate function reading the active locale at call time. */
+  bind<N extends keyof LocaleNamespaceMap & string>(ns: N): TranslateNS<N>
+  /** Current locale snapshot. */
+  getSnapshot(): LocaleSnapshot
+  /** Subscribe to locale changes. */
+  subscribe(fn: () => void): () => void
+}
+
+declare module 'cordis' {
+  interface Context {
+    locale: LocaleService
+  }
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-locale/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-client-locale/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@deepseek-ai/dsh-client-locale",
+  "version": "0.0.1",
+  "private": true,
+  "types": "index.d.ts"
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-runtime/client.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-runtime/client.d.ts
@@ -1,0 +1,6 @@
+/**
+ * `@deepseek-ai/dsh-client-runtime/client` subpath mirror: re-exports the
+ * consumed runtime/client face (declared in `./index`), like the real
+ * package's `./client` export.
+ */
+export * from './index'

--- a/peer-stubs/@deepseek-ai/dsh-client-runtime/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-runtime/index.d.ts
@@ -1,0 +1,84 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-client-runtime` seam
+ * consumed by the `dsh-llm-fallbacks` client half.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — `ClientContext`, the `slots` Context merge (the `SlotsService`
+ * register/inject face the settings section registration uses), the
+ * `settings/changed` + `connection/reset` event merges, and the
+ * `createSnapshotStore` / `SnapshotStore` store engine. Mirrors dsh-private
+ * commit b8343cb (2026-08-09 snapshot,
+ * `packages/client/runtime/src/client/index.ts` + `src/client/slots.ts`);
+ * keep in sync when the dsh baseline moves.
+ *
+ * Runtime access in tests is aliased (vitest `resolve.alias`) to
+ * `tests/support/runtime-stub.ts`; this stub only types the plugin source.
+ */
+import type { Context } from 'cordis'
+import type {
+  EntryKeyOf, InjectFace, KindOptions, LocaleNamespaceMap, PropsLocale, PropsRuntime,
+  SlotComponent, SlotLabel, SlotMap,
+} from '@deepseek-ai/dsh-client-ui-slots'
+
+/** Client-side Cordis context after declaration merging. */
+export type ClientContext = Context
+
+/** Minimal observable snapshot source. */
+export interface ObservableSnapshot<T> { getSnapshot(): T; subscribe(fn: () => void): () => void }
+
+/** Writable snapshot store (bare data face; React selector hooks live in web-react). */
+export interface SnapshotStore<T> extends ObservableSnapshot<T> {
+  update(mutator: (draft: T) => void): void
+  set(next: T): void
+}
+
+/** Create a snapshot store (engine contract, consumed surface). */
+export function createSnapshotStore<T>(
+  init: T, opts?: { flush?: 'raf' | 'sync'; persist?: { name: string } }): SnapshotStore<T>
+
+/** The slot-service face the plugin consumes (runtime `SlotsService` mirror). */
+export class SlotsService {
+  /**
+   * The single registration API. List-kind registrations carry
+   * `id`/`order`/`label`; the component is checked against the composed props
+   * (runtime + locale seats + the inject business face).
+   */
+  register<
+    K extends keyof SlotMap & string,
+    EntryKey extends EntryKeyOf<K> = EntryKeyOf<K>,
+    N extends (keyof LocaleNamespaceMap & string) | undefined = undefined,
+  >(
+    options: { name: K; locale?: N } & KindOptions<K, EntryKey>,
+    component: SlotComponent<PropsRuntime<K, EntryKey> & PropsLocale<N>>,
+  ): () => void
+  register<
+    K extends keyof SlotMap & string,
+    I extends object,
+    EntryKey extends EntryKeyOf<K> = EntryKeyOf<K>,
+    N extends (keyof LocaleNamespaceMap & string) | undefined = undefined,
+  >(
+    options: { name: K; locale?: N; inject: (...args: never[]) => I } & KindOptions<K, EntryKey>,
+    component: SlotComponent<PropsRuntime<K, EntryKey> & InjectFace<I> & PropsLocale<N>>,
+  ): () => void
+  /**
+   * Inject a registration callback that runs once the target slot's
+   * declaration is on the ledger; returns a disposer.
+   */
+  inject(key: keyof SlotMap & string, callback: () => (() => void) | Iterable<() => void>): () => void
+}
+
+declare module 'cordis' {
+  interface Events {
+    /** A settings namespace changed (host-pushed wire event). @mode emit */
+    'settings/changed'(ns: string): void
+    /** A connection generation was (re-)established. @mode emit */
+    'connection/reset'(): void
+  }
+  interface Context {
+    /** The slot system's cordis Service layer. */
+    slots: SlotsService
+  }
+}
+
+export type { SlotLabel }

--- a/peer-stubs/@deepseek-ai/dsh-client-runtime/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-client-runtime/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@deepseek-ai/dsh-client-runtime",
+  "version": "0.0.1",
+  "private": true,
+  "types": "index.d.ts"
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-ui-settings/client.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-ui-settings/client.d.ts
@@ -1,0 +1,7 @@
+/**
+ * `@deepseek-ai/dsh-client-ui-settings/client` subpath mirror: pulls the
+ * `settings.section` SlotMap merge (declared in `./index`) into programs that
+ * import the client subpath, exactly like the real package's `./client`
+ * export.
+ */
+import './index'

--- a/peer-stubs/@deepseek-ai/dsh-client-ui-settings/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-ui-settings/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-client-ui-settings` seam
+ * consumed by the `dsh-llm-fallbacks` client half.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — the `settings.section` SlotMap row and its `SettingsSectionOwnerProps`
+ * owner share (the shell owns the slot contract; a section receives nothing
+ * but the render site — data arrives through its own store). Mirrors
+ * dsh-private commit b8343cb (2026-08-09 snapshot,
+ * `packages/client/ui-settings/src/client/contract/slots.ts`); keep in sync
+ * when the dsh baseline moves.
+ */
+import type { SlotEntryDef } from '@deepseek-ai/dsh-client-ui-slots'
+
+declare module '@deepseek-ai/dsh-client-ui-slots' {
+  interface SlotMap {
+    /**
+     * One settings page per list entry. Registrant options carry the nav
+     * identity: `id` (section key, drives `only` filtering), `order` (nav
+     * position), `label` (registrant-localized display text). Sections render
+     * inside the panel content column.
+     */
+    'settings.section': { kind: 'list'; scope: 'root'; owner: SettingsSectionOwnerProps }
+  }
+}
+
+/** Owner share of a settings section entry (intentionally empty — see contract). */
+export interface SettingsSectionOwnerProps {
+  /** Marker field: section owner props are intentionally empty for now. */
+  children?: never
+}
+
+export type { SlotEntryDef }

--- a/peer-stubs/@deepseek-ai/dsh-client-ui-settings/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-client-ui-settings/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@deepseek-ai/dsh-client-ui-settings",
+  "version": "0.0.1",
+  "private": true,
+  "types": "index.d.ts"
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-ui-slots/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-client-ui-slots/index.d.ts
@@ -1,0 +1,261 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-client-ui-slots` seam
+ * consumed by the `dsh-llm-fallbacks` client half.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — the slot-contract machinery the settings section registration relies
+ * on: `SlotMap` / `LocaleNamespaceMap` merge targets, `PropsRuntime` /
+ * `PropsLocale` / `PropsRenderSlots`, `SlotLabel`, `SlotComponent`,
+ * `InjectFace`, `HostObservable`. Mirrors dsh-private commit b8343cb
+ * (2026-08-09 snapshot); keep in sync when the dsh baseline moves.
+ *
+ * The `settings.section` SlotMap row is declared by the
+ * `@deepseek-ai/dsh-client-ui-settings` stub (the shell owns the contract,
+ * exactly as in the real source); the locale-namespace merge for the
+ * `fallbacks` dictionary lives in `src/client/locales.ts`.
+ */
+import type { ReactNode } from 'react'
+
+/** Slot contract table. Owners extend via declaration merging. */
+export interface SlotMap {}
+
+/** Locale namespace table. Dictionary owners extend via declaration merging. */
+export interface LocaleNamespaceMap {}
+
+/** Minimal observable snapshot source (renderer.ts mirror). */
+export interface HostObservable<T> {
+  getSnapshot(): T
+  subscribe(fn: () => void): () => void
+}
+
+/** Selector hook over one observable snapshot (store.ts mirror). */
+export type SnapshotSelectorHook<T> = <S>(sel: (s: T) => S, eq?: (a: S, b: S) => boolean) => S
+
+/** Translate a dictionary key with optional `{name}` template params. */
+export type Translate<K extends string = string> =
+  (key: K, params?: Record<string, unknown>) => string
+
+/** Shared `common` vocabulary keys as merged by the locale plugin; `never` without the merge. */
+export type CommonKeyOf = LocaleNamespaceMap extends { common: infer C } ? C & string : never
+
+/** Key domain of a namespace-bound translate. */
+export type LocaleKeysOf<N extends keyof LocaleNamespaceMap & string> =
+  (LocaleNamespaceMap[N] & string) | CommonKeyOf
+
+/** Namespace-addressed translate — the developer-facing alias over {@link Translate}. */
+export type TranslateNS<N extends keyof LocaleNamespaceMap & string> = Translate<LocaleKeysOf<N>>
+
+/** Dictionary shape for a declared namespace. */
+export type LocaleDictOf<N extends keyof LocaleNamespaceMap & string> =
+  Record<LocaleNamespaceMap[N] & string, string>
+
+/** Locale share of the composed component props: the framework-injected `t` seat. */
+export type PropsLocale<N> = N extends keyof LocaleNamespaceMap & string
+  ? { t: TranslateNS<N> }
+  : object
+
+/** Slot cardinality. */
+export type SlotKind = 'single' | 'list' | 'keyed' | 'chain'
+/** Slot data context. */
+export type SlotScope = 'root' | 'session-maybe' | 'session'
+
+/** One SlotMap entry (index.ts mirror, consumed surface only). */
+export interface SlotEntryDef {
+  kind: SlotKind
+  scope: SlotScope
+  owner?: object
+  keyProps?: Record<string, object>
+  hookContext?: unknown
+  inject?: object
+}
+
+/** Runtime dispatch spec for one slot, recorded from a register call's `children`. */
+export type SlotSpec<E extends SlotEntryDef> = {
+  kind: E['kind']
+  scope: E['scope']
+} & ('inject' extends keyof E
+  ? E extends { inject: infer Injected extends object }
+    ? { inject: Injected }
+    : { inject?: object }
+  : { inject?: never })
+
+/** Child-slot declaration table for register(). */
+export type ChildrenDecl = { [P in keyof SlotMap & string]?: SlotSpec<SlotMap[P]> }
+
+/** Owner-supplied props share for a slot key. */
+export type OwnerOf<K extends keyof SlotMap & string> =
+  SlotMap[K] extends { owner: infer O extends object } ? O : object
+
+/** Registration/dispatch key domain of one keyed slot. */
+export type EntryKeyOf<K extends keyof SlotMap & string> =
+  SlotMap[K] extends { kind: 'keyed'; keyProps: infer P extends object }
+    ? keyof P & string
+    : string
+
+/** Key-dependent props supplied by the owner at one keyed dispatch site. */
+export type KeyPropsOf<
+  K extends keyof SlotMap & string,
+  EntryKey extends EntryKeyOf<K>,
+> = SlotMap[K] extends { kind: 'keyed'; keyProps: infer P extends object }
+  ? EntryKey extends keyof P
+    ? P[EntryKey] extends object ? P[EntryKey] : never
+    : never
+  : object
+
+/** Opaque per-render occurrence context declared by one slot. */
+export type HookContextOf<K extends keyof SlotMap & string> =
+  SlotMap[K] extends { hookContext: infer Context } ? Context : never
+
+/** Common render-occurrence inject face declared by one slot. */
+export type SlotInjectOf<K extends keyof SlotMap & string> =
+  SlotMap[K] extends { inject: infer Injected extends object } ? Injected : object
+
+/** Scope axis of a slot key's SlotMap entry. */
+export type ScopeOf<K extends keyof SlotMap & string> = SlotMap[K]['scope']
+
+/** Framework standard kit delivered to EVERY slot component (empty here; the runtime merges). */
+export interface GlobalStandardProps {}
+/** Framework standard kit for session-scope slots (empty here). */
+export interface SessionStandardProps {}
+/** Framework standard kit for session-maybe slots (empty here). */
+export interface SessionMaybeStandardProps {}
+
+/** The session id type (falls back to `string` without the runtime merge). */
+export type SessionIdOf = SessionStandardProps extends { sessionId: infer S } ? S : string
+
+/** Runtime props share for a slot key: owner share + session kit + the global seat. */
+export type PropsRuntime<
+  K extends keyof SlotMap & string,
+  EntryKey extends EntryKeyOf<K> = EntryKeyOf<K>,
+> =
+  OwnerOf<K> &
+  KeyPropsOf<K, EntryKey> &
+  SlotInjectFace<SlotInjectOf<K>> &
+  (ScopeOf<K> extends 'session' ? SessionStandardProps
+    : ScopeOf<K> extends 'session-maybe' ? SessionMaybeStandardProps
+      : object) &
+  GlobalStandardProps
+
+/** renderSlot dispatch options. */
+export interface RenderOpts<EntryKey extends string = string> {
+  entryKey?: EntryKey
+  only?: string
+  fallback?: ReactNode
+  hookContext?: unknown
+}
+
+/** Keys of a slot-key union whose SlotMap entry is chain-kind. */
+export type ChainKeysOf<S extends keyof SlotMap & string> =
+  S extends unknown ? (SlotMap[S]['kind'] extends 'chain' ? S : never) : never
+
+/** Keys in a render share whose dispatch occurrence requires hookContext. */
+type ContextualKeysOf<S extends keyof SlotMap & string> =
+  S extends unknown ? (SlotMap[S] extends { hookContext: unknown } ? S : never) : never
+
+/** Keys in a render share with the ordinary optional options bag. */
+type OrdinaryKeysOf<S extends keyof SlotMap & string> = Exclude<S, ContextualKeysOf<S>>
+
+type RenderSlotFn<S extends keyof SlotMap & string> =
+  ([ContextualKeysOf<S>] extends [never] ? object : {
+    <
+      K extends ContextualKeysOf<S>,
+      EntryKey extends EntryKeyOf<K> = EntryKeyOf<K>,
+    >(
+      key: K,
+      owner: OwnerOf<K> & KeyPropsOf<K, NoInfer<EntryKey>>,
+      opts: RenderOpts<EntryKey> & { hookContext: HookContextOf<K> },
+    ): ReactNode
+  }) &
+  ([OrdinaryKeysOf<S>] extends [never] ? object : {
+    <
+      K extends OrdinaryKeysOf<S>,
+      EntryKey extends EntryKeyOf<K> = EntryKeyOf<K>,
+    >(
+      key: K,
+      owner: OwnerOf<K> & KeyPropsOf<K, NoInfer<EntryKey>>,
+      opts?: Omit<RenderOpts<EntryKey>, 'hookContext'>,
+    ): ReactNode
+  })
+
+/** Child-slot render share: `renderSlot` statically narrowed to declared children keys. */
+export type PropsRenderSlots<S extends keyof SlotMap & string> = {
+  renderSlot: RenderSlotFn<Exclude<S, ChainKeysOf<S>>>
+  readonly __renders?: ((key: S) => void) | undefined
+} & ([ChainKeysOf<S>] extends [never] ? object : {
+  renderSlotChain: <K extends ChainKeysOf<S>>(key: K, owner: OwnerOf<K>, opts?: { fallback?: ReactNode; overlay?: boolean }) => ReactNode
+}) & ('session' extends ScopeOf<S> ? { SessionProvider: (props: { empty?: () => ReactNode; children: (sessionId: SessionIdOf) => ReactNode }) => ReactNode } : object)
+
+/** Registration-position component shape: the bare call signature. */
+export type SlotComponent<P> = (props: P) => ReactNode
+
+/** Registrant hooks compartment. */
+export type HooksSources = Record<string, HostObservable<unknown>>
+
+/** Framework-owned props visible while a slot-level contextual Hook is bound. */
+export type StandardPropsOf<K extends keyof SlotMap & string> =
+  (ScopeOf<K> extends 'session' ? SessionStandardProps
+    : ScopeOf<K> extends 'session-maybe' ? SessionMaybeStandardProps
+      : object) &
+  GlobalStandardProps
+
+/** One function-valued slot-level inject.hooks member factory. */
+export type SlotHookFactory<
+  K extends keyof SlotMap & string,
+  Hook extends (...args: never[]) => unknown,
+> = (
+  standard: StandardPropsOf<K>,
+  hookContext: HookContextOf<K>,
+) => Hook
+
+type BoundHookOf<Definition> =
+  Definition extends HostObservable<infer Snapshot>
+    ? SnapshotSelectorHook<Snapshot>
+    : Definition extends (...args: never[]) => infer Hook
+      ? Hook extends (...args: never[]) => unknown ? Hook : never
+      : never
+
+/** Selector-hook share synthesized from a hooks compartment. */
+export type PropsSlotHooks<HS extends object> = {
+  [N in keyof HS & string as `use${Capitalize<N>}`]:
+  BoundHookOf<HS[N]>
+}
+
+/** Component-side view of a slot dispatcher's common inject face. */
+export type SlotInjectFace<I extends object> =
+  I extends { hooks: infer HS extends object } ? Omit<I, 'hooks'> & PropsSlotHooks<HS> : I
+
+/** Selector-hook share synthesized from an entry inject hooks compartment. */
+export type PropsHooks<HS extends HooksSources> = {
+  [N in keyof HS & string as `use${Capitalize<N>}`]:
+  SnapshotSelectorHook<HS[N] extends HostObservable<infer T> ? T : never>
+}
+
+/** The component-side view of an inject face. */
+export type InjectFace<I extends object> =
+  I extends { hooks: infer HS extends HooksSources } ? Omit<I, 'hooks'> & PropsHooks<HS> : I
+
+/** A list-entry display label: a plain string, or a thunk re-evaluated per read. */
+export type SlotLabel = string | (() => string)
+
+/** Kind shape fields carried in register options (list kind: id/order/label). */
+export type KindOptions<
+  K extends keyof SlotMap & string,
+  EntryKey extends EntryKeyOf<K>,
+  M = never,
+> =
+  SlotMap[K]['kind'] extends 'keyed' ? { key: EntryKey }
+    : SlotMap[K]['kind'] extends 'list' ? { id: string; order?: number; label?: SlotLabel }
+      : SlotMap[K]['kind'] extends 'chain' ? {
+          select: ChainSelect<SlotMap[K] extends { owner: infer O extends object } ? O : object, M>
+          priority?: number
+        }
+        : object
+
+/** Chain-entry selector (chain kind only). */
+export type ChainSelect<O extends object, M> = (owner: O) => M | null
+
+/** Resolve a possibly-thunked list label at read time. */
+export function resolveSlotLabel(label: SlotLabel | undefined): string | undefined {
+  return typeof label === 'function' ? label() : label
+}

--- a/peer-stubs/@deepseek-ai/dsh-client-ui-slots/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-client-ui-slots/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@deepseek-ai/dsh-client-ui-slots",
+  "version": "0.0.1",
+  "private": true,
+  "types": "index.d.ts"
+}

--- a/peer-stubs/@deepseek-ai/dsh-llm/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-llm/index.d.ts
@@ -1,0 +1,60 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-llm` seam consumed by
+ * `dsh-llm-fallbacks`.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — `LlmFailure` / `LlmCallConfig` / `LlmError` / `ResolvedRetryPolicy`
+ * / `ReasoningEffortId`. Mirrors dsh-private commit b8343cb (2026-08-09
+ * snapshot); keep in sync when the dsh baseline moves.
+ */
+
+/** Serializable provider-boundary facts; policy decides whether they are retryable. */
+export interface LlmFailure {
+  /** Human-readable provider or transport failure. */
+  readonly message: string
+  /** Stable provider-neutral machine-routing code. */
+  readonly code: string
+  /** HTTP status observed at the provider boundary, when available. */
+  readonly status?: number
+  /** Provider-requested delay in milliseconds, when valid and available. */
+  readonly providerRetryAfterMs?: number
+  /** Opaque provider-issued request identifier for diagnostics. */
+  readonly requestId?: string
+}
+
+/** Process-local identity of one reasoning-effort id (mirror of the real brand). */
+export type ReasoningEffortId = string & { readonly __brand?: 'ReasoningEffortId' }
+
+/** Provider, model, reasoning effort, and sampling scalars of one conversation's requests. */
+export interface LlmCallConfig {
+  provider: string
+  model: string
+  reasoningEffort?: ReasoningEffortId
+  temperature?: number
+  maxTokens?: number
+  stop?: string[]
+}
+
+/** Immutable provider policy captured when its adapter route is registered. */
+export interface ResolvedRetryPolicy {
+  readonly mode: 'normal' | 'always'
+  readonly maxRetries?: number
+  readonly retryableCodes?: readonly string[]
+  readonly initialDelayMs: number
+  readonly maxDelayMs: number
+  readonly jitterRatio: number
+}
+
+/** Typed error for LLM-related failures; carries the stable `code` taxonomy. */
+export declare class LlmError extends Error {
+  /** Stable machine-routable failure class (e.g. `AUTH`, `RATE_LIMIT`). */
+  readonly code: string
+  /** Serializable facts retained beside this live Error. */
+  readonly failure: LlmFailure
+  constructor(message: string, code: string, options?: ErrorOptions & {
+    status?: number
+    providerRetryAfterMs?: number
+    requestId?: string
+  })
+}

--- a/peer-stubs/@deepseek-ai/dsh-llm/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-llm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@deepseek-ai/dsh-llm",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "types": "index.d.ts",
+  "description": "Dev-time type-only stub for @deepseek-ai/dsh-llm. The real package is private (not on the npm registry) and ships from the host dsh app at runtime; this stub declares the type surface dsh-llm-fallbacks consumes (LlmFailure / LlmCallConfig / LlmError / ResolvedRetryPolicy / ReasoningEffortId). Mirrors dsh-private commit b8343cb (2026-08-09 snapshot)."
+}

--- a/peer-stubs/@deepseek-ai/dsh-session/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-session/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-session` seam consumed by
+ * `dsh-llm-fallbacks`.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — `SessionEventMap` (merge-extensible, augmented by
+ * `src/events.ts`), `SessionEvent`, `Session`, `SessionId`, `EpochHeader`.
+ * Mirrors dsh-private commit b8343cb (2026-08-09 snapshot); keep in sync
+ * when the dsh baseline moves.
+ *
+ * `'llm/retry'` is a placeholder declared directly (the real augmentation
+ * lives in llm-retry) so the plugin's always-mode cap counting type-checks.
+ */
+export * from './types'

--- a/peer-stubs/@deepseek-ai/dsh-session/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-session/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@deepseek-ai/dsh-session",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "types": "index.d.ts",
+  "description": "Dev-time type-only stub for @deepseek-ai/dsh-session. The real package is private (not on the npm registry) and ships from the host dsh app at runtime; this stub declares the type surface dsh-llm-fallbacks consumes (SessionEventMap / SessionEvent / Session / SessionId / EpochHeader; the @deepseek-ai/dsh-session/types subpath feeds the fallbacks/switch module augmentation). Mirrors dsh-private commit b8343cb (2026-08-09 snapshot)."
+}

--- a/peer-stubs/@deepseek-ai/dsh-session/types.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-session/types.d.ts
@@ -12,12 +12,15 @@ export interface SessionEventMap {
   /**
    * Placeholder for the llm-retry event the plugin's always-mode cap counts
    * (the real augmentation lives in llm-retry). Only the fields the plugin
-   * consumes are declared.
+   * consumes are declared — `mode` discriminates always-mode (unbounded)
+   * retries from normal (bounded) ones, which the cap must not count
+   * (T3 review Minor 2).
    */
   'llm/retry': {
     turn: number
     step: number
     provider: string
+    mode: 'normal' | 'always'
     policyKey?: string
     retry?: number
   }

--- a/peer-stubs/@deepseek-ai/dsh-session/types.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-session/types.d.ts
@@ -1,0 +1,78 @@
+/**
+ * Session event vocabulary stub (see `index.d.ts` header). Mirrors
+ * dsh-private commit b8343cb (2026-08-09 snapshot), consumed surface only.
+ */
+import type { LlmCallConfig } from '@deepseek-ai/dsh-llm'
+
+/**
+ * The merge-extensible, append-only source of truth for an agent interaction.
+ * Plugin-owned events augment this interface (see `src/events.ts`).
+ */
+export interface SessionEventMap {
+  /**
+   * Placeholder for the llm-retry event the plugin's always-mode cap counts
+   * (the real augmentation lives in llm-retry). Only the fields the plugin
+   * consumes are declared.
+   */
+  'llm/retry': {
+    turn: number
+    step: number
+    provider: string
+    policyKey?: string
+    retry?: number
+  }
+}
+
+/** The appendable event-type keys of {@link SessionEventMap}, plugin-merged extensions included. */
+export type SessionEventType = keyof SessionEventMap
+
+/** One immutable entry in the session log (simplified — no surface metadata). */
+export type SessionEvent<T extends SessionEventType = SessionEventType> = {
+  [K in SessionEventType]: {
+    type: K
+    /** Monotonic sequence number within the session. */
+    seq: number
+    /** Unix epoch milliseconds. */
+    time: number
+    data: SessionEventMap[K]
+  }
+}[T]
+
+/** Process-local branded session identity. */
+export type SessionId = string & { readonly __brand?: 'SessionId' }
+
+/** Full header for the next request, appended inside its step before dispatch. */
+export interface EpochHeader {
+  /** The conversation's call configuration (provider, model, reasoning effort, and sampling scalars). */
+  config: LlmCallConfig
+  /** Effective config fields materialized from the exact adapter rather than proposed by a caller. */
+  adapterDefaults?: unknown
+  /** Rendered system prompt text; absent for a system-less request. */
+  system?: string
+  /** Assembled tool schemas; absent for a tool-less request. */
+  tools?: unknown[]
+}
+
+/** Session identity + creation metadata folded into the durable header. */
+export interface SessionHeader {
+  /** The session's id (mirrors the {@link Session}'s id). */
+  readonly id: SessionId
+  /** Coarse product classification for a session created as a subagent child. */
+  readonly origin?: 'subagent'
+  /** Delegation depth: absent (zero) for a top-level session. */
+  readonly delegationDepth?: number
+}
+
+/** An event-sourced session: an append-only log of {@link SessionEvent}s (consumed surface only). */
+export interface Session {
+  /** The session identity. */
+  readonly id: SessionId
+  /** The durable session header (carries `origin` for subagent children). */
+  readonly header: SessionHeader
+  /** An immutable snapshot of the append-only event log. */
+  readonly events: readonly SessionEvent[]
+  /** Append one typed event to the log (non-surface events take no surface metadata). */
+  append<T extends SessionEventType>(type: T, data: SessionEventMap[T]): SessionEvent<T>
+  /** The folded request header of the latest logged request, when one exists. */
+  requestHeader(): EpochHeader | undefined
+}

--- a/peer-stubs/@deepseek-ai/dsh-settings/index.d.ts
+++ b/peer-stubs/@deepseek-ai/dsh-settings/index.d.ts
@@ -1,0 +1,70 @@
+/**
+ * Dev-time type-only stub for the `@deepseek-ai/dsh-settings` seam consumed
+ * by `dsh-llm-fallbacks`.
+ *
+ * The real package is private (not on the npm registry) and ships from the
+ * composed dsh app at runtime; only the consumed type surface is declared
+ * here — `installSettingsSection` / `settingsNamespace` / `SettingsScope` /
+ * `SettingsRegisterOptions` / `SettingsSectionHooks`. Mirrors dsh-private
+ * commit b8343cb (2026-08-09 snapshot); keep in sync when the dsh baseline
+ * moves.
+ *
+ * Runtime access in tests is aliased (vitest `resolve.alias`) to
+ * `tests/support/settings-stub.ts`; this stub only types the plugin source.
+ */
+import type { Context } from 'cordis'
+import type z from 'schemastery'
+
+/** Nominal id of one registered settings namespace. */
+export type SettingsNamespace = string & { readonly __brand?: 'SettingsNamespace' }
+
+/** Brand a raw string as a {@link SettingsNamespace}. */
+export function settingsNamespace(value: string): SettingsNamespace
+
+/** When a namespace's changes take effect for its owner. */
+export type SettingsApplies = 'live' | 'restart'
+
+/** Registration options beyond the namespace schema. */
+export interface SettingsRegisterOptions<T> {
+  /** Composition-layer values resolved below the user layer (entry-config subset). */
+  base?: Partial<T>
+  /** Owner's effect timing, surfaced to configuration UIs; defaults to `live`. */
+  applies?: SettingsApplies
+  /** Reject a resolved section the owner could not act on (cross-field constraints). */
+  validate?: (value: T) => void
+}
+
+/** Owner-facing handle for one registered namespace. */
+export interface SettingsScope<T> {
+  /** Current resolved value: schema defaults, then `base`, then the user layer. */
+  get(): T
+  /**
+   * Observe committed changes to this namespace's resolved value.
+   * @returns the disposer removing this observer.
+   */
+  watch(callback: (next: T, prev: T) => void | Promise<void>): () => void
+}
+
+/** Hooks a consumer hands to {@link installSettingsSection}. */
+export interface SettingsSectionHooks<T> {
+  /** Receive the active configuration source (scope while attached, composition entry otherwise). */
+  setSource(current: () => T): void
+  /** Re-judge anything derived from the source after attach/detach/committed change. */
+  onChange(): void
+  /** Reject a resolved section this consumer could not act on. */
+  validate?: (value: T) => void
+}
+
+/**
+ * Install the canonical optional-settings consumer wiring: while a settings
+ * service exists, register `ns` with the consumer's composition entry as the
+ * `base` layer and point the source thunk at the resolved scope; when the
+ * service goes away, fall back to the entry.
+ */
+export function installSettingsSection<T>(
+  ctx: Context,
+  ns: SettingsNamespace,
+  schema: z<T>,
+  entry: T,
+  hooks: SettingsSectionHooks<T>,
+): void

--- a/peer-stubs/@deepseek-ai/dsh-settings/package.json
+++ b/peer-stubs/@deepseek-ai/dsh-settings/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@deepseek-ai/dsh-settings",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "types": "index.d.ts",
+  "description": "Dev-time type-only stub for @deepseek-ai/dsh-settings. The real package is private (not on the npm registry) and ships from the host dsh app at runtime; this stub declares the type surface dsh-llm-fallbacks consumes (installSettingsSection / settingsNamespace / SettingsScope / SettingsRegisterOptions / SettingsSectionHooks). Mirrors dsh-private commit b8343cb (2026-08-09 snapshot). Runtime access in tests is aliased to tests/support/settings-stub.ts."
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,760 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      bun-types:
+        specifier: ^1.2.17
+        version: 1.3.14
+      cordis:
+        specifier: ^4.0.0-rc.7
+        version: 4.0.0-rc.7
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.10(@types/node@26.2.0)
+
+packages:
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cordis@4.0.0-rc.7:
+    resolution: {integrity: sha512-5nm6ehrSfJhEUV659CctEvyNuBY/AXapw8+ZEw7YENztdzpiT+Ha8nIfkyhfyAgPtJns9aB5On5nzl9Sm6zHeQ==}
+    hasBin: true
+    peerDependencies:
+      '@cordisjs/plugin-include': ^1.0.4
+      '@cordisjs/plugin-loader': ^1.0.0-rc.5
+    peerDependenciesMeta:
+      '@cordisjs/plugin-include':
+        optional: true
+      '@cordisjs/plugin-loader':
+        optional: true
+
+  cosmokit@1.8.1:
+    resolution: {integrity: sha512-PDBv4l90xZKrUsZ0vtoycgZpO/j4iFsqJXrAxsyBDsnQRI7ZMJXIjgDJsKNjd5L8jnVnnlrDCdhkFbTncgCVjQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  schemastery@3.18.0:
+    resolution: {integrity: sha512-Jw2uxjoyyqc/yeurmChUEc/jbi8GsrdXV/KmqRUDZXJAXAmrJiPsz8vKa17l/VckyzljHZ9oGaul443CQiXxtA==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@oxc-project/types@0.143.0': {}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@26.2.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  assertion-error@2.0.1: {}
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 26.2.0
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  cordis@4.0.0-rc.7:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      cosmokit: 1.8.1
+
+  cosmokit@1.8.1: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.18: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
+
+  schemastery@3.18.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      cosmokit: 1.8.1
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@8.3.0: {}
+
+  vite@8.2.1(@types/node@26.2.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@26.2.0):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@26.2.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+    transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     devDependencies:
+      '@types/react':
+        specifier: ~18.3.31
+        version: 18.3.31
       bun-types:
         specifier: ^1.2.17
         version: 1.3.14
       cordis:
         specifier: ^4.0.0-rc.7
         version: 4.0.0-rc.7
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
       schemastery:
         specifier: ^3.18.0
         version: 3.18.0
@@ -134,6 +140,12 @@ packages:
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -192,6 +204,9 @@ packages:
   cosmokit@1.8.1:
     resolution: {integrity: sha512-PDBv4l90xZKrUsZ0vtoycgZpO/j4iFsqJXrAxsyBDsnQRI7ZMJXIjgDJsKNjd5L8jnVnnlrDCdhkFbTncgCVjQ==}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -219,6 +234,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -290,6 +308,10 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -315,6 +337,10 @@ packages:
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   rolldown@1.2.3:
     resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
@@ -513,6 +539,13 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -571,6 +604,8 @@ snapshots:
 
   cosmokit@1.8.1: {}
 
+  csstype@3.2.3: {}
+
   detect-libc@2.1.2: {}
 
   es-module-lexer@2.3.1: {}
@@ -587,6 +622,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  js-tokens@4.0.0: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -637,6 +674,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -656,6 +697,10 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   rolldown@1.2.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# dsh profile convention: the @deepseek-ai/* and cordis peer dependencies
+# resolve from the dsh installation at runtime (in-box bundles), never from
+# the npm registry. Disable auto-install-peers so a local `pnpm install`
+# does not try to fetch unpublished packages.
+autoInstallPeers: false

--- a/scripts/apply-dsh-patch.sh
+++ b/scripts/apply-dsh-patch.sh
@@ -42,7 +42,7 @@ PATCH_FILES=(
 )
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 

--- a/scripts/apply-dsh-patch.sh
+++ b/scripts/apply-dsh-patch.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# apply-dsh-patch.sh — 将 dsh 本体 role patch 应用到目标 dsh 源码树。
+#
+# 背景：dsh-llm-fallbacks 需要 subagent 的显式角色来源。dsh 本体最小改动：
+#   - @deepseek-ai/dsh-agent:        AgentOptions 追加可选 role?: string
+#   - @deepseek-ai/dsh-tool-subagent: Config.agentOptions schema 追加 role: z.string()
+# 本脚本把这些改动以 git patch 形式应用到 dsh 源码树（本仓库不携带 dsh 源码）。
+#
+# 目标解析（运行时，脚本本身不含本地绝对路径）：
+#   $DSH_SOURCE_DIR（若设置）→ 缺省 ${DSH_HOME}/source/current
+#
+# 流程（对每个 patch）：
+#   git apply --check 通过 → 尚未应用 → git apply 应用；
+#   git apply --reverse --check 通过 → 已应用 → 跳过（幂等）；
+#   两者都失败 → 冲突/损坏 → 报错退出。
+# 应用完成后重建受影响包（tsc -b 增量 + tsdown host 打包）。
+#
+# 选项：
+#   --check        仅检查每个 patch 是否可应用，不修改任何文件、不构建。
+#   --skip-build   应用 patch 后跳过构建步骤（exit 0；供无 pnpm 环境的场景手动构建）。
+#   -d|--target DIR  指定目标 dsh 源码树（覆盖 env 解析）。
+#   -h|--help      显示本帮助。
+#
+# 退出码：
+#   0  全部 patch 已应用（或已应用跳过）/ --check 全部就绪
+#   1  任一 patch 冲突、目标目录不可用、或构建失败 / 因缺 pnpm 环境而跳过构建
+#
+# 安全说明：构建步骤会在目标树执行安装时代码（tsc/tsdown），仅应对可信的 dsh
+# 源码树运行；目标树由 $DSH_SOURCE_DIR / $DSH_HOME 显式指定。
+set -euo pipefail
+
+# 定位本脚本与仓库根（运行时推导，无硬编码绝对路径）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PATCHES_DIR="${REPO_ROOT}/patches"
+
+# 本任务交付的两个 pnpm 格式 patch（文件名即 pnpm 惯例 @scope+pkg@version.patch）
+PATCH_FILES=(
+  "@deepseek-ai+dsh-agent@0.0.1.patch"
+  "@deepseek-ai+dsh-tool-subagent@0.0.1.patch"
+)
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+CHECK_ONLY=0
+SKIP_BUILD=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) CHECK_ONLY=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    -d|--target) TARGET="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "未知选项: $1" >&2; usage 1 ;;
+  esac
+done
+
+# 解析目标目录
+if [[ -z "$TARGET" ]]; then
+  TARGET="${DSH_SOURCE_DIR:-${DSH_HOME:-}/source/current}"
+fi
+if [[ ! -d "$TARGET/.git" ]]; then
+  echo "ERROR: 目标目录不是 git 仓库: $TARGET" >&2
+  echo "       请设置 DSH_SOURCE_DIR（或 DSH_HOME），或使用 --target。" >&2
+  exit 1
+fi
+echo "== 目标 dsh 源码树: $TARGET"
+
+# 返回单个 patch 的状态：needs-apply / applied / conflict
+patch_status() {
+  local patch="$1"
+  if git -C "$TARGET" apply --check "${PATCHES_DIR}/${patch}" 2>/dev/null; then
+    echo "needs-apply"
+  elif git -C "$TARGET" apply --reverse --check "${PATCHES_DIR}/${patch}" 2>/dev/null; then
+    echo "applied"
+  else
+    echo "conflict"
+  fi
+}
+
+# 重建受影响包：tsc -b 增量（两个包及其引用）→ tsdown host 打包（产出 lib/ 运行产物）。
+# dsh monorepo 无每包 build 脚本，这是与仓库一致的增量构建入口。
+build_affected() {
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "WARN: PATH 中找不到 pnpm；patch 已应用但构建已跳过。" >&2
+    echo "      请手动重建: cd \"\$DSH_SOURCE_DIR\" && pnpm install && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent && pnpm exec tsdown --env.DSH_BUILD_FACE host" >&2
+    return 1
+  fi
+  if [[ ! -d "$TARGET/node_modules" ]]; then
+    echo "WARN: 目标树缺少 node_modules（非 pnpm 工作区安装）；patch 已应用但构建已跳过。" >&2
+    echo "      请手动重建: cd \"\$DSH_SOURCE_DIR\" && pnpm install && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent && pnpm exec tsdown --env.DSH_BUILD_FACE host" >&2
+    return 1
+  fi
+  echo "== 重建受影响包（tsc -b 增量 + tsdown host 打包）"
+  if ! ( cd "$TARGET" && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent ); then
+    echo "ERROR: tsc 增量构建失败（见上方输出）。" >&2
+    return 1
+  fi
+  if ! ( cd "$TARGET" && pnpm exec tsdown --env.DSH_BUILD_FACE host ); then
+    echo "ERROR: tsdown 打包失败（见上方输出）。" >&2
+    return 1
+  fi
+  echo "== 构建完成"
+}
+
+HAD_CONFLICT=0
+APPLIED_ANY=0
+
+for patch in "${PATCH_FILES[@]}"; do
+  if [[ ! -f "${PATCHES_DIR}/${patch}" ]]; then
+    echo "ERROR: 找不到 patch 文件: ${PATCHES_DIR}/${patch}" >&2
+    exit 1
+  fi
+  status="$(patch_status "$patch")"
+  case "$status" in
+    needs-apply)
+      if [[ "$CHECK_ONLY" -eq 1 ]]; then
+        echo "  [check] ${patch}: 可应用（目标尚未应用）"
+      else
+        echo "== 应用 ${patch}"
+        git -C "$TARGET" apply "${PATCHES_DIR}/${patch}"
+        APPLIED_ANY=1
+      fi
+      ;;
+    applied)
+      echo "  [skip]  ${patch}: 已应用（幂等跳过）"
+      ;;
+    conflict)
+      echo "ERROR: ${patch}: 既不能正向应用也不能反向撤销 —— 目标树与该 patch 冲突（可能已手工改动）。" >&2
+      HAD_CONFLICT=1
+      ;;
+  esac
+done
+
+if [[ "$HAD_CONFLICT" -eq 1 ]]; then
+  echo "ERROR: 存在冲突 patch，未完成全部应用。" >&2
+  exit 1
+fi
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  echo "== 检查完成（未修改任何文件）"
+  exit 0
+fi
+
+if [[ "$APPLIED_ANY" -eq 1 && "$SKIP_BUILD" -eq 0 ]]; then
+  build_affected || exit 1
+elif [[ "$APPLIED_ANY" -eq 0 ]]; then
+  echo "== 全部 patch 已应用，无需构建"
+fi
+
+echo "== 完成"

--- a/scripts/apply-dsh-patch.sh
+++ b/scripts/apply-dsh-patch.sh
@@ -54,7 +54,12 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --check) CHECK_ONLY=1; shift ;;
     --skip-build) SKIP_BUILD=1; shift ;;
-    -d|--target) TARGET="$2"; shift 2 ;;
+    -d|--target)
+      if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: $1 需要一个目标目录参数" >&2
+        usage 1
+      fi
+      TARGET="$2"; shift 2 ;;
     -h|--help) usage 0 ;;
     *) echo "未知选项: $1" >&2; usage 1 ;;
   esac

--- a/scripts/build-client.ts
+++ b/scripts/build-client.ts
@@ -1,0 +1,66 @@
+/**
+ * Client bundle build: emits the closure-factory CJS artifact the dsh web
+ * loader consumes — `window.__ModuleLoader__.load({ id: 'dsh-llm-fallbacks',
+ * factory: (require) => { … return module.exports; } })`. Externals resolve
+ * through the loader module table (platform seed entries + the documented
+ * `@deepseek-ai/dsh-client-runtime/client` exemption); everything else
+ * inlines.
+ *
+ * Build tool: `bun build` (the mstar client-bundle recipe; no tsdown needed).
+ * `dist/client/index.js` is a build artifact (gitignored like the rest of
+ * `dist/`); the matching `dist/client/index.d.ts` is emitted by `tsc`
+ * (`emitDeclarationOnly`) from `src/client/index.ts`.
+ *
+ * simplify: no CSS-modules transform or `@deepseek-ai/*` purity gate yet —
+ * the Task 1 client entry imports nothing but types, so neither has any input
+ * to act on. Task 5 (Fallbacks settings section) adds the CSS-module inliner
+ * and the purity gate together with the first value imports.
+ */
+
+import { build } from 'bun'
+import { join } from 'node:path'
+
+const ID = 'dsh-llm-fallbacks'
+const ENTRY = 'src/client/index.ts'
+const OUT_DIR = 'dist/client'
+const OUT_FILE = 'index.js'
+
+/** Loader module table (dsh mechanism-guide): platform seed entries plus the documented runtime/client exemption. */
+export const CLIENT_EXTERNALS: readonly string[] = [
+  'react',
+  'react/jsx-runtime',
+  'react-dom',
+  'react-dom/client',
+  'cordis',
+  '@deepseek-ai/dsh-client-ui-slots',
+  '@deepseek-ai/dsh-client-web-react',
+  '@deepseek-ai/dsh-client-ui-primitives',
+  '@deepseek-ai/dsh-client-schema-form',
+  '@deepseek-ai/dsh-client-runtime/client',
+]
+
+const result = await build({
+  entrypoints: [ENTRY],
+  outdir: OUT_DIR,
+  target: 'browser',
+  format: 'cjs',
+  external: [...CLIENT_EXTERNALS],
+  // Closure-factory handoff: `module`/`exports` are declared inside the
+  // factory body because bun's cjs emission assigns module.exports itself;
+  // the factory returns that surface to the loader.
+  banner: `window.__ModuleLoader__.load({ id: ${JSON.stringify(ID)}, factory: (require) => {\nvar module = { exports: {} }; var exports = module.exports;`,
+  footer: 'return module.exports; } });',
+  naming: { entry: OUT_FILE },
+})
+
+if (!result.success) {
+  const detail = result.logs.map((log) => (typeof log === 'string' ? log : log.message)).join('\n')
+  throw new Error(`client bundle build failed:\n${detail}`)
+}
+if (result.outputs.length !== 1 || !result.outputs[0]!.path.endsWith(join(OUT_DIR, OUT_FILE))) {
+  throw new Error(
+    `client bundle build: expected exactly one ${join(OUT_DIR, OUT_FILE)} output, got ${result.outputs.map((o) => o.path).join(', ')}`,
+  )
+}
+
+console.log(`build-client: ${ENTRY} -> ${result.outputs[0]!.path} (closure-factory CJS, ${result.outputs[0]!.kind})`)

--- a/scripts/build-client.ts
+++ b/scripts/build-client.ts
@@ -11,14 +11,21 @@
  * `dist/`); the matching `dist/client/index.d.ts` is emitted by `tsc`
  * (`emitDeclarationOnly`) from `src/client/index.ts`.
  *
- * simplify: no CSS-modules transform or `@deepseek-ai/*` purity gate yet —
- * the Task 1 client entry imports nothing but types, so neither has any input
- * to act on. Task 5 (Fallbacks settings section) adds the CSS-module inliner
- * and the purity gate together with the first value imports.
+ * One build plugin enforces the bundle contract (Task 5 upgrade of the Task 1
+ * `simplify:` marker, mirroring mstar build-client-bundle.ts):
+ * - CSS Modules (`*.module.css`) are compiled to a hashed class map plus an
+ *   inline `<style data-plugin>` injection that runs when the factory
+ *   materializes (the loader removes plugin-owned tags on unload).
+ *
+ * The `@deepseek-ai/*` purity gate stays deferred: the client half's only
+ * runtime `@deepseek-ai/*` import is `@deepseek-ai/dsh-client-runtime/client`
+ * (a documented CLIENT_EXTERNALS platform module) — every other
+ * `@deepseek-ai/*` import is type-only and erased before resolution.
  */
 
 import { build } from 'bun'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
+import { readFileSync } from 'node:fs'
 
 const ID = 'dsh-llm-fallbacks'
 const ENTRY = 'src/client/index.ts'
@@ -39,18 +46,96 @@ export const CLIENT_EXTERNALS: readonly string[] = [
   '@deepseek-ai/dsh-client-runtime/client',
 ]
 
+/**
+ * Deterministic CSS-module class hash: FNV-1a 32-bit over the local name →
+ * `8hex_local` (mirrors the mstar recipe's `[hash]_[local]` pattern; the hash
+ * only needs to be stable within the bundle — the class map and the rewritten
+ * css text come from the same transform).
+ */
+function hashClass(local: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < local.length; i++) {
+    h ^= local.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return `${h.toString(16).padStart(8, '0')}_${local}`
+}
+
+/**
+ * Inline `<style data-plugin>` injection source for a css text blob: the tag
+ * is created once per factory materialization (the loader removes plugin-owned
+ * tags on unload).
+ */
+function styleInjectionContents(cssText: string, tagId: string): string {
+  return [
+    `const css = ${JSON.stringify(cssText)};`,
+    `const tagId = ${JSON.stringify(tagId)};`,
+    `if (typeof document !== 'undefined' && document.querySelector('style[data-plugin-css=' + JSON.stringify(tagId) + ']') === null) {`,
+    `  const tag = document.createElement('style');`,
+    `  tag.dataset.plugin = ${JSON.stringify(ID)};`,
+    `  tag.dataset.pluginCss = tagId;`,
+    `  tag.textContent = css;`,
+    `  document.head.appendChild(tag);`,
+    `}`,
+  ].join('\n')
+}
+
+/**
+ * Compile one `*.module.css` file into a JS module: the css text (comments
+ * stripped, class tokens hashed) plus a `<style data-plugin>` injection that
+ * runs at factory materialization, and the hashed class map as the default
+ * export (mirror of the mstar CSS plugin).
+ *
+ * simplify: the css text is emitted as-is (comment-stripped, not minified);
+ * the snapshot recipe runs lightningcss. If bundle size ever matters, switch
+ * the devDep path (tsdown + the clientBundle recipe) or add a minifier here.
+ */
+function cssModuleContents(fileId: string): { contents: string; loader: 'js' } {
+  const source = readFileSync(fileId, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+  const classMap: Record<string, string> = {}
+  const css = source.replace(/\.[A-Za-z_][A-Za-z0-9_-]*/g, (match) => {
+    const local = match.slice(1)
+    const hashed = hashClass(local)
+    classMap[local] = hashed
+    return `.${hashed}`
+  })
+  const tagId = `${ID}/${basename(fileId)}`
+  const contents = [
+    styleInjectionContents(css, tagId),
+    `export default ${JSON.stringify(classMap)};`,
+  ].join('\n')
+  return { contents, loader: 'js' }
+}
+
 const result = await build({
   entrypoints: [ENTRY],
   outdir: OUT_DIR,
   target: 'browser',
   format: 'cjs',
   external: [...CLIENT_EXTERNALS],
+  // react/zustand-style deps read process.env.NODE_ENV; honor the build env
+  // like the mstar recipe (artifacts default to production). No `import.meta`
+  // define needed: nothing inlined reads it (the store engine is external),
+  // and a literal `import.meta` would be a SyntaxError under the classic
+  // <script> loader anyway.
+  define: {
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'production'),
+  },
+  loader: { '.css': 'text' },
   // Closure-factory handoff: `module`/`exports` are declared inside the
   // factory body because bun's cjs emission assigns module.exports itself;
   // the factory returns that surface to the loader.
   banner: `window.__ModuleLoader__.load({ id: ${JSON.stringify(ID)}, factory: (require) => {\nvar module = { exports: {} }; var exports = module.exports;`,
   footer: 'return module.exports; } });',
   naming: { entry: OUT_FILE },
+  plugins: [
+    {
+      name: 'dsh-css-modules-inline',
+      setup(build) {
+        build.onLoad({ filter: /\.module\.css$/ }, (args) => cssModuleContents(args.path))
+      },
+    },
+  ],
 })
 
 if (!result.success) {
@@ -61,6 +146,24 @@ if (result.outputs.length !== 1 || !result.outputs[0]!.path.endsWith(join(OUT_DI
   throw new Error(
     `client bundle build: expected exactly one ${join(OUT_DIR, OUT_FILE)} output, got ${result.outputs.map((o) => o.path).join(', ')}`,
   )
+}
+
+// Inline bundle-contract assertions: the emitted text must carry the inlined
+// css-module class map (the transform ran), must NOT contain `import.meta` /
+// ESM statements (the classic-script loader would fail to parse them), and
+// the only `@deepseek-ai/*` value import must be the documented external
+// runtime/client exemption.
+const bundleText = readFileSync(result.outputs[0]!.path, 'utf8')
+if (!bundleText.includes('data-plugin-css')) {
+  throw new Error('client bundle contract: no inlined css-module style injection found — check the dsh-css-modules-inline plugin')
+}
+if (bundleText.includes('import.meta') || /(^|\n)\s*(import|export)\s/.test(bundleText)) {
+  throw new Error('client bundle contract: emitted bundle contains import.meta / ESM statements — the classic-script loader would fail to parse it')
+}
+const deepseekRequires = [...bundleText.matchAll(/require\(\s*["'](@deepseek-ai\/[^"']+)["']\s*\)/g)].map(match => match[1])
+const unexpected = deepseekRequires.filter(specifier => !CLIENT_EXTERNALS.includes(specifier))
+if (unexpected.length > 0) {
+  throw new Error(`client bundle contract: non-external @deepseek-ai/* value import(s) survived: ${unexpected.join(', ')}`)
 }
 
 console.log(`build-client: ${ENTRY} -> ${result.outputs[0]!.path} (closure-factory CJS, ${result.outputs[0]!.kind})`)

--- a/scripts/revert-dsh-patch.sh
+++ b/scripts/revert-dsh-patch.sh
@@ -43,7 +43,12 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --check) CHECK_ONLY=1; shift ;;
     --skip-build) SKIP_BUILD=1; shift ;;
-    -d|--target) TARGET="$2"; shift 2 ;;
+    -d|--target)
+      if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: $1 需要一个目标目录参数" >&2
+        usage 1
+      fi
+      TARGET="$2"; shift 2 ;;
     -h|--help) usage 0 ;;
     *) echo "未知选项: $1" >&2; usage 1 ;;
   esac

--- a/scripts/revert-dsh-patch.sh
+++ b/scripts/revert-dsh-patch.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# revert-dsh-patch.sh — 回滚 apply-dsh-patch.sh 应用到目标 dsh 源码树的 role patch。
+#
+# 对每个 patch 执行 git apply --reverse（先 --reverse --check 确认已应用）；
+# 已回滚的 patch 幂等跳过；随后重建受影响包（与 apply 相同的构建步骤）。
+#
+# 目标解析（运行时，脚本本身不含本地绝对路径）：
+#   $DSH_SOURCE_DIR（若设置）→ 缺省 ${DSH_HOME}/source/current
+#
+# 选项：
+#   --check        仅检查每个 patch 是否处于已应用态（可回滚），不修改任何文件。
+#   --skip-build   回滚后跳过构建步骤（exit 0）。
+#   -d|--target DIR  指定目标 dsh 源码树（覆盖 env 解析）。
+#   -h|--help      显示本帮助。
+#
+# 退出码：
+#   0  全部 patch 已回滚（或已回滚跳过）/ --check 全部可回滚
+#   1  任一 patch 无法回滚、目标目录不可用、或构建失败 / 因缺 pnpm 环境而跳过构建
+set -euo pipefail
+
+# 定位本脚本与仓库根（运行时推导，无硬编码绝对路径）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PATCHES_DIR="${REPO_ROOT}/patches"
+
+# 与 apply-dsh-patch.sh 相同的两个 pnpm 格式 patch
+PATCH_FILES=(
+  "@deepseek-ai+dsh-agent@0.0.1.patch"
+  "@deepseek-ai+dsh-tool-subagent@0.0.1.patch"
+)
+
+usage() {
+  sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+CHECK_ONLY=0
+SKIP_BUILD=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) CHECK_ONLY=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    -d|--target) TARGET="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "未知选项: $1" >&2; usage 1 ;;
+  esac
+done
+
+# 解析目标目录
+if [[ -z "$TARGET" ]]; then
+  TARGET="${DSH_SOURCE_DIR:-${DSH_HOME:-}/source/current}"
+fi
+if [[ ! -d "$TARGET/.git" ]]; then
+  echo "ERROR: 目标目录不是 git 仓库: $TARGET" >&2
+  echo "       请设置 DSH_SOURCE_DIR（或 DSH_HOME），或使用 --target。" >&2
+  exit 1
+fi
+echo "== 目标 dsh 源码树: $TARGET"
+
+# 返回单个 patch 的已应用态：applied / reverted / conflict
+patch_status() {
+  local patch="$1"
+  if git -C "$TARGET" apply --reverse --check "${PATCHES_DIR}/${patch}" 2>/dev/null; then
+    echo "applied"
+  elif git -C "$TARGET" apply --check "${PATCHES_DIR}/${patch}" 2>/dev/null; then
+    echo "reverted"
+  else
+    echo "conflict"
+  fi
+}
+
+# 与 apply-dsh-patch.sh 相同的重建步骤（tsc -b 增量 + tsdown host 打包）
+build_affected() {
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "WARN: PATH 中找不到 pnpm；patch 已回滚但构建已跳过。" >&2
+    echo "      请手动重建: cd \"\$DSH_SOURCE_DIR\" && pnpm install && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent && pnpm exec tsdown --env.DSH_BUILD_FACE host" >&2
+    return 1
+  fi
+  if [[ ! -d "$TARGET/node_modules" ]]; then
+    echo "WARN: 目标树缺少 node_modules（非 pnpm 工作区安装）；patch 已回滚但构建已跳过。" >&2
+    echo "      请手动重建: cd \"\$DSH_SOURCE_DIR\" && pnpm install && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent && pnpm exec tsdown --env.DSH_BUILD_FACE host" >&2
+    return 1
+  fi
+  echo "== 重建受影响包（tsc -b 增量 + tsdown host 打包）"
+  if ! ( cd "$TARGET" && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent ); then
+    echo "ERROR: tsc 增量构建失败（见上方输出）。" >&2
+    return 1
+  fi
+  if ! ( cd "$TARGET" && pnpm exec tsdown --env.DSH_BUILD_FACE host ); then
+    echo "ERROR: tsdown 打包失败（见上方输出）。" >&2
+    return 1
+  fi
+  echo "== 构建完成"
+}
+
+HAD_CONFLICT=0
+REVERTED_ANY=0
+
+for patch in "${PATCH_FILES[@]}"; do
+  if [[ ! -f "${PATCHES_DIR}/${patch}" ]]; then
+    echo "ERROR: 找不到 patch 文件: ${PATCHES_DIR}/${patch}" >&2
+    exit 1
+  fi
+  status="$(patch_status "$patch")"
+  case "$status" in
+    applied)
+      if [[ "$CHECK_ONLY" -eq 1 ]]; then
+        echo "  [check] ${patch}: 已应用（可回滚）"
+      else
+        echo "== 回滚 ${patch}"
+        git -C "$TARGET" apply --reverse "${PATCHES_DIR}/${patch}"
+        REVERTED_ANY=1
+      fi
+      ;;
+    reverted)
+      echo "  [skip]  ${patch}: 已回滚（幂等跳过）"
+      ;;
+    conflict)
+      echo "ERROR: ${patch}: 既不能反向撤销也不能正向应用 —— 目标树与该 patch 冲突（可能已手工改动）。" >&2
+      HAD_CONFLICT=1
+      ;;
+  esac
+done
+
+if [[ "$HAD_CONFLICT" -eq 1 ]]; then
+  echo "ERROR: 存在冲突 patch，未完成全部回滚。" >&2
+  exit 1
+fi
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  echo "== 检查完成（未修改任何文件）"
+  exit 0
+fi
+
+if [[ "$REVERTED_ANY" -eq 1 && "$SKIP_BUILD" -eq 0 ]]; then
+  build_affected || exit 1
+elif [[ "$REVERTED_ANY" -eq 0 ]]; then
+  echo "== 全部 patch 已回滚，无需构建"
+fi
+
+echo "== 完成"

--- a/scripts/revert-dsh-patch.sh
+++ b/scripts/revert-dsh-patch.sh
@@ -31,7 +31,7 @@ PATCH_FILES=(
 )
 
 usage() {
-  sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 

--- a/scripts/verify-dsh-patch.sh
+++ b/scripts/verify-dsh-patch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# verify-dsh-patch.sh — 校验目标 dsh 源码树中 role patch 的效果（出现 / 消失）。
+#
+# 检查两组探针（文件存在即检查，缺失记为 SKIP；不会把缺失误判为通过或失败）：
+#   @deepseek-ai/dsh-agent          src/runtime-types.ts          → 期望 `role?: string`
+#                                   lib/types/runtime-types.d.ts  → 期望 `role?: string`
+#                                   （构建产物；注意 AgentOptions 编译到
+#                                     runtime-types.d.ts，而非 index.d.ts）
+#   @deepseek-ai/dsh-tool-subagent  src/index.ts                  → 期望 `role: z.string()`
+#                                   lib/types/index.js            → 期望 `role: z.string()`
+#                                   （构建产物；类型只引用 AgentOptions，
+#                                     role 的文本标记在编译后的 schema JS 中）
+#
+# 默认断言 marker 出现（patch 已应用并已构建）；--absent 反转断言（revert 后）。
+# 判定：任一存在的探针不符合断言 → exit 1；所有探针文件均缺失 → 视为非 dsh 树 → exit 1。
+#
+# 目标解析（运行时，脚本本身不含本地绝对路径）：
+#   $DSH_SOURCE_DIR（若设置）→ 缺省 ${DSH_HOME}/source/current
+#
+# 选项：
+#   --absent        断言 marker 不存在（用于 revert 后验证）。
+#   -d|--target DIR  指定目标 dsh 源码树（覆盖 env 解析）。
+#   -q|--quiet      只输出最终结论。
+#   -h|--help       显示本帮助。
+#
+# 退出码：0 = 校验通过；1 = 校验失败 / 目标不可用。
+set -euo pipefail
+
+usage() {
+  sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+ABSENT=0
+QUIET=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --absent) ABSENT=1; shift ;;
+    -q|--quiet) QUIET=1; shift ;;
+    -d|--target) TARGET="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "未知选项: $1" >&2; usage 1 ;;
+  esac
+done
+
+# 解析目标目录
+if [[ -z "$TARGET" ]]; then
+  TARGET="${DSH_SOURCE_DIR:-${DSH_HOME:-}/source/current}"
+fi
+if [[ ! -d "$TARGET" ]]; then
+  echo "ERROR: 目标目录不存在: $TARGET" >&2
+  echo "       请设置 DSH_SOURCE_DIR（或 DSH_HOME），或使用 --target。" >&2
+  exit 1
+fi
+
+# 探针：(相对路径|固定字符串|说明)
+PROBES=(
+  "packages/core/agent/src/runtime-types.ts|role?: string|agent source (runtime-types.ts)"
+  "packages/core/agent/lib/types/runtime-types.d.ts|role?: string|agent build (lib/types/runtime-types.d.ts)"
+  "packages/subagent/tool-subagent/src/index.ts|role: z.string()|tool-subagent source (index.ts)"
+  "packages/subagent/tool-subagent/lib/types/index.js|role: z.string()|tool-subagent build (lib/types/index.js)"
+)
+
+EXPECT_LABEL="出现"
+[[ "$ABSENT" -eq 1 ]] && EXPECT_LABEL="不出现"
+
+FAIL=0
+CHECKED=0
+
+for probe in "${PROBES[@]}"; do
+  IFS='|' read -r rel marker label <<< "$probe"
+  file="${TARGET}/${rel}"
+  if [[ ! -f "$file" ]]; then
+    [[ "$QUIET" -eq 0 ]] && printf '  [SKIP] %-52s 文件缺失\n' "$label"
+    continue
+  fi
+  CHECKED=1
+  if grep -qF -- "$marker" "$file"; then
+    present=1
+  else
+    present=0
+  fi
+  if [[ "$ABSENT" -eq 1 ]]; then
+    # 期望 marker 不出现：出现即失败
+    if [[ "$present" -eq 1 ]]; then
+      FAIL=1
+      [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] %-52s 意外出现 %s\n' "$label" "'$marker'"
+    else
+      [[ "$QUIET" -eq 0 ]] && printf '  [PASS] %-52s 未出现 %s\n' "$label" "'$marker'"
+    fi
+  else
+    # 期望 marker 出现：缺失即失败
+    if [[ "$present" -eq 1 ]]; then
+      [[ "$QUIET" -eq 0 ]] && printf '  [PASS] %-52s 命中 %s\n' "$label" "'$marker'"
+    else
+      FAIL=1
+      [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] %-52s 未命中 %s\n' "$label" "'$marker'"
+    fi
+  fi
+done
+
+if [[ "$CHECKED" -eq 0 ]]; then
+  echo "ERROR: 目标目录中未找到任何探针文件，不像是 dsh 源码树: $TARGET" >&2
+  exit 1
+fi
+
+if [[ "$FAIL" -eq 1 ]]; then
+  echo "== 校验失败：role 标记（期望${EXPECT_LABEL}）未满足" >&2
+  exit 1
+fi
+
+echo "== 校验通过：role 标记（期望${EXPECT_LABEL}）满足"

--- a/scripts/verify-dsh-patch.sh
+++ b/scripts/verify-dsh-patch.sh
@@ -28,7 +28,7 @@
 set -euo pipefail
 
 usage() {
-  sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,27p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 

--- a/scripts/verify-dsh-patch.sh
+++ b/scripts/verify-dsh-patch.sh
@@ -40,7 +40,12 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --absent) ABSENT=1; shift ;;
     -q|--quiet) QUIET=1; shift ;;
-    -d|--target) TARGET="$2"; shift 2 ;;
+    -d|--target)
+      if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: $1 需要一个目标目录参数" >&2
+        usage 1
+      fi
+      TARGET="$2"; shift 2 ;;
     -h|--help) usage 0 ;;
     *) echo "未知选项: $1" >&2; usage 1 ;;
   esac

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -1,0 +1,119 @@
+/**
+ * Fallback chain resolution (spec §2 clause 2, §4; plan Task 2).
+ *
+ * `resolveChain` returns the ordered candidate list for a failing
+ * (provider, model): specificity order exact `provider/model` key →
+ * `provider/*` key → role key → `default` key, entries keeping their listed
+ * order within a key. Wildcard entries (`provider/*`) are resolved against
+ * the failing model — keep the model id, swap only the provider; the
+ * "target provider has no such model id" skip is judged by
+ * {@link resolveCandidate} (via `modelExists`) or by the caller's filter.
+ *
+ * Cooldown / failed-set / same-as-current filtering is caller-side (Task 3);
+ * {@link createCandidateFilter} provides the ready-made predicate.
+ *
+ * @module dsh-llm-fallbacks/chains
+ */
+
+import type { CooldownStore, StepFailureSet } from './cooldown.ts'
+import { parseSelector, resolveWildcardEntry, selectorKey, type Selector } from './selectors.ts'
+
+/** The model that just failed — the anchor for chain resolution. */
+export interface FailingModel {
+  provider: string
+  model: string
+}
+
+/**
+ * Resolve one chain entry against the failing model.
+ *
+ * - `provider/model` → that exact selector (not subject to `modelExists` —
+ *   the user explicitly listed it).
+ * - `provider/*` → keeps the failing model id, swaps only the provider; when
+ *   `modelExists` is given and the target provider has no such model id →
+ *   `null` (skip).
+ * - Malformed entries → `null`: they "do not take effect"; the strict throw
+ *   path is {@link parseSelector}, used by the Task 3 config-warning path.
+ */
+export function resolveCandidate(
+  entry: string,
+  failing: FailingModel,
+  modelExists?: (provider: string, model: string) => boolean,
+): Selector | null {
+  let selector: Selector
+  try {
+    selector = parseSelector(entry)
+  } catch {
+    return null
+  }
+  if (selector.model === undefined) {
+    const resolved = resolveWildcardEntry(failing.model, selector.provider)
+    if (modelExists && !modelExists(resolved.provider, resolved.model!)) return null
+    return resolved
+  }
+  return selector
+}
+
+/**
+ * Ordered fallback candidates for the failing (provider, model).
+ *
+ * Chain keys are consulted in specificity order (exact → `provider/*` →
+ * `role` → `default`); every present key contributes its entries, so the
+ * result is a priority-ordered union. Wildcard entries are resolved against
+ * the failing model. `filter` optionally drops candidates — the caller owns
+ * cooldown/failed-set/same-model/absent-id filtering (see
+ * {@link createCandidateFilter}).
+ */
+export function resolveChain(
+  chains: Record<string, string[]>,
+  role: string,
+  provider: string,
+  model: string,
+  filter?: (candidate: Selector) => boolean,
+): Selector[] {
+  const failing: FailingModel = { provider, model }
+  const keys = [selectorKey(provider, model), selectorKey(provider), role, 'default']
+  const candidates: Selector[] = []
+  const seenKeys = new Set<string>()
+  for (const key of keys) {
+    if (seenKeys.has(key)) continue
+    seenKeys.add(key)
+    const entries = chains[key]
+    if (!entries) continue
+    for (const entry of entries) {
+      const candidate = resolveCandidate(entry, failing)
+      if (candidate && (!filter || filter(candidate))) candidates.push(candidate)
+    }
+  }
+  return candidates
+}
+
+/** Inputs for {@link createCandidateFilter}. */
+export interface CandidateFilterOptions {
+  /** The currently active (failing) model — skipped as "same as current". */
+  current: FailingModel
+  /** Cooldown store: suppressed candidates are skipped (keyed `provider/model`). */
+  cooldown: Pick<CooldownStore, 'isSuppressed'>
+  /** Failed-set for the current step: already-failed candidates are skipped. */
+  failed: Pick<StepFailureSet, 'has'>
+  /** Optional existence probe: candidates the target provider lacks are skipped. */
+  modelExists?: (provider: string, model: string) => boolean
+}
+
+/**
+ * The caller-side candidate filter (Task 3): a candidate is usable when it
+ * differs from the current model, is not cooldown-suppressed, has not failed
+ * in this step, and (when `modelExists` is given) exists on its provider.
+ */
+export function createCandidateFilter(options: CandidateFilterOptions): (candidate: Selector) => boolean {
+  const { current, cooldown, failed, modelExists } = options
+  return (candidate) => {
+    if (candidate.provider === current.provider && candidate.model === current.model) return false
+    if (cooldown.isSuppressed(selectorKey(candidate.provider, candidate.model))) return false
+    if (failed.has(selectorKey(candidate.provider, candidate.model))) return false
+    if (modelExists && candidate.model !== undefined && !modelExists(candidate.provider, candidate.model)) {
+      return false
+    }
+    return true
+  }
+}

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -121,3 +121,47 @@ export function createCandidateFilter(options: CandidateFilterOptions): (candida
     return true
   }
 }
+
+/** Why one considered candidate was excluded from the selection (spec §2 行为可见性). */
+export type CandidateSkipReason = 'same-as-current' | 'cooldown' | 'step-failed' | 'missing-id'
+
+/** One entry of the ordered, per-candidate annotation (T3 review Minor 1). */
+export interface AnnotatedCandidate {
+  candidate: Selector
+  /** Why this candidate was excluded; `undefined` = it survived every exclusion. */
+  skip?: CandidateSkipReason
+}
+
+/**
+ * Annotate the ordered "considered" candidate list with each candidate's skip
+ * reason (spec §2 行为可见性: the switch log must show the attempt order and
+ * why each candidate was skipped). The selection-relevant view is the
+ * `surviving` list the decision path resolved with filter + existence probe:
+ * a candidate absent from it failed one of the exclusions, and the concrete
+ * reason is derived from the same checks {@link createCandidateFilter}
+ * applies, in the same precedence. `missing-id` therefore only ever labels
+ * entries the existence probe dropped — exact entries are never
+ * existence-probed (T2 contract), so they stay in `surviving` and are
+ * reported as usable, never as missing-id.
+ *
+ * This is the diagnostic counterpart of {@link createCandidateFilter} — pure,
+ * order-preserving, and duplicate-preserving.
+ */
+export function annotateCandidates(
+  candidates: readonly Selector[],
+  surviving: readonly Selector[],
+  options: Pick<CandidateFilterOptions, 'current' | 'cooldown' | 'failed'>,
+): AnnotatedCandidate[] {
+  const { current, cooldown, failed } = options
+  const usable = new Set(surviving.map((candidate) => selectorKey(candidate.provider, candidate.model)))
+  return candidates.map((candidate) => {
+    if (candidate.provider === current.provider && candidate.model === current.model) {
+      return { candidate, skip: 'same-as-current' }
+    }
+    const key = selectorKey(candidate.provider, candidate.model)
+    if (usable.has(key)) return { candidate }
+    if (cooldown.isSuppressed(key)) return { candidate, skip: 'cooldown' }
+    if (failed.has(key)) return { candidate, skip: 'step-failed' }
+    return { candidate, skip: 'missing-id' }
+  })
+}

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -61,8 +61,11 @@ export function resolveCandidate(
  * `role` → `default`); every present key contributes its entries, so the
  * result is a priority-ordered union. Wildcard entries are resolved against
  * the failing model. `filter` optionally drops candidates — the caller owns
- * cooldown/failed-set/same-model/absent-id filtering (see
- * {@link createCandidateFilter}).
+ * cooldown/failed-set/same-model filtering (see {@link createCandidateFilter}).
+ * `modelExists` is forwarded to {@link resolveCandidate}, so the
+ * "target provider has no such model id" skip (spec §2 clause 2) applies to
+ * `provider/*` entries only — explicitly listed exact entries are never
+ * existence-filtered (T2 review Important #1: Task 3 decision path contract).
  */
 export function resolveChain(
   chains: Record<string, string[]>,
@@ -70,6 +73,7 @@ export function resolveChain(
   provider: string,
   model: string,
   filter?: (candidate: Selector) => boolean,
+  modelExists?: (provider: string, model: string) => boolean,
 ): Selector[] {
   const failing: FailingModel = { provider, model }
   const keys = [selectorKey(provider, model), selectorKey(provider), role, 'default']
@@ -81,7 +85,7 @@ export function resolveChain(
     const entries = chains[key]
     if (!entries) continue
     for (const entry of entries) {
-      const candidate = resolveCandidate(entry, failing)
+      const candidate = resolveCandidate(entry, failing, modelExists)
       if (candidate && (!filter || filter(candidate))) candidates.push(candidate)
     }
   }

--- a/src/client/FallbacksSection.module.css
+++ b/src/client/FallbacksSection.module.css
@@ -1,0 +1,263 @@
+/* Fallbacks settings section, in the settings-panel design language: 14/22
+ * body, 12/18 captions, `border-l2` hairlines, and the --dsw-alias-* tokens
+ * the Models section and GeneralSection already use (theme-agnostic — colors
+ * resolve through the alias tokens, never light-mode literals). */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 720px;
+  color: var(--dsw-alias-label-primary);
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 500;
+  color: var(--dsw-alias-label-primary);
+}
+
+.intro {
+  margin: 0;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--dsw-alias-label-tertiary);
+}
+
+.notice {
+  margin: 0;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--dsw-alias-label-tertiary);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  min-width: 0;
+}
+
+.fieldLabel {
+  font-size: 14px;
+  line-height: 22px;
+  font-weight: 500;
+  color: var(--dsw-alias-label-primary);
+  padding: 0;
+}
+
+.subField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.subFieldLabel {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--dsw-alias-label-secondary);
+}
+
+.hint {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--dsw-alias-label-tertiary);
+}
+
+.defaultNote {
+  margin-left: 8px;
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 400;
+  color: var(--dsw-alias-label-tertiary);
+}
+
+.optionRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--dsw-alias-label-primary);
+}
+
+.textInput,
+.numberInput,
+.textarea {
+  box-sizing: border-box;
+  width: 100%;
+  font: inherit;
+  color: var(--dsw-alias-label-primary);
+  background: var(--dsw-alias-bg-layer-1);
+  border: 1px solid var(--dsw-alias-border-l2);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+.numberInput {
+  width: 180px;
+}
+
+.textarea {
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.rowCard,
+.ruleCard {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--dsw-alias-border-l2);
+  border-radius: 8px;
+  background: var(--dsw-alias-bg-base);
+}
+
+.ruleCard {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.ruleCell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 120px;
+  flex: 1;
+}
+
+.ruleCellLabel {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--dsw-alias-label-secondary);
+}
+
+.addButton,
+.primaryButton,
+.secondaryButton {
+  font: inherit;
+  font-size: 14px;
+  line-height: 22px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.addButton {
+  align-self: flex-start;
+  padding: 4px 12px;
+  color: var(--dsw-alias-label-primary);
+  background: var(--dsw-alias-bg-layer-1);
+  border: 1px solid var(--dsw-alias-border-l2);
+}
+
+.linkButton {
+  font: inherit;
+  font-size: 13px;
+  line-height: 20px;
+  padding: 2px 0;
+  color: var(--dsw-alias-brand-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.primaryButton {
+  padding: 8px 20px;
+  color: var(--dsw-alias-label-primary-foreground);
+  background: var(--dsw-alias-brand-primary);
+  border: 1px solid transparent;
+}
+
+.secondaryButton {
+  padding: 8px 20px;
+  color: var(--dsw-alias-label-primary);
+  background: var(--dsw-alias-bg-layer-1);
+  border: 1px solid var(--dsw-alias-border-l2);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.addButton:disabled,
+.textInput:disabled,
+.numberInput:disabled,
+.textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.statusBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--dsw-alias-border-l2);
+  border-radius: 8px;
+  background: var(--dsw-alias-bg-layer-1);
+}
+
+.statusTitle {
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 500;
+  color: var(--dsw-alias-label-secondary);
+}
+
+.statusSummary {
+  margin: 0;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--dsw-alias-label-primary);
+}
+
+.statusPlaceholder {
+  margin: 0;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--dsw-alias-label-tertiary);
+}
+
+.statusHint {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--dsw-alias-label-dimmed);
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 20px;
+  padding: 8px 12px;
+  border: 1px solid var(--dsw-alias-state-warn-primary);
+  border-radius: 8px;
+  color: var(--dsw-alias-state-warn-label);
+  background: var(--dsw-alias-state-warn-tertiary);
+}

--- a/src/client/FallbacksSection.tsx
+++ b/src/client/FallbacksSection.tsx
@@ -1,0 +1,423 @@
+/**
+ * Fallbacks settings section — the web settings GUI page for the `fallbacks`
+ * namespace (spec §4). Registered into the `settings.section` slot (id
+ * `fallbacks`, order 30 — after the Models section at 10); owner props are
+ * empty and all data flows through {@link FallbacksSettingsController}.
+ *
+ * Form surface (spec §4 用户直观性): enumerable values render readable labels
+ * (`RATE_LIMIT` → 限流（429）, `QUOTA` → 配额超限, `AUTH` → 权限/认证失败;
+ * `cooldown-expiry` → 冷却到期后回主模型, `never` → 保持备用模型) and every
+ * field shows its default value. Chains and role rules are row editors; any
+ * trigger codes loaded from the descriptor that are not in the known set are
+ * preserved on save.
+ *
+ * Read-only status block (AC-7 行为可见性): an effective-config summary plus
+ * a placeholder for the recent-switch summary. The client half has no
+ * session-event reading face wired for a root-scoped settings section
+ * (runtime confirmation lands with T8) — nothing here invents an API.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { useSyncExternalStore } from 'react'
+import type { PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+import type { FallbacksConfig, RevertPolicy } from '../config.ts'
+import {
+  FallbacksSettingsController,
+  chainsToRows,
+  rowsToChains,
+  rowsToRules,
+  rulesToRows,
+  type ChainRow,
+  type RoleRuleRow,
+} from './fallbacks-store.ts'
+import {
+  configSummary,
+  KNOWN_TRIGGER_CODES,
+  TRIGGER_CODE_LABELS,
+  withTriggerCode,
+} from './locales.ts'
+import css from './FallbacksSection.module.css'
+
+/** Injected dependencies of {@link FallbacksSection} (slot `inject`). */
+export interface FallbacksSectionInjected {
+  /** The section store (loaded on mount, refreshed on pushed invalidations). */
+  controller: FallbacksSettingsController
+}
+
+/** Props delivered by the slot outlet: runtime share + locale seat + inject face. */
+export type FallbacksSectionProps =
+  PropsRuntime<'settings.section'> & PropsLocale<'fallbacks'> & FallbacksSectionInjected
+
+/** Scalar (non-row) fields of the form draft. */
+interface FallbacksScalars {
+  enabled: boolean
+  triggerCodes: string[]
+  defaultRole: string
+  cooldownMs: number
+  revertPolicy: RevertPolicy
+  maxSwitchesPerStep: number
+  alwaysModeRetryCap: number
+}
+
+/** Split scalars from the row editors (chains / role rules). */
+function scalarsOf(config: FallbacksConfig): FallbacksScalars {
+  return {
+    enabled: config.enabled,
+    triggerCodes: [...config.triggerCodes],
+    defaultRole: config.roles.default,
+    cooldownMs: config.cooldownMs,
+    revertPolicy: config.revertPolicy,
+    maxSwitchesPerStep: config.maxSwitchesPerStep,
+    alwaysModeRetryCap: config.alwaysModeRetryCap,
+  }
+}
+
+/** Assemble the full config the row editors + scalars describe. */
+function assembleConfig(scalars: FallbacksScalars, chainRows: ChainRow[], ruleRows: RoleRuleRow[]): FallbacksConfig {
+  return {
+    enabled: scalars.enabled,
+    triggerCodes: [...scalars.triggerCodes],
+    chains: rowsToChains(chainRows),
+    roles: { default: scalars.defaultRole, rules: rowsToRules(ruleRows) },
+    cooldownMs: scalars.cooldownMs,
+    revertPolicy: scalars.revertPolicy,
+    maxSwitchesPerStep: scalars.maxSwitchesPerStep,
+    alwaysModeRetryCap: scalars.alwaysModeRetryCap,
+  }
+}
+
+/** Parse a number input, clamped to a non-negative integer. */
+function parseCount(raw: string): number {
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isNaN(parsed) ? 0 : Math.max(0, parsed)
+}
+
+/**
+ * Render the Fallbacks settings section content column.
+ * @param props - composed slot props (contract/slots.ts).
+ * @returns the section element tree.
+ */
+export function FallbacksSection({ controller, t }: FallbacksSectionProps): ReactNode {
+  const state = useSyncExternalStore(
+    controller.store.subscribe,
+    controller.store.getSnapshot,
+    controller.store.getSnapshot,
+  )
+
+  // Editors seed from the descriptor once per revision; a save or a reload
+  // bumps the revision and re-seeds with server truth.
+  const [scalars, setScalars] = useState<FallbacksScalars | null>(null)
+  const [chainRows, setChainRows] = useState<ChainRow[]>([])
+  const [ruleRows, setRuleRows] = useState<RoleRuleRow[]>([])
+  const seededRevision = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (state.status !== 'ready') return
+    if (seededRevision.current === state.revision) return
+    seededRevision.current = state.revision
+    setScalars(scalarsOf(state.config))
+    setChainRows(chainsToRows(state.config.chains))
+    setRuleRows(rulesToRows(state.config.roles.rules))
+  }, [state.status, state.revision, state.config])
+
+  // Statuses that keep the form mounted: ready, saving, and error-with-
+  // conflict (the stale draft stays visible next to the conflict banner so a
+  // reload can re-seed instead of silently discarding the user's edits).
+  const formMounted = scalars !== null && (
+    state.status === 'ready'
+    || state.status === 'saving'
+    || (state.status === 'error' && state.conflict !== null)
+  )
+  if (!formMounted) {
+    if (state.status === 'unavailable') {
+      return <div className={css.notice}>{t('unavailable')}</div>
+    }
+    if (state.status === 'error') {
+      return <div className={css.notice} role="alert">{t('error.generic', { message: state.error ?? '' })}</div>
+    }
+    return <div className={css.notice}>{t('loading')}</div>
+  }
+
+  const updateScalars = (mutator: (draft: FallbacksScalars) => void): void => {
+    setScalars(prev => {
+      if (prev === null) return prev
+      const next: FallbacksScalars = { ...prev, triggerCodes: [...prev.triggerCodes] }
+      mutator(next)
+      return next
+    })
+  }
+
+  const updateChainRow = (index: number, patch: Partial<ChainRow>): void => {
+    setChainRows(rows => {
+      const next = rows.map(row => ({ ...row }))
+      next[index] = { ...next[index]!, ...patch }
+      return next
+    })
+  }
+
+  const updateRuleRow = (index: number, patch: Partial<RoleRuleRow>): void => {
+    setRuleRows(rows => {
+      const next = rows.map(row => ({ ...row }))
+      next[index] = { ...next[index]!, ...patch }
+      return next
+    })
+  }
+
+  const dirty = JSON.stringify(assembleConfig(scalars, chainRows, ruleRows)) !== JSON.stringify(state.config)
+  const saving = state.status === 'saving'
+  const writable = state.writable && state.conflict === null
+  const unknownCodes = scalars.triggerCodes.filter(code => !KNOWN_TRIGGER_CODES.includes(code))
+
+  const save = (): void => {
+    void controller.save(assembleConfig(scalars, chainRows, ruleRows))
+  }
+
+  const reset = (): void => {
+    if (window.confirm(t('reset.confirm'))) void controller.resetToDefaults()
+  }
+
+  return (
+    <div className={css.section}>
+      <h3 className={css.title}>{t('nav')}</h3>
+      <p className={css.intro}>{t('nav.description')}</p>
+
+      {state.conflict !== null && (
+        <div className={css.banner} role="alert">
+          {t('save.conflict', { expected: state.conflict.expected, actual: state.conflict.actual })}
+          <button type="button" className={css.linkButton} onClick={() => { void controller.load() }}>
+            {t('reload')}
+          </button>
+        </div>
+      )}
+      {state.error !== null && state.conflict === null && (
+        <div className={css.banner} role="alert">{t('error.generic', { message: state.error })}</div>
+      )}
+
+      {/* AC-7 read-only status: effective config summary; the recent-switch
+       * summary is a placeholder until T8 wires a session-event reading face
+       * for the settings page (see module doc — no fabricated API). */}
+      <div className={css.statusBlock}>
+        <span className={css.statusTitle}>{t('status.title')}</span>
+        <p className={css.statusSummary}>{configSummary(state.config, t)}</p>
+        {/* simplify: recent-switch placeholder. Upgrade path: T8 supplies a
+         * client session-event source (e.g. a session.history-derived face)
+         * and this block renders the latest `fallbacks/switch` events. */}
+        <p className={css.statusPlaceholder}>
+          {t('status.switchesPlaceholder')}
+          <span className={css.statusHint}>{t('status.switchesHint')}</span>
+        </p>
+      </div>
+
+      <label className={css.field}>
+        <span className={css.fieldLabel}>{t('enabled.label')}</span>
+        <input
+          type="checkbox"
+          checked={scalars.enabled}
+          disabled={!writable}
+          onChange={event => { updateScalars(draft => { draft.enabled = event.target.checked }) }}
+        />
+        <span className={css.hint}>{t('enabled.hint')}</span>
+      </label>
+
+      <fieldset className={css.field} disabled={!writable}>
+        <legend className={css.fieldLabel}>{t('triggerCodes.label')}</legend>
+        <span className={css.hint}>{t('triggerCodes.hint')}</span>
+        {KNOWN_TRIGGER_CODES.map(code => (
+          <label key={code} className={css.optionRow}>
+            <input
+              type="checkbox"
+              checked={scalars.triggerCodes.includes(code)}
+              onChange={event => {
+                updateScalars(draft => { draft.triggerCodes = withTriggerCode(draft.triggerCodes, code, event.target.checked) })
+              }}
+            />
+            {t(TRIGGER_CODE_LABELS[code])}
+          </label>
+        ))}
+        {unknownCodes.length > 0 && (
+          <span className={css.hint}>{t('triggerCodes.extra', { codes: unknownCodes.join(', ') })}</span>
+        )}
+      </fieldset>
+
+      <fieldset className={css.field} disabled={!writable}>
+        <legend className={css.fieldLabel}>{t('revertPolicy.label')}</legend>
+        <span className={css.hint}>{t('revertPolicy.hint')}</span>
+        {(['cooldown-expiry', 'never'] as const).map(policy => (
+          <label key={policy} className={css.optionRow}>
+            <input
+              type="radio"
+              name="fallbacks-revert-policy"
+              checked={scalars.revertPolicy === policy}
+              onChange={() => { updateScalars(draft => { draft.revertPolicy = policy }) }}
+            />
+            {t(`revertPolicy.${policy}`)}
+          </label>
+        ))}
+      </fieldset>
+
+      <label className={css.field}>
+        <span className={css.fieldLabel}>
+          {t('cooldownMs.label')}
+          <span className={css.defaultNote}>{t('defaults.prefix')}: {state.config.cooldownMs}</span>
+        </span>
+        <input
+          className={css.numberInput}
+          type="number"
+          min={0}
+          value={String(scalars.cooldownMs)}
+          disabled={!writable}
+          onChange={event => { updateScalars(draft => { draft.cooldownMs = parseCount(event.target.value) }) }}
+        />
+        <span className={css.hint}>{t('cooldownMs.hint')}</span>
+      </label>
+
+      <label className={css.field}>
+        <span className={css.fieldLabel}>
+          {t('maxSwitchesPerStep.label')}
+          <span className={css.defaultNote}>{t('defaults.prefix')}: {state.config.maxSwitchesPerStep}</span>
+        </span>
+        <input
+          className={css.numberInput}
+          type="number"
+          min={0}
+          value={String(scalars.maxSwitchesPerStep)}
+          disabled={!writable}
+          onChange={event => { updateScalars(draft => { draft.maxSwitchesPerStep = parseCount(event.target.value) }) }}
+        />
+        <span className={css.hint}>{t('maxSwitchesPerStep.hint')}</span>
+      </label>
+
+      <label className={css.field}>
+        <span className={css.fieldLabel}>
+          {t('alwaysModeRetryCap.label')}
+          <span className={css.defaultNote}>{t('defaults.prefix')}: {state.config.alwaysModeRetryCap}</span>
+        </span>
+        <input
+          className={css.numberInput}
+          type="number"
+          min={0}
+          value={String(scalars.alwaysModeRetryCap)}
+          disabled={!writable}
+          onChange={event => { updateScalars(draft => { draft.alwaysModeRetryCap = parseCount(event.target.value) }) }}
+        />
+        <span className={css.hint}>{t('alwaysModeRetryCap.hint')}</span>
+      </label>
+
+      <fieldset className={css.field} disabled={!writable}>
+        <legend className={css.fieldLabel}>{t('chains.label')}</legend>
+        <span className={css.hint}>{t('chains.hint')}</span>
+        <div className={css.list}>
+          {chainRows.map((row, index) => (
+            <div key={index} className={css.rowCard}>
+              <input
+                className={css.textInput}
+                value={row.key}
+                placeholder={t('chains.keyPlaceholder')}
+                aria-label={t('chains.key')}
+                onChange={event => { updateChainRow(index, { key: event.target.value }) }}
+              />
+              <textarea
+                className={css.textarea}
+                rows={2}
+                value={row.entries}
+                placeholder={t('chains.entriesPlaceholder')}
+                aria-label={t('chains.entries')}
+                onChange={event => { updateChainRow(index, { entries: event.target.value }) }}
+              />
+              <button type="button" className={css.linkButton} onClick={() => {
+                setChainRows(rows => rows.filter((_, rowIndex) => rowIndex !== index))
+              }}>
+                {t('chains.remove')}
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className={css.addButton} onClick={() => {
+          setChainRows(rows => [...rows, { key: '', entries: '' }])
+        }}>
+          {t('chains.add')}
+        </button>
+      </fieldset>
+
+      <fieldset className={css.field} disabled={!writable}>
+        <legend className={css.fieldLabel}>{t('roles.label')}</legend>
+        <span className={css.hint}>{t('roles.hint')}</span>
+        <label className={css.subField}>
+          <span className={css.subFieldLabel}>{t('roles.default')}</span>
+          <input
+            className={css.textInput}
+            value={scalars.defaultRole}
+            onChange={event => { updateScalars(draft => { draft.defaultRole = event.target.value }) }}
+          />
+        </label>
+        <div className={css.list}>
+          {ruleRows.map((row, index) => (
+            <div key={index} className={css.ruleCard}>
+              <label className={css.ruleCell}>
+                <span className={css.ruleCellLabel}>{t('roles.rule.origin')}</span>
+                <select
+                  className={css.textInput}
+                  value={row.origin}
+                  onChange={event => { updateRuleRow(index, { origin: event.target.value }) }}
+                >
+                  <option value="">{t('roles.rule.origin.any')}</option>
+                  <option value="root">{t('roles.rule.origin.root')}</option>
+                  <option value="subagent">{t('roles.rule.origin.subagent')}</option>
+                </select>
+              </label>
+              <label className={css.ruleCell}>
+                <span className={css.ruleCellLabel}>{t('roles.rule.provider')}</span>
+                <input
+                  className={css.textInput}
+                  value={row.provider}
+                  onChange={event => { updateRuleRow(index, { provider: event.target.value }) }}
+                />
+              </label>
+              <label className={css.ruleCell}>
+                <span className={css.ruleCellLabel}>{t('roles.rule.model')}</span>
+                <input
+                  className={css.textInput}
+                  value={row.model}
+                  onChange={event => { updateRuleRow(index, { model: event.target.value }) }}
+                />
+              </label>
+              <label className={css.ruleCell}>
+                <span className={css.ruleCellLabel}>{t('roles.rule.role')}</span>
+                <input
+                  className={css.textInput}
+                  value={row.role}
+                  onChange={event => { updateRuleRow(index, { role: event.target.value }) }}
+                />
+              </label>
+              <button type="button" className={css.linkButton} onClick={() => {
+                setRuleRows(rows => rows.filter((_, rowIndex) => rowIndex !== index))
+              }}>
+                {t('roles.removeRule')}
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className={css.addButton} onClick={() => {
+          setRuleRows(rows => [...rows, { origin: '', provider: '', model: '', role: '' }])
+        }}>
+          {t('roles.addRule')}
+        </button>
+      </fieldset>
+
+      <div className={css.actions}>
+        <button
+          type="button"
+          className={css.primaryButton}
+          disabled={!writable || saving || !dirty}
+          onClick={save}
+        >
+          {saving ? t('save.saving') : t('save')}
+        </button>
+        <button type="button" className={css.secondaryButton} disabled={!writable || saving} onClick={reset}>
+          {t('reset')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/client/css-modules.d.ts
+++ b/src/client/css-modules.d.ts
@@ -1,0 +1,11 @@
+/**
+ * CSS-modules typing for the client half (mirror of the dsh
+ * `css-modules.d.ts` convention): the build-client CSS-modules transform
+ * compiles `*.module.css` into a hashed class map default export.
+ */
+declare module '*.module.css' {
+  const classes: Record<string, string>
+  export default classes
+}
+
+declare module '*.css'

--- a/src/client/fallbacks-store.ts
+++ b/src/client/fallbacks-store.ts
@@ -1,0 +1,361 @@
+/**
+ * Fallbacks settings controller — the client half's own store (slot owner
+ * props are empty; data rides this store, per the `settings.section`
+ * contract).
+ *
+ * Read path: `settings.describe({})` → the `fallbacks` namespace descriptor.
+ * The descriptor is the **redactSecrets** face: `value` is the redacted
+ * resolved layer (schema defaults → composition base → user section) and
+ * secret slots only report presence. `fallbacks` declares no secret-role
+ * fields today, but the store reads through the same seam.
+ *
+ * Write path: `settings.update({ ns, patch, expectedRevision })` merges the
+ * draft into the user layer; `settings.replace({ ns, section: {},
+ * expectedRevision })` resets to composition defaults. A write whose
+ * `expectedRevision` is stale is refused by the host with the wire error
+ * code `settings-conflict` (details carry expected/actual); the store
+ * surfaces it as `state.conflict` so the form can prompt a reload instead of
+ * silently overwriting a concurrent change (the `SettingsConflictError`
+ * presentation contract).
+ */
+
+import type {
+  IApiClient, SettingsNamespaceView,
+} from '@deepseek-ai/dsh-client-connection/client'
+import {
+  createSnapshotStore, type SnapshotStore,
+} from '@deepseek-ai/dsh-client-runtime/client'
+import {
+  defaultFallbacksConfig, type FallbacksConfig, type FallbacksRoleRule,
+} from '../config.ts'
+
+/** The plugin's settings namespace on the host wire. */
+export const FALLBACKS_SETTINGS_NS = 'fallbacks'
+
+/** Stable wire code of a refused stale-revision write (rpc.d.ts mirror). */
+export const SETTINGS_CONFLICT_CODE = 'settings-conflict'
+
+/** Fallbacks settings-row snapshot. */
+export interface FallbacksSettingsState {
+  status: 'idle' | 'loading' | 'ready' | 'saving' | 'unavailable' | 'error'
+  error: string | null
+  /** Whether the provider allows writes at all. */
+  writable: boolean
+  /** The resolved configuration from the descriptor. */
+  config: FallbacksConfig
+  /** The descriptor revision the loaded config was read at. */
+  revision: number
+  /** A refused write's expected/actual revisions; null when none pending. */
+  conflict: { expected: number; actual: number } | null
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Fold the redacted descriptor value into a complete {@link FallbacksConfig}:
+ * missing optional fields take spec §4 defaults; gross type mismatches throw
+ * so the UI can surface a broken descriptor instead of mis-rendering.
+ */
+export function parseFallbacksConfig(value: unknown): FallbacksConfig {
+  if (!isRecord(value)) {
+    throw new TypeError(`fallbacks descriptor value is not an object: ${String(value)}`)
+  }
+  const triggerCodes = value.triggerCodes
+  if (triggerCodes !== undefined && (!Array.isArray(triggerCodes) || triggerCodes.some(code => typeof code !== 'string'))) {
+    throw new TypeError('fallbacks descriptor triggerCodes must be a string array')
+  }
+  const chains = value.chains
+  if (chains !== undefined && (!isRecord(chains) || Object.values(chains).some(entries => !Array.isArray(entries) || entries.some(e => typeof e !== 'string')))) {
+    throw new TypeError('fallbacks descriptor chains must be a string-array record')
+  }
+  const roles = isRecord(value.roles) ? value.roles : {}
+  const rules = Array.isArray(roles.rules) ? roles.rules : []
+  const parsedRules: FallbacksRoleRule[] = rules.map((rule, index) => {
+    if (!isRecord(rule) || typeof rule.role !== 'string') {
+      throw new TypeError(`fallbacks descriptor roles.rules[${String(index)}] must have a string role`)
+    }
+    const origin = rule.origin
+    if (origin !== undefined && origin !== 'root' && origin !== 'subagent') {
+      throw new TypeError(`fallbacks descriptor roles.rules[${String(index)}].origin must be root|subagent`)
+    }
+    const provider = rule.provider
+    const model = rule.model
+    if (provider !== undefined && typeof provider !== 'string') {
+      throw new TypeError(`fallbacks descriptor roles.rules[${String(index)}].provider must be a string`)
+    }
+    if (model !== undefined && typeof model !== 'string') {
+      throw new TypeError(`fallbacks descriptor roles.rules[${String(index)}].model must be a string`)
+    }
+    return {
+      ...(origin === undefined ? {} : { origin }),
+      ...(provider === undefined ? {} : { provider }),
+      ...(model === undefined ? {} : { model }),
+      role: rule.role,
+    }
+  })
+  const cooldownMs = value.cooldownMs
+  const maxSwitchesPerStep = value.maxSwitchesPerStep
+  const alwaysModeRetryCap = value.alwaysModeRetryCap
+  for (const [field, raw] of [['cooldownMs', cooldownMs], ['maxSwitchesPerStep', maxSwitchesPerStep], ['alwaysModeRetryCap', alwaysModeRetryCap]] as const) {
+    if (raw !== undefined && typeof raw !== 'number') {
+      throw new TypeError(`fallbacks descriptor ${field} must be a number`)
+    }
+  }
+  const revertPolicy = value.revertPolicy
+  if (revertPolicy !== undefined && revertPolicy !== 'cooldown-expiry' && revertPolicy !== 'never') {
+    throw new TypeError('fallbacks descriptor revertPolicy must be cooldown-expiry|never')
+  }
+  const enabled = value.enabled
+  if (enabled !== undefined && typeof enabled !== 'boolean') {
+    throw new TypeError('fallbacks descriptor enabled must be a boolean')
+  }
+  return {
+    enabled: enabled ?? defaultFallbacksConfig.enabled,
+    triggerCodes: (triggerCodes as string[] | undefined) ?? [...defaultFallbacksConfig.triggerCodes],
+    chains: (chains as Record<string, string[]> | undefined) ?? {},
+    roles: {
+      default: typeof roles.default === 'string' ? roles.default : defaultFallbacksConfig.roles.default,
+      rules: parsedRules,
+    },
+    // The field-level guards above narrowed the raw values only inside the
+    // loop; the fallback merge re-narrows each field for the return type.
+    cooldownMs: (cooldownMs as number | undefined) ?? defaultFallbacksConfig.cooldownMs,
+    revertPolicy: (revertPolicy as FallbacksConfig['revertPolicy'] | undefined) ?? defaultFallbacksConfig.revertPolicy,
+    maxSwitchesPerStep: (maxSwitchesPerStep as number | undefined) ?? defaultFallbacksConfig.maxSwitchesPerStep,
+    alwaysModeRetryCap: (alwaysModeRetryCap as number | undefined) ?? defaultFallbacksConfig.alwaysModeRetryCap,
+  }
+}
+
+/** Whether a wire error is the stale-revision refusal (`settings-conflict`). */
+export function isSettingsConflict(error: { code?: string } | null | undefined): boolean {
+  return error?.code === SETTINGS_CONFLICT_CODE
+}
+
+/** Extract the conflict revisions from a `settings-conflict` wire error. */
+export function conflictDetailsOf(error: { code?: string; details?: unknown } | null | undefined):
+  { expected: number; actual: number } | null {
+  if (!isSettingsConflict(error)) return null
+  const details = error?.details
+  if (!isRecord(details) || typeof details.expected !== 'number' || typeof details.actual !== 'number') return null
+  return { expected: details.expected, actual: details.actual }
+}
+
+/** Split a chains textarea into trimmed, non-empty selector lines. */
+export function parseEntryLines(text: string): string[] {
+  return text.split(/\r?\n/).map(line => line.trim()).filter(line => line.length > 0)
+}
+
+/** Join ordered selectors into one textarea body. */
+export function formatEntries(entries: readonly string[]): string {
+  return entries.join('\n')
+}
+
+/** One chain row in the editor: key + the entries textarea body. */
+export interface ChainRow {
+  key: string
+  entries: string
+}
+
+/** Project the chains record into editable rows (one textarea body per key). */
+export function chainsToRows(chains: Record<string, string[]>): ChainRow[] {
+  return Object.entries(chains).map(([key, entries]) => ({ key, entries: formatEntries(entries) }))
+}
+
+/** Rebuild the chains record from edited rows; empty keys drop out. */
+export function rowsToChains(rows: readonly ChainRow[]): Record<string, string[]> {
+  const chains: Record<string, string[]> = {}
+  for (const row of rows) {
+    const key = row.key.trim()
+    if (key === '') continue
+    chains[key] = parseEntryLines(row.entries)
+  }
+  return chains
+}
+
+/** One role-rule row in the editor; empty origin means "any". */
+export interface RoleRuleRow {
+  origin: string
+  provider: string
+  model: string
+  role: string
+}
+
+/** Project the role rules into editable rows. */
+export function rulesToRows(rules: readonly FallbacksRoleRule[]): RoleRuleRow[] {
+  return rules.map(rule => ({
+    origin: rule.origin ?? '',
+    provider: rule.provider ?? '',
+    model: rule.model ?? '',
+    role: rule.role,
+  }))
+}
+
+/** Rebuild the role rules from edited rows; empty origin/provider/model drop out. */
+export function rowsToRules(rows: readonly RoleRuleRow[]): FallbacksRoleRule[] {
+  return rows
+    .map(row => ({
+      ...(row.origin === '' ? {} : { origin: row.origin as 'root' | 'subagent' }),
+      ...(row.provider.trim() === '' ? {} : { provider: row.provider.trim() }),
+      ...(row.model.trim() === '' ? {} : { model: row.model.trim() }),
+      role: row.role.trim(),
+    }))
+    .filter(rule => rule.role !== '')
+}
+
+/** Controller joining Settings reads, writes, and pushed invalidations. */
+export class FallbacksSettingsController {
+  /** Snapshot consumed by the section through `useSyncExternalStore`. */
+  readonly store: SnapshotStore<FallbacksSettingsState> = createSnapshotStore({
+    status: 'idle',
+    error: null,
+    writable: false,
+    config: defaultFallbacksConfig,
+    revision: 0,
+    conflict: null,
+  })
+
+  private generation = 0
+  private view: SettingsNamespaceView | undefined
+
+  /** @param api - Settings wire face. */
+  constructor(private readonly api: Pick<IApiClient, 'settings'>) {}
+
+  /**
+   * Refresh the `fallbacks` descriptor. Latest request wins.
+   * @returns nothing; {@link store} carries success or failure.
+   */
+  async load(): Promise<void> {
+    const generation = ++this.generation
+    this.store.update((state) => {
+      state.status = 'loading'
+      state.error = null
+      state.conflict = null
+    })
+    try {
+      const response = await this.api.settings.describe({})
+      if (generation !== this.generation) return
+      if (!response.result.ok) throw response.result.error
+      const view = response.result.value.namespaces.find(entry => entry.ns === FALLBACKS_SETTINGS_NS)
+      if (view === undefined) {
+        this.view = undefined
+        this.store.update((state) => {
+          state.status = 'unavailable'
+          state.writable = false
+          state.config = defaultFallbacksConfig
+          state.revision = 0
+          state.error = null
+        })
+        return
+      }
+      this.accept(view, response.result.value.writable)
+    } catch (error) {
+      if (generation !== this.generation) return
+      this.fail(error)
+    }
+  }
+
+  /**
+   * Persist the full edited configuration via `settings.update` (merge
+   * semantics), carrying the descriptor revision so a stale editor is
+   * refused rather than silently overwriting a concurrent change.
+   * @param next - the complete edited configuration.
+   */
+  async save(next: FallbacksConfig): Promise<void> {
+    const view = this.view
+    const state = this.store.getSnapshot()
+    if (view === undefined || !state.writable || state.status === 'saving') return
+    const generation = ++this.generation
+    this.store.update((draft) => {
+      draft.status = 'saving'
+      draft.error = null
+      draft.conflict = null
+    })
+    try {
+      const response = await this.api.settings.update({
+        ns: FALLBACKS_SETTINGS_NS,
+        patch: next as unknown as object,
+        expectedRevision: view.revision,
+      })
+      if (generation !== this.generation) return
+      if (!response.result.ok) throw response.result.error
+      this.accept(response.result.value, true)
+    } catch (error) {
+      if (generation !== this.generation) return
+      this.fail(error)
+    }
+  }
+
+  /**
+   * Reset the namespace's user section wholesale via `settings.replace`
+   * (`section: {}` resets to composition defaults — the removal path a merge
+   * cannot express).
+   */
+  async resetToDefaults(): Promise<void> {
+    const view = this.view
+    const state = this.store.getSnapshot()
+    if (view === undefined || !state.writable || state.status === 'saving') return
+    const generation = ++this.generation
+    this.store.update((draft) => {
+      draft.status = 'saving'
+      draft.error = null
+      draft.conflict = null
+    })
+    try {
+      const response = await this.api.settings.replace({
+        ns: FALLBACKS_SETTINGS_NS,
+        section: {},
+        expectedRevision: view.revision,
+      })
+      if (generation !== this.generation) return
+      if (!response.result.ok) throw response.result.error
+      this.accept(response.result.value, true)
+    } catch (error) {
+      if (generation !== this.generation) return
+      this.fail(error)
+    }
+  }
+
+  /** Stop in-flight responses from publishing after plugin disposal. */
+  dispose(): void {
+    this.generation += 1
+    this.view = undefined
+  }
+
+  private accept(view: SettingsNamespaceView, writable: boolean): void {
+    const config = parseFallbacksConfig(view.value)
+    this.view = view
+    this.store.update((state) => {
+      state.status = 'ready'
+      state.error = null
+      state.writable = writable
+      state.config = config
+      state.revision = view.revision
+      state.conflict = null
+    })
+  }
+
+  private fail(error: unknown): void {
+    const wire = error as { code?: string; details?: unknown; message?: string } | null
+    this.store.update((state) => {
+      state.status = 'error'
+      state.error = typeof wire?.message === 'string' ? wire.message : messageOf(error)
+      state.conflict = isSettingsConflict(wire) ? conflictDetailsOf(wire) : null
+    })
+  }
+}
+
+/**
+ * Refetch after reconnect / settings change only when the section has already
+ * opened once.
+ * @param controller - the fallbacks settings controller.
+ */
+export function refreshFallbacksIfLoaded(controller: FallbacksSettingsController): void {
+  if (controller.store.getSnapshot().status === 'idle') return
+  void controller.load()
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -57,7 +57,13 @@ export function apply(ctx: ClientContext): void {
       ctx.on('settings/changed', refresh),
       ctx.on('connection/reset', () => { refresh() }),
     ]
-    return () => { for (const dispose of disposers) dispose() }
+    return () => {
+      for (const dispose of disposers) dispose()
+      // F-006 / M-01: stop in-flight describe/update/replace responses from
+      // publishing to the dead store once the plugin unloads (HMR/dispose) —
+      // the generation guard only helps when it is actually bumped here.
+      controller.dispose()
+    }
   }, 'llm-fallbacks: pushed invalidations')
 
   ctx.slots.inject('settings.section', () => ctx.slots.register({

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,17 +1,71 @@
 /**
- * dsh-llm-fallbacks client half (skeleton).
+ * dsh-llm-fallbacks client half (plan Task 5): registers the Fallbacks
+ * settings page into the web settings GUI.
  *
- * Bundled to the closure-factory artifact `dist/client/index.js` consumed by
- * the dsh web loader (`dshClient` metadata declares the injected platform
- * modules). Task 1 ships the empty entry only: the Fallbacks settings
- * section (`settings.section` slot, id `fallbacks`) lands in Task 5.
+ * Wiring (mirrors ui-settings-general / ui-models):
+ * - Registers the `fallbacks` locale dictionaries (zh/en).
+ * - Constructs the section's own store over the settings loopback API
+ *   (`settings.describe` read + `settings.update`/`replace` writes with
+ *   `expectedRevision`; see `fallbacks-store.ts`).
+ * - Registers the `settings.section` entry `id: 'fallbacks'` (order 30, after
+ *   the Models section at 10) with a locale-following nav label thunk; owner
+ *   props are empty and all data flows through the store (slot contract).
+ * - Refreshes the store on pushed invalidations (`settings/changed` for the
+ *   fallbacks namespace, `connection/reset`).
  *
  * @module dsh-llm-fallbacks/client
  */
 
-import type { Context } from 'cordis'
+import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+// Type-only: pulls the `ctx.locale` Context merge (LocaleService face).
+import type {} from '@deepseek-ai/dsh-client-locale/client'
+// Type-only: pulls the shell's `settings.section` SlotMap merge.
+import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
+import type { ConnectionHandle } from '@deepseek-ai/dsh-client-connection/client'
+import { FallbacksSection } from './FallbacksSection.tsx'
+import {
+  FallbacksSettingsController, FALLBACKS_SETTINGS_NS, refreshFallbacksIfLoaded,
+} from './fallbacks-store.ts'
+import { en, NS, zh } from './locales.ts'
 
-export function apply(ctx: Context): void {
-  // Placeholder client entry — the Fallbacks settings section lands in Task 5.
-  ctx.logger('llm-fallbacks/client').info('dsh-llm-fallbacks client skeleton loaded')
+export type { FallbacksSectionInjected, FallbacksSectionProps } from './FallbacksSection.tsx'
+export type { FallbacksSettingsState } from './fallbacks-store.ts'
+export { FallbacksSettingsController, FALLBACKS_SETTINGS_NS } from './fallbacks-store.ts'
+
+/** Required services (cordis fiber inject); registrations wait on the slot declaration. */
+export const inject = ['slots', 'locale', 'connection']
+
+/**
+ * Register the `fallbacks` dictionaries and the settings section once the
+ * `settings.section` declaration is on the ledger.
+ * @param ctx - client root context.
+ */
+export function apply(ctx: ClientContext): void {
+  ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'llm-fallbacks: dictionaries')
+
+  const t = ctx.locale.bind(NS)
+  const connection = ctx.get('connection') as ConnectionHandle
+  const controller = new FallbacksSettingsController(connection.api)
+
+  // Pushed invalidations converge every open surface without polling.
+  ctx.effect(() => {
+    const refresh = (ns?: string): void => {
+      if (ns !== undefined && ns !== FALLBACKS_SETTINGS_NS) return
+      refreshFallbacksIfLoaded(controller)
+    }
+    const disposers = [
+      ctx.on('settings/changed', refresh),
+      ctx.on('connection/reset', () => { refresh() }),
+    ]
+    return () => { for (const dispose of disposers) dispose() }
+  }, 'llm-fallbacks: pushed invalidations')
+
+  ctx.slots.inject('settings.section', () => ctx.slots.register({
+    name: 'settings.section',
+    id: 'fallbacks',
+    order: 30,
+    label: () => t('nav'),
+    locale: NS,
+    inject: () => ({ controller }),
+  }, FallbacksSection))
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,17 @@
+/**
+ * dsh-llm-fallbacks client half (skeleton).
+ *
+ * Bundled to the closure-factory artifact `dist/client/index.js` consumed by
+ * the dsh web loader (`dshClient` metadata declares the injected platform
+ * modules). Task 1 ships the empty entry only: the Fallbacks settings
+ * section (`settings.section` slot, id `fallbacks`) lands in Task 5.
+ *
+ * @module dsh-llm-fallbacks/client
+ */
+
+import type { Context } from 'cordis'
+
+export function apply(ctx: Context): void {
+  // Placeholder client entry — the Fallbacks settings section lands in Task 5.
+  ctx.logger('llm-fallbacks/client').info('dsh-llm-fallbacks client skeleton loaded')
+}

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -1,0 +1,171 @@
+/**
+ * Fallbacks settings section dictionaries (zh source of truth) plus the
+ * `fallbacks` LocaleNamespaceMap merge — the registration's `locale:` seat
+ * (`PropsLocale<'fallbacks'>` puts the typed `t` on the section props).
+ *
+ * Label conventions follow spec §4 用户直观性: enumerable config values
+ * (triggerCodes / revertPolicy) render readable labels, never raw enum
+ * strings.
+ */
+import type { FallbacksConfig } from '../config.ts'
+
+/** Simplified Chinese dictionary (the key-set source of truth). */
+export const zh = {
+  'nav': 'Fallbacks',
+  'nav.description': '模型故障自动降级',
+  'enabled.label': '启用故障降级',
+  'enabled.hint': '关闭后插件完全不介入；开启但未配置任何链时行为与未安装插件一致。',
+  'triggerCodes.label': '触发失败码',
+  'triggerCodes.hint': '命中这些失败码时进入降级链决策；可重试型故障（如 5xx）由 llm-retry 先行退避，预算耗尽后同样进入决策。',
+  'triggerCodes.RATE_LIMIT': '限流（429）',
+  'triggerCodes.QUOTA': '配额超限',
+  'triggerCodes.AUTH': '权限/认证失败',
+  'triggerCodes.extra': '此外还保留了 {codes} 等自定义失败码。',
+  'revertPolicy.label': '冷却结束后',
+  'revertPolicy.cooldown-expiry': '冷却到期后回主模型',
+  'revertPolicy.never': '保持备用模型（会话内不回）',
+  'revertPolicy.hint': '被切换离的模型在冷却期内不再入选；到期后按此策略决定是否回主。',
+  'cooldownMs.label': '冷却时长（毫秒）',
+  'cooldownMs.hint': '被切离/失败的模型在冷却期内不再入选。',
+  'maxSwitchesPerStep.label': '单步最大切换次数',
+  'maxSwitchesPerStep.hint': '超过后停止切换，以原始错误语义结束当前步，防止链循环放大延迟。',
+  'alwaysModeRetryCap.label': 'always 模式重试上限',
+  'alwaysModeRetryCap.hint': 'retryPolicy 为 always 的模型在同一请求内重试达到该次数后切换；0 表示禁用。',
+  'chains.label': '降级链',
+  'chains.hint': '键为 角色名 / provider/model / provider/*；条目为有序的 provider/model 或 provider/* 选择器。',
+  'chains.key': '键',
+  'chains.entries': '有序选择器（每行一个）',
+  'chains.add': '添加链',
+  'chains.remove': '删除该链',
+  'chains.keyPlaceholder': '例如 default 或 openai/gpt-4o',
+  'chains.entriesPlaceholder': '例如\nanthropic/claude-3-5-sonnet\nopenai/*',
+  'roles.label': '角色',
+  'roles.hint': '解析顺序：agent.options.role → rules 顺序匹配 → default。',
+  'roles.default': '默认角色',
+  'roles.rules': '角色规则',
+  'roles.rule.origin': '来源',
+  'roles.rule.origin.any': '任意',
+  'roles.rule.origin.root': 'root',
+  'roles.rule.origin.subagent': 'subagent',
+  'roles.rule.provider': 'provider',
+  'roles.rule.model': 'model',
+  'roles.rule.role': '角色',
+  'roles.addRule': '添加规则',
+  'roles.removeRule': '删除该规则',
+  'status.title': '运行状态（只读）',
+  'status.configSummary': '当前配置：已启用 {enabled}；默认角色 {role}；{chains} 条链；触发失败码 {codes}。',
+  'status.switchesPlaceholder': '最近切换摘要将在此显示。',
+  'status.switchesHint': '切换历史来自会话事件流；设置页的只读事件读取面将在运行期验证（T8）后接入，当前为占位。',
+  'defaults.prefix': '默认值',
+  'save': '保存',
+  'save.saving': '保存中…',
+  'save.error': '保存失败：{message}',
+  'save.conflict': '配置已被其它地方修改（期望修订 {expected}，当前 {actual}）。请重新加载后再保存。',
+  'reload': '重新加载',
+  'reset': '恢复默认',
+  'reset.confirm': '确定要把 fallbacks 配置恢复为默认值吗？',
+  'loading': '加载中…',
+  'unavailable': '无法读取 fallbacks 设置（未注册或只读环境）。',
+  'error.generic': '出错：{message}',
+} satisfies Record<string, string>
+
+/** The fallbacks dictionary key union. */
+export type FallbacksKey = keyof typeof zh
+
+/** English dictionary, checked complete against the zh key set. */
+export const en = {
+  'nav': 'Fallbacks',
+  'nav.description': 'Automatic fallback on model failures',
+  'enabled.label': 'Enable failure fallback',
+  'enabled.hint': 'When off the plugin never intervenes; when on with no chains configured behavior is identical to an uninstalled plugin.',
+  'triggerCodes.label': 'Trigger failure codes',
+  'triggerCodes.hint': 'Failures with these codes enter chain decision; retryable failures (e.g. 5xx) back off via llm-retry first and reach the decision only when its budget is exhausted.',
+  'triggerCodes.RATE_LIMIT': 'Rate limit (429)',
+  'triggerCodes.QUOTA': 'Quota exceeded',
+  'triggerCodes.AUTH': 'Auth / permission failure',
+  'triggerCodes.extra': 'Custom codes are preserved: {codes}.',
+  'revertPolicy.label': 'After cooldown',
+  'revertPolicy.cooldown-expiry': 'Return to the primary model',
+  'revertPolicy.never': 'Keep the fallback model (until session end)',
+  'revertPolicy.hint': 'A model switched away from stays out of candidacy during its cooldown; this policy decides whether it returns afterwards.',
+  'cooldownMs.label': 'Cooldown (milliseconds)',
+  'cooldownMs.hint': 'Switched-away or failed models stay out of candidacy during the cooldown window.',
+  'maxSwitchesPerStep.label': 'Max switches per step',
+  'maxSwitchesPerStep.hint': 'Beyond this the step stops switching and ends with the original error semantics, preventing chain loops from amplifying latency.',
+  'alwaysModeRetryCap.label': 'Always-mode retry cap',
+  'alwaysModeRetryCap.hint': 'Models whose retryPolicy is always switch after this many retries within one request; 0 disables.',
+  'chains.label': 'Fallback chains',
+  'chains.hint': 'Keys are role names / provider/model / provider/*; entries are ordered provider/model or provider/* selectors.',
+  'chains.key': 'Key',
+  'chains.entries': 'Ordered selectors (one per line)',
+  'chains.add': 'Add chain',
+  'chains.remove': 'Remove this chain',
+  'chains.keyPlaceholder': 'e.g. default or openai/gpt-4o',
+  'chains.entriesPlaceholder': 'e.g.\nanthropic/claude-3-5-sonnet\nopenai/*',
+  'roles.label': 'Roles',
+  'roles.hint': 'Resolution order: agent.options.role → rules in order → default.',
+  'roles.default': 'Default role',
+  'roles.rules': 'Role rules',
+  'roles.rule.origin': 'Origin',
+  'roles.rule.origin.any': 'Any',
+  'roles.rule.origin.root': 'root',
+  'roles.rule.origin.subagent': 'subagent',
+  'roles.rule.provider': 'provider',
+  'roles.rule.model': 'model',
+  'roles.rule.role': 'role',
+  'roles.addRule': 'Add rule',
+  'roles.removeRule': 'Remove this rule',
+  'status.title': 'Runtime status (read-only)',
+  'status.configSummary': 'Effective config: enabled {enabled}; default role {role}; {chains} chains; trigger codes {codes}.',
+  'status.switchesPlaceholder': 'Recent switch summary will appear here.',
+  'status.switchesHint': 'Switch history comes from the session event stream; the read-only event face for the settings page lands after runtime verification (T8) — placeholder for now.',
+  'defaults.prefix': 'Default',
+  'save': 'Save',
+  'save.saving': 'Saving…',
+  'save.error': 'Save failed: {message}',
+  'save.conflict': 'The configuration changed elsewhere (expected revision {expected}, now {actual}). Reload and try again.',
+  'reload': 'Reload',
+  'reset': 'Reset to defaults',
+  'reset.confirm': 'Reset the fallbacks configuration to defaults?',
+  'loading': 'Loading…',
+  'unavailable': 'Cannot read fallbacks settings (namespace not registered or read-only environment).',
+  'error.generic': 'Error: {message}',
+} satisfies Record<FallbacksKey, string>
+
+/** The settings section's dictionary namespace. */
+export const NS = 'fallbacks'
+
+declare module '@deepseek-ai/dsh-client-ui-slots' {
+  interface LocaleNamespaceMap {
+    /** This feature's settings-section copy. */
+    fallbacks: FallbacksKey
+  }
+}
+
+/** Human-readable trigger-code labels (spec §4 用户直观性). */
+export const TRIGGER_CODE_LABELS: Readonly<Record<string, FallbacksKey>> = {
+  RATE_LIMIT: 'triggerCodes.RATE_LIMIT',
+  QUOTA: 'triggerCodes.QUOTA',
+  AUTH: 'triggerCodes.AUTH',
+}
+
+/** The known trigger codes the form toggles; unknown codes are preserved. */
+export const KNOWN_TRIGGER_CODES: readonly string[] = ['AUTH', 'QUOTA', 'RATE_LIMIT']
+
+/** Toggle one known code's membership in `codes` (used by the form; pure). */
+export function withTriggerCode(codes: readonly string[], code: string, present: boolean): string[] {
+  const next = new Set(codes)
+  if (present) next.add(code)
+  else next.delete(code)
+  return [...next]
+}
+
+/** Render a config summary line (AC-7 read-only block). */
+export function configSummary(config: FallbacksConfig, t: (key: FallbacksKey, params?: Record<string, unknown>) => string): string {
+  return t('status.configSummary', {
+    enabled: config.enabled ? 'on' : 'off',
+    role: config.roles.default,
+    chains: String(Object.keys(config.chains).length),
+    codes: config.triggerCodes.join(', '),
+  })
+}

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -8,6 +8,7 @@
  * strings.
  */
 import type { FallbacksConfig } from '../config.ts'
+import { defaultFallbacksConfig } from '../config.ts'
 
 /** Simplified Chinese dictionary (the key-set source of truth). */
 export const zh = {
@@ -149,8 +150,13 @@ export const TRIGGER_CODE_LABELS: Readonly<Record<string, FallbacksKey>> = {
   AUTH: 'triggerCodes.AUTH',
 }
 
-/** The known trigger codes the form toggles; unknown codes are preserved. */
-export const KNOWN_TRIGGER_CODES: readonly string[] = ['AUTH', 'QUOTA', 'RATE_LIMIT']
+/**
+ * The known trigger codes the form toggles; unknown codes are preserved.
+ * M-04: derived from the host defaults so the toggle set can never drift from
+ * the decision set (`defaultFallbacksConfig.triggerCodes` is the single
+ * source of truth; the labels mapping above stays keyed by code).
+ */
+export const KNOWN_TRIGGER_CODES: readonly string[] = [...defaultFallbacksConfig.triggerCodes]
 
 /** Toggle one known code's membership in `codes` (used by the form; pure). */
 export function withTriggerCode(codes: readonly string[], code: string, present: boolean): string[] {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,90 @@
+/**
+ * The `fallbacks` settings namespace: plugin config schema + defaults.
+ *
+ * Spec §4 is authoritative for field names and default values — notably
+ * `triggerCodes` defaults to dsh's stable failure codes `['AUTH', 'QUOTA',
+ * 'RATE_LIMIT']` (there is no `QUOTA_EXCEEDED` code in dsh), and `chains`
+ * defaults to `{}` so an unconfigured install is a no-op (AC-8).
+ *
+ * This module is pure logic: it must not import any `@deepseek-ai/*` package
+ * (types included) — `FallbacksConfig` is the plugin's own type. Task 3
+ * registers this schema with `installSettingsSection` under the `fallbacks`
+ * settings namespace.
+ *
+ * @module dsh-llm-fallbacks/config
+ */
+
+import z from 'schemastery'
+
+/** How a cooled-down model comes back (spec §4). */
+export type RevertPolicy = 'cooldown-expiry' | 'never'
+
+/** A single role rule: match on origin/provider/model patterns (spec §3). */
+export interface FallbacksRoleRule {
+  origin?: 'root' | 'subagent'
+  provider?: string
+  model?: string
+  role: string
+}
+
+/** Role grouping for fallback chains (spec §3). */
+export interface FallbacksRoles {
+  default: string
+  rules: FallbacksRoleRule[]
+}
+
+/**
+ * The full `fallbacks` settings shape (spec §4, verbatim field names).
+ */
+export interface FallbacksConfig {
+  enabled: boolean
+  triggerCodes: string[]
+  chains: Record<string, string[]>
+  roles: FallbacksRoles
+  cooldownMs: number
+  revertPolicy: RevertPolicy
+  maxSwitchesPerStep: number
+  alwaysModeRetryCap: number
+}
+
+/** Spec §4 defaults — `Config({})` must equal this (no-op install). */
+export const defaultFallbacksConfig: FallbacksConfig = {
+  enabled: true,
+  triggerCodes: ['AUTH', 'QUOTA', 'RATE_LIMIT'],
+  chains: {},
+  roles: { default: 'default', rules: [] },
+  cooldownMs: 300_000,
+  revertPolicy: 'cooldown-expiry',
+  maxSwitchesPerStep: 8,
+  alwaysModeRetryCap: 5,
+}
+
+/**
+ * Plugin Config schema (schemastery), mirroring {@link FallbacksConfig}.
+ * Object fields are optional by default in schemastery; `.default()` fills
+ * the spec defaults, `.required()` keeps `rules[].role` mandatory.
+ */
+export const Config = z.object({
+  enabled: z.boolean().default(true),
+  triggerCodes: z.array(z.string()).default(['AUTH', 'QUOTA', 'RATE_LIMIT']),
+  chains: z.dict(z.array(z.string())).default({}),
+  roles: z
+    .object({
+      default: z.string().default('default'),
+      rules: z
+        .array(
+          z.object({
+            origin: z.union([z.const('root'), z.const('subagent')]),
+            provider: z.string(),
+            model: z.string(),
+            role: z.string().required(),
+          }),
+        )
+        .default([]),
+    })
+    .default({ default: 'default', rules: [] }),
+  cooldownMs: z.number().default(300_000),
+  revertPolicy: z.union([z.const('cooldown-expiry'), z.const('never')]).default('cooldown-expiry'),
+  maxSwitchesPerStep: z.number().default(8),
+  alwaysModeRetryCap: z.number().default(5),
+}) as unknown as z<FallbacksConfig>

--- a/src/cooldown.ts
+++ b/src/cooldown.ts
@@ -1,0 +1,66 @@
+/**
+ * Cooldown store + per-step failure set (spec §5.1; plan Task 2).
+ *
+ * `CooldownStore` maps `provider/model` keys to an expiry epoch ms with lazy
+ * evaluation: expired entries are dropped on read. `revertPolicy: 'never'`
+ * is expressed by suppressing with `Infinity` — the entry never expires
+ * within the session.
+ *
+ * `StepFailureSet` is the step's failed-model set (spec §5.1 `failed`).
+ * `switchCount` / `maxSwitchesPerStep` judgement belongs to the caller
+ * (Task 3) — this task only provides the data structure.
+ *
+ * @module dsh-llm-fallbacks/cooldown
+ */
+
+/**
+ * Per-agent model cooldown: `suppress(key, untilEpochMs)` then
+ * `isSuppressed(key, now?)` with lazy expiry.
+ */
+export class CooldownStore {
+  private entries = new Map<string, number>()
+
+  /** Number of tracked keys (expired entries are dropped lazily on read). */
+  get size(): number {
+    return this.entries.size
+  }
+
+  /** Suppress `key` until `untilEpochMs` (use `Infinity` for `revertPolicy: 'never'`). */
+  suppress(key: string, untilEpochMs: number): void {
+    this.entries.set(key, untilEpochMs)
+  }
+
+  /** True while `key` is suppressed at time `now` (default `Date.now()`); expired entries are removed. */
+  isSuppressed(key: string, now: number = Date.now()): boolean {
+    const until = this.entries.get(key)
+    if (until === undefined) return false
+    if (until <= now) {
+      this.entries.delete(key)
+      return false
+    }
+    return true
+  }
+}
+
+/**
+ * The current step's failed-model set (`${provider}/${model}` keys).
+ */
+export class StepFailureSet {
+  private keys = new Set<string>()
+
+  get size(): number {
+    return this.keys.size
+  }
+
+  add(key: string): void {
+    this.keys.add(key)
+  }
+
+  has(key: string): boolean {
+    return this.keys.has(key)
+  }
+
+  reset(): void {
+    this.keys.clear()
+  }
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,33 @@
+/**
+ * `fallbacks/switch` session event vocabulary (spec §5 table; plan Task 3).
+ *
+ * The event is appended (never rewrites history — AC-7) at every switch,
+ * including the always-mode cap path: "无事件即无切换" (Global Constraint).
+ * The module is type-only — the augmentation is erased at runtime; the
+ * plugin's runtime behavior lives in `src/index.ts`.
+ *
+ * @module dsh-llm-fallbacks/events
+ */
+
+/** Why a switch was decided (spec §5.1 `PendingSwitch.reason`). */
+export type FallbackSwitchReason = 'trigger-code' | 'always-cap'
+
+/** Durable payload of one provider/model switch (spec §5 table). */
+export interface FallbacksSwitchEventData {
+  turn: number
+  step: number
+  /** The model the request was using when the switch was decided. */
+  from: { provider: string; model: string }
+  /** The chain candidate the switch moves to. */
+  to: { provider: string; model: string }
+  /** The fallback-chain role the decision resolved for the agent (ADR-3). */
+  role: string
+  reason: FallbackSwitchReason
+}
+
+declare module '@deepseek-ai/dsh-session/types' {
+  interface SessionEventMap {
+    /** Durable, append-only record of one provider/model switch decided by dsh-llm-fallbacks. */
+    'fallbacks/switch': FallbacksSwitchEventData
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,306 @@
 /**
- * dsh-llm-fallbacks host half (skeleton).
+ * dsh-llm-fallbacks host half (plan Task 3: settings + waterfall + state
+ * machine + events).
  *
  * Cordis function plugin mounted by the profile bundle patch row
- * `llm-fallbacks` (see `bundle/cordis.patch.yml`). Task 1 ships the
- * loadable skeleton only: the real work — `fallbacks` settings namespace,
- * `agent/request-error` + `agent/request` waterfall decisions, per-agent
- * state machine, `fallbacks/switch` session events — lands in Tasks 2/3.
+ * `llm-fallbacks` (see `bundle/cordis.patch.yml`), composed AFTER llm-retry.
+ *
+ * Wiring:
+ * - `fallbacks` settings namespace via {@link installSettingsSection}
+ *   (composition entry as base; `scope.watch` → `onChange` re-reads the
+ *   runtime and re-validates selectors — spec §4).
+ * - `agent/request-error` waterfall: `!enabled` / code ∉ `triggerCodes`
+ *   (**always mode included**) → `next()`; otherwise resolve role + chain,
+ *   and when a candidate survives the filter (current / cooldown /
+ *   step-failed / `provider/*`-missing-id) write the pending switch +
+ *   cooldown + failure bookkeeping + append `fallbacks/switch`, then return
+ *   `{ kind: 'retry' }` (own recovery, no `next()`).
+ * - `agent/request` waterfall: apply a pending switch after `await next()`
+ *   (provider/model override, inherited `reasoningEffort` dropped — the
+ *   `installModelSelection` `withoutInheritedEffort` pattern), then the
+ *   always-mode cap check (count `llm/retry` events for the current
+ *   turn/step/provider; ≥ `alwaysModeRetryCap` → same decision path, reason
+ *   `always-cap` — ADR-2).
+ * - Per-agent state (`FallbackStateStore`): `agent/disposed` removes it,
+ *   `agent/status` idle prunes per-step state defensively, plugin dispose
+ *   clears everything (spec §6 — no residual state).
  *
  * @module dsh-llm-fallbacks
  */
 
-import type { Context } from 'cordis'
-import z from 'schemastery'
+import type { Context, Logger } from 'cordis'
+import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import type { LlmCallConfig } from '@deepseek-ai/dsh-llm'
+import type { Session } from '@deepseek-ai/dsh-session'
+import { Config, defaultFallbacksConfig, type FallbacksConfig } from './config.ts'
+import { createCandidateFilter, resolveChain, type FailingModel } from './chains.ts'
+import { parseSelector, selectorKey } from './selectors.ts'
+import { resolveRole } from './roles.ts'
+import { FallbackStateStore, type AgentFallbackState, type PendingSwitch } from './state.ts'
+import type { FallbackSwitchReason } from './events.ts'
 
 /** The plugin row id mounted by the profile bundle patch. */
 export const name = 'llm-fallbacks'
 
-/** No host config in the skeleton — the `fallbacks` settings namespace arrives with Task 2/3. */
-export type Config = Readonly<Record<string, never>>
+export { Config }
+/** The plugin's composition config — the `fallbacks` settings schema (spec §4). */
+export type Config = FallbacksConfig
+export type { FallbackSwitchReason, FallbacksSwitchEventData } from './events.ts'
+export type { AgentFallbackState, FallbackStateStore, PendingSwitch, StepFailures } from './state.ts'
 
-/** Runtime schema for {@link Config}. */
-export const Config = z.object({}) as unknown as z<Config>
+/** Model-catalog service shape the wildcard existence probe reads (`ctx.llm`). */
+interface ModelCatalogService {
+  listModels(provider: string): Promise<readonly { id: string }[]>
+}
 
-export function apply(ctx: Context): void {
-  ctx.logger('llm-fallbacks').info('dsh-llm-fallbacks skeleton loaded — fallback logic lands in Tasks 2/3')
+/**
+ * Chain-map normalization (T2 review Minor #1): keys containing `/` are
+ * selector keys and are canonicalized via `parseSelector` + `selectorKey`, so
+ * whitespace-padded keys match the resolved lookups; keys without `/` are
+ * role names and are trimmed. Illegal keys warn and are dropped — they "do
+ * not take effect" (spec §4). Entries are validated lazily at resolve time
+ * (`resolveCandidate` returns null for malformed ones) after the same warning
+ * is emitted here.
+ *
+ * Exported for direct unit testing of the config-warning path; the plugin
+ * calls it at startup and on every settings change (`onChange`).
+ */
+export function normalizeChains(chains: Record<string, string[]>, logger: Logger): Record<string, string[]> {
+  const normalized: Record<string, string[]> = {}
+  for (const [key, entries] of Object.entries(chains)) {
+    const roleKey = key.includes('/') ? normalizeSelectorKey(key, logger) : key.trim()
+    if (roleKey === null || roleKey === '') continue
+    for (const entry of entries) {
+      try {
+        parseSelector(entry)
+      } catch (error) {
+        logger.warn(`llm-fallbacks: ignoring invalid chain entry "${entry}" in key "${key}": ${(error as Error).message}`)
+      }
+    }
+    normalized[roleKey] = entries
+  }
+  return normalized
+}
+
+function normalizeSelectorKey(key: string, logger: Logger): string | null {
+  try {
+    const parsed = parseSelector(key)
+    return selectorKey(parsed.provider, parsed.model)
+  } catch (error) {
+    logger.warn(`llm-fallbacks: ignoring invalid chain key "${key}": ${(error as Error).message}`)
+    return null
+  }
+}
+
+/**
+ * The `provider/*`-entry existence probe (spec §2 clause 2): the target
+ * provider's advertised catalog, fetched once per decision and cached per
+ * provider. A missing/unknown provider or a failing catalog reads as "no such
+ * model", so wildcard candidates to it are skipped; without an `llm` service
+ * no filtering happens (`() => true`).
+ *
+ * simplify: catalog fetched per decision, never cached across decisions.
+ * Decisions are failure-driven and rare; cache per provider in the plugin if
+ * they ever become hot.
+ */
+async function makeModelExists(
+  ctx: Context,
+  providers: readonly string[],
+): Promise<(provider: string, model: string) => boolean> {
+  const llm = ctx.get('llm') as ModelCatalogService | undefined
+  if (llm === undefined || typeof llm.listModels !== 'function') return () => true
+  const catalog = new Map<string, Set<string>>()
+  await Promise.all(providers.map(async (provider) => {
+    try {
+      const models = await llm.listModels(provider)
+      catalog.set(provider, new Set(models.map((model) => model.id)))
+    } catch {
+      catalog.set(provider, new Set())
+    }
+  }))
+  return (provider, model) => catalog.get(provider)?.has(model) ?? false
+}
+
+/** Count durable `llm/retry` events for the current (turn, step, provider) (ADR-2, llm-retry matching pattern). */
+function countRetryEvents(session: Session, turn: number, step: number, provider: string): number {
+  let count = 0
+  for (const event of session.events) {
+    if (event.type !== 'llm/retry') continue
+    if (event.data.turn === turn && event.data.step === step && event.data.provider === provider) count += 1
+  }
+  return count
+}
+
+/** The model the failed/current request was routed to. */
+function currentModel(agent: Agent, provider: string): FailingModel {
+  const header = agent.session.requestHeader()
+  return { provider, model: header?.config.model ?? agent.options.model ?? '' }
+}
+
+/**
+ * Override a request config with a pending switch: provider/model replaced,
+ * inherited `reasoningEffort` dropped (the `installModelSelection`
+ * `withoutInheritedEffort` pattern).
+ */
+function overrideConfig(seed: LlmCallConfig, to: { provider: string; model: string }): LlmCallConfig {
+  const { reasoningEffort: _inherited, ...withoutInheritedEffort } = seed
+  return { ...withoutInheritedEffort, provider: to.provider, model: to.model }
+}
+
+export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksConfig): void {
+  const logger = ctx.logger('llm-fallbacks')
+  // Cordis resolves the entry through the schema before apply, so `config` is
+  // already defaulted; re-resolving keeps direct calls (tests) normalized.
+  const entry = Config(config)
+  let source: () => FallbacksConfig = () => entry
+  let chains = normalizeChains(entry.chains, logger)
+
+  installSettingsSection(ctx, settingsNamespace('fallbacks'), Config, entry, {
+    setSource: (current) => {
+      source = current
+    },
+    onChange: () => {
+      chains = normalizeChains(source().chains, logger)
+    },
+  })
+
+  const states = new FallbackStateStore()
+
+  /**
+   * Shared decision path (spec §5.1 lifecycle step 1): resolve the agent's
+   * role and chain, filter candidates (same-model / cooldown / step-failed /
+   * `provider/*`-missing-id), enforce the per-step safety valve, and — on a
+   * hit — return the pending switch for the caller to commit.
+   */
+  async function decide(
+    agent: Agent,
+    turn: number,
+    step: number,
+    current: FailingModel,
+    reason: FallbackSwitchReason,
+    state: AgentFallbackState,
+  ): Promise<PendingSwitch | null> {
+    const config = source()
+    states.syncStep(state, turn, step)
+    if (state.stepFailures.switchCount >= config.maxSwitchesPerStep) return null
+    const role = resolveRole(agent, config.roles.rules, config.roles.default)
+    const all = resolveChain(chains, role, current.provider, current.model)
+    if (all.length === 0) return null
+    // T2 review Important #1: the decision path filters through
+    // createCandidateFilter AND forwards the existence probe to
+    // resolveChain/resolveCandidate, so the "missing id" skip stays scoped to
+    // `provider/*` entries (spec §2 clause 2 — exact entries are never
+    // existence-filtered; createCandidateFilter's own modelExists would
+    // over-filter them).
+    const modelExists = await makeModelExists(
+      ctx,
+      [...new Set(all.map((candidate) => candidate.provider))],
+    )
+    const filter = createCandidateFilter({
+      current,
+      cooldown: { isSuppressed: (key) => states.isSuppressed(state, key) },
+      failed: { has: (key) => state.stepFailures.failed.has(key) },
+    })
+    const target = resolveChain(chains, role, current.provider, current.model, filter, modelExists)[0]
+    if (target === undefined || target.model === undefined) return null
+    logger.info(
+      'llm-fallbacks: agent "%s" switch %s/%s -> %s/%s (role=%s, reason=%s, considered=%o)',
+      agent.id,
+      current.provider,
+      current.model,
+      target.provider,
+      target.model,
+      role,
+      reason,
+      all.map((candidate) => `${candidate.provider}/${candidate.model}`),
+    )
+    return {
+      from: { provider: current.provider, model: current.model },
+      to: { provider: target.provider, model: target.model },
+      role,
+      reason,
+    }
+  }
+
+  /** Commit a decision: pending switch + cooldown + failure bookkeeping + durable event (spec §5.1 step 1). */
+  function commit(agent: Agent, state: AgentFallbackState, pending: PendingSwitch, turn: number, step: number): void {
+    const config = source()
+    const fromKey = selectorKey(pending.from.provider, pending.from.model)
+    const until = config.revertPolicy === 'never' ? Number.POSITIVE_INFINITY : Date.now() + config.cooldownMs
+    states.writePending(state, pending)
+    states.suppress(state, fromKey, until)
+    states.recordFailure(state, fromKey)
+    states.recordSwitch(state)
+    agent.session.append('fallbacks/switch', {
+      turn,
+      step,
+      from: pending.from,
+      to: pending.to,
+      role: pending.role,
+      reason: pending.reason,
+    })
+  }
+
+  ctx.on('agent/request-error', async (
+    { agent, turn, step, provider, failure },
+    next,
+  ) => {
+    const config = source()
+    // Always mode delegates downstream first (llm-retry), so non-trigger
+    // failures must pass through here too — the cap lives at agent/request
+    // (ADR-2). Only trigger codes enter the decision path.
+    if (!config.enabled || !config.triggerCodes.includes(failure.code)) return next()
+    const current = currentModel(agent, provider)
+    if (!current.model) return next()
+    const state = states.get(agent.id)
+    const pending = await decide(agent, turn, step, current, 'trigger-code', state)
+    if (pending === null) return next()
+    commit(agent, state, pending, turn, step)
+    return { kind: 'retry' }
+  })
+
+  ctx.on('agent/request', async ({ agent, turn, step }, next) => {
+    const seed = await next()
+    const state = states.get(agent.id)
+    // Apply a pending decision first (trigger-code path); a switch for this
+    // request means the always-cap count of the previous provider is moot.
+    const applied = states.applyPending(state, turn, step)
+    if (applied !== undefined) return overrideConfig(seed, applied.to)
+    const config = source()
+    if (
+      config.enabled
+      && config.alwaysModeRetryCap > 0
+      && countRetryEvents(agent.session, turn, step, seed.provider) >= config.alwaysModeRetryCap
+    ) {
+      const pending = await decide(
+        agent,
+        turn,
+        step,
+        { provider: seed.provider, model: seed.model },
+        'always-cap',
+        state,
+      )
+      if (pending !== null) {
+        commit(agent, state, pending, turn, step)
+        const appliedCap = states.applyPending(state, turn, step)
+        if (appliedCap !== undefined) return overrideConfig(seed, appliedCap.to)
+      }
+    }
+    return seed
+  })
+
+  ctx.on('agent/status', ({ agent, status }) => {
+    if (status !== 'idle') return
+    const state = states.peek(agent.id)
+    if (state !== undefined) states.clearStepState(state)
+  })
+
+  ctx.on('agent/disposed', ({ agent }) => {
+    states.delete(agent.id)
+  })
+
+  ctx.effect(() => () => {
+    states.clear()
+  }, 'llm-fallbacks: clear per-agent state')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { LlmCallConfig } from '@deepseek-ai/dsh-llm'
 import type { Session } from '@deepseek-ai/dsh-session'
 import { Config, defaultFallbacksConfig, type FallbacksConfig } from './config.ts'
-import { createCandidateFilter, resolveChain, type FailingModel } from './chains.ts'
+import { annotateCandidates, createCandidateFilter, resolveChain, type FailingModel } from './chains.ts'
 import { parseSelector, selectorKey } from './selectors.ts'
 import { resolveRole } from './roles.ts'
 import { FallbackStateStore, type AgentFallbackState, type PendingSwitch } from './state.ts'
@@ -52,6 +52,23 @@ export type { AgentFallbackState, FallbackStateStore, PendingSwitch, StepFailure
 /** Model-catalog service shape the wildcard existence probe reads (`ctx.llm`). */
 interface ModelCatalogService {
   listModels(provider: string): Promise<readonly { id: string }[]>
+}
+
+/**
+ * Per-apply state stores, keyed by context. Weak so entries die with the
+ * context; the plugin's own dispose effect clears the store contents.
+ * @internal
+ */
+const stateStores = new WeakMap<Context, FallbackStateStore>()
+
+/**
+ * @internal Test seam (T3 review Minor 3): the per-agent fallback state store
+ * of the plugin applied to `ctx` — last apply wins. Not part of the plugin's
+ * public surface; lets tests assert the no-op purity invariant (a plain
+ * request must not grow the store) without reaching into the closure.
+ */
+export function stateStore(ctx: Context): FallbackStateStore | undefined {
+  return stateStores.get(ctx)
 }
 
 /**
@@ -122,12 +139,35 @@ async function makeModelExists(
   return (provider, model) => catalog.get(provider)?.has(model) ?? false
 }
 
-/** Count durable `llm/retry` events for the current (turn, step, provider) (ADR-2, llm-retry matching pattern). */
-function countRetryEvents(session: Session, turn: number, step: number, provider: string): number {
+/**
+ * Count durable `llm/retry` events for the current (turn, step, provider) in
+ * **always mode** (ADR-2; spec §2 clause 5). Normal-mode retries belong to
+ * llm-retry's bounded budget and must not preempt the fallback, so only
+ * `mode: 'always'` events count toward `alwaysModeRetryCap` (T3 review
+ * Minor 2 — the real event carries the discriminator, llm-retry types.ts).
+ *
+ * Fast path (T3 review Minor 4): the session log is append-ordered, so the
+ * scan runs backwards and stops at the first event older than the target
+ * (turn, step) — a long session's earlier turns are never scanned.
+ *
+ * Exported for direct unit testing of the counting + fast path.
+ */
+export function countRetryEvents(session: Session, turn: number, step: number, provider: string): number {
   let count = 0
-  for (const event of session.events) {
+  const events = session.events
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!
+    const data = event.data as { turn?: number; step?: number }
+    // Everything before the first event older than the target cannot match.
+    if (
+      typeof data.turn === 'number'
+      && typeof data.step === 'number'
+      && (data.turn < turn || (data.turn === turn && data.step < step))
+    ) break
     if (event.type !== 'llm/retry') continue
-    if (event.data.turn === turn && event.data.step === step && event.data.provider === provider) count += 1
+    if (data.turn === turn && data.step === step && event.data.provider === provider && event.data.mode === 'always') {
+      count += 1
+    }
   }
   return count
 }
@@ -166,6 +206,7 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
   })
 
   const states = new FallbackStateStore()
+  stateStores.set(ctx, states)
 
   /**
    * Shared decision path (spec §5.1 lifecycle step 1): resolve the agent's
@@ -197,15 +238,20 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
       ctx,
       [...new Set(all.map((candidate) => candidate.provider))],
     )
-    const filter = createCandidateFilter({
-      current,
-      cooldown: { isSuppressed: (key) => states.isSuppressed(state, key) },
-      failed: { has: (key) => state.stepFailures.failed.has(key) },
-    })
-    const target = resolveChain(chains, role, current.provider, current.model, filter, modelExists)[0]
+    const cooldown = { isSuppressed: (key: string) => states.isSuppressed(state, key) }
+    const failed = { has: (key: string) => state.stepFailures.failed.has(key) }
+    // T2 review Important #1: the decision path filters through
+    // createCandidateFilter AND forwards the existence probe to
+    // resolveChain/resolveCandidate, so the "missing id" skip stays scoped to
+    // `provider/*` entries (spec §2 clause 2 — exact entries are never
+    // existence-filtered; createCandidateFilter's own modelExists would
+    // over-filter them). The filter deliberately does NOT receive modelExists.
+    const filter = createCandidateFilter({ current, cooldown, failed })
+    const surviving = resolveChain(chains, role, current.provider, current.model, filter, modelExists)
+    const target = surviving[0]
     if (target === undefined || target.model === undefined) return null
     logger.info(
-      'llm-fallbacks: agent "%s" switch %s/%s -> %s/%s (role=%s, reason=%s, considered=%o)',
+      'llm-fallbacks: agent "%s" switch %s/%s -> %s/%s (role=%s, reason=%s, candidates=%o)',
       agent.id,
       current.provider,
       current.model,
@@ -213,7 +259,14 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
       target.model,
       role,
       reason,
-      all.map((candidate) => `${candidate.provider}/${candidate.model}`),
+      // spec §2 行为可见性: the log shows the candidate attempt order AND why
+      // each candidate was skipped (cooldown / step-failed / same-as-current /
+      // target-provider missing id); survivors (including the target) are
+      // unlabelled.
+      annotateCandidates(all, surviving, { current, cooldown, failed })
+        .map(({ candidate, skip }) => skip === undefined
+          ? `${candidate.provider}/${candidate.model}`
+          : `${candidate.provider}/${candidate.model} (skipped: ${skip})`),
     )
     return {
       from: { provider: current.provider, model: current.model },
@@ -262,10 +315,14 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
 
   ctx.on('agent/request', async ({ agent, turn, step }, next) => {
     const seed = await next()
-    const state = states.get(agent.id)
+    // No-op purity (T3 review Minor 3): peek, never create — a plain request
+    // must not grow the per-agent map (AC-8). State is created lazily only
+    // when a real switch intent exists (a pending decision to apply, or the
+    // always-cap tripped below).
+    const state = states.peek(agent.id)
     // Apply a pending decision first (trigger-code path); a switch for this
     // request means the always-cap count of the previous provider is moot.
-    const applied = states.applyPending(state, turn, step)
+    const applied = state === undefined ? undefined : states.applyPending(state, turn, step)
     if (applied !== undefined) return overrideConfig(seed, applied.to)
     const config = source()
     if (
@@ -273,17 +330,19 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
       && config.alwaysModeRetryCap > 0
       && countRetryEvents(agent.session, turn, step, seed.provider) >= config.alwaysModeRetryCap
     ) {
+      // Cap tripped: a genuine switch intent — create the state lazily.
+      const decisionState = states.get(agent.id)
       const pending = await decide(
         agent,
         turn,
         step,
         { provider: seed.provider, model: seed.model },
         'always-cap',
-        state,
+        decisionState,
       )
       if (pending !== null) {
-        commit(agent, state, pending, turn, step)
-        const appliedCap = states.applyPending(state, turn, step)
+        commit(agent, decisionState, pending, turn, step)
+        const appliedCap = states.applyPending(decisionState, turn, step)
         if (appliedCap !== undefined) return overrideConfig(seed, appliedCap.to)
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,39 @@ function normalizeSelectorKey(key: string, logger: Logger): string | null {
 }
 
 /**
+ * Whether any chain entry reachable for this failing (provider, model) is a
+ * wildcard (`provider/*`). F-002: `resolveChain` resolves wildcard entries to
+ * concrete models, so the wildcard provenance is invisible on the resolved
+ * candidate list — the decision path consults the raw entries under the same
+ * keys `resolveChain` walks (exact → `provider/*` → role → `default`) to
+ * decide whether the catalog existence probe is needed at all. Malformed
+ * entries never become candidates and are skipped.
+ */
+function hasWildcardEntry(
+  chains: Record<string, string[]>,
+  role: string,
+  provider: string,
+  model: string,
+): boolean {
+  const keys = [selectorKey(provider, model), selectorKey(provider), role, 'default']
+  const seen = new Set<string>()
+  for (const key of keys) {
+    if (seen.has(key)) continue
+    seen.add(key)
+    const entries = chains[key]
+    if (!entries) continue
+    for (const entry of entries) {
+      try {
+        if (parseSelector(entry).model === undefined) return true
+      } catch {
+        // malformed entries never become candidates (config-warning path)
+      }
+    }
+  }
+  return false
+}
+
+/**
  * The `provider/*`-entry existence probe (spec §2 clause 2): the target
  * provider's advertised catalog, fetched once per decision and cached per
  * provider. A missing/unknown provider or a failing catalog reads as "no such
@@ -195,6 +228,10 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
   const entry = Config(config)
   let source: () => FallbacksConfig = () => entry
   let chains = normalizeChains(entry.chains, logger)
+  // F-001: an unconfigured install (empty chains) must be truly zero-cost —
+  // the always-cap session scan is short-circuited on this flag, so a plain
+  // request never touches the event log when no chains are configured (AC-8).
+  let hasChains = Object.keys(chains).length > 0
 
   installSettingsSection(ctx, settingsNamespace('fallbacks'), Config, entry, {
     setSource: (current) => {
@@ -202,6 +239,7 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
     },
     onChange: () => {
       chains = normalizeChains(source().chains, logger)
+      hasChains = Object.keys(chains).length > 0
     },
   })
 
@@ -213,6 +251,11 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
    * role and chain, filter candidates (same-model / cooldown / step-failed /
    * `provider/*`-missing-id), enforce the per-step safety valve, and — on a
    * hit — return the pending switch for the caller to commit.
+   *
+   * `state` is the agent's peeked entry: `undefined` for agents with no state
+   * yet (F-004 — the store is only grown on a real switch intent, inside
+   * `commit`). With no state there is no step bookkeeping, so the valve check
+   * passes and cooldown/step-failed reads are false.
    */
   async function decide(
     agent: Agent,
@@ -220,32 +263,35 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
     step: number,
     current: FailingModel,
     reason: FallbackSwitchReason,
-    state: AgentFallbackState,
+    state: AgentFallbackState | undefined,
   ): Promise<PendingSwitch | null> {
     const config = source()
-    states.syncStep(state, turn, step)
-    if (state.stepFailures.switchCount >= config.maxSwitchesPerStep) return null
+    if (state !== undefined) {
+      states.syncStep(state, turn, step)
+      if (state.stepFailures.switchCount >= config.maxSwitchesPerStep) return null
+    }
     const role = resolveRole(agent, config.roles.rules, config.roles.default)
     const all = resolveChain(chains, role, current.provider, current.model)
     if (all.length === 0) return null
-    // T2 review Important #1: the decision path filters through
-    // createCandidateFilter AND forwards the existence probe to
-    // resolveChain/resolveCandidate, so the "missing id" skip stays scoped to
-    // `provider/*` entries (spec §2 clause 2 — exact entries are never
-    // existence-filtered; createCandidateFilter's own modelExists would
-    // over-filter them).
-    const modelExists = await makeModelExists(
-      ctx,
-      [...new Set(all.map((candidate) => candidate.provider))],
-    )
-    const cooldown = { isSuppressed: (key: string) => states.isSuppressed(state, key) }
-    const failed = { has: (key: string) => state.stepFailures.failed.has(key) }
-    // T2 review Important #1: the decision path filters through
-    // createCandidateFilter AND forwards the existence probe to
-    // resolveChain/resolveCandidate, so the "missing id" skip stays scoped to
-    // `provider/*` entries (spec §2 clause 2 — exact entries are never
-    // existence-filtered; createCandidateFilter's own modelExists would
-    // over-filter them). The filter deliberately does NOT receive modelExists.
+    // T2 review Important #1 (decision-path contract): the "missing id" skip
+    // stays scoped to `provider/*` entries (spec §2 clause 2 — exact entries
+    // are never existence-filtered; createCandidateFilter's own modelExists
+    // would over-filter them), so the probe is forwarded to
+    // resolveChain/resolveCandidate while the filter deliberately does NOT
+    // receive modelExists. F-002: the probe is built only when a wildcard
+    // entry is reachable — pure exact chains take zero catalog probes.
+    const modelExists = hasWildcardEntry(chains, role, current.provider, current.model)
+      ? await makeModelExists(
+        ctx,
+        [...new Set(all.map((candidate) => candidate.provider))],
+      )
+      : undefined
+    const cooldown = {
+      isSuppressed: (key: string) => state !== undefined && states.isSuppressed(state, key),
+    }
+    const failed = {
+      has: (key: string) => state !== undefined && state.stepFailures.failed.has(key),
+    }
     const filter = createCandidateFilter({ current, cooldown, failed })
     const surviving = resolveChain(chains, role, current.provider, current.model, filter, modelExists)
     const target = surviving[0]
@@ -281,6 +327,11 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
     const config = source()
     const fromKey = selectorKey(pending.from.provider, pending.from.model)
     const until = config.revertPolicy === 'never' ? Number.POSITIVE_INFINITY : Date.now() + config.cooldownMs
+    // F-004 follow-up: a state freshly created by `states.get` at the commit
+    // site carries no (turn, step) markers — sync them here so the next
+    // decision's valve/failed-set bookkeeping sees this committed step (a
+    // no-op for states `decide` already synced at the same (turn, step)).
+    states.syncStep(state, turn, step)
     states.writePending(state, pending)
     states.suppress(state, fromKey, until)
     states.recordFailure(state, fromKey)
@@ -306,11 +357,23 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
     if (!config.enabled || !config.triggerCodes.includes(failure.code)) return next()
     const current = currentModel(agent, provider)
     if (!current.model) return next()
-    const state = states.get(agent.id)
-    const pending = await decide(agent, turn, step, current, 'trigger-code', state)
-    if (pending === null) return next()
-    commit(agent, state, pending, turn, step)
-    return { kind: 'retry' }
+    // F-005: the decision path is defensive — an unexpected throw (e.g. a
+    // session.append failure, a future refactor) must not replace the original
+    // failure semantics (spec §6); log and delegate instead.
+    try {
+      // F-004: peek, never create — a null decision must not grow the store.
+      const state = states.peek(agent.id)
+      const pending = await decide(agent, turn, step, current, 'trigger-code', state)
+      if (pending === null) return next()
+      commit(agent, states.get(agent.id), pending, turn, step)
+      return { kind: 'retry' }
+    } catch (error) {
+      logger.warn(
+        'llm-fallbacks: decision path failed, passing the original failure through: %s',
+        (error as Error)?.message ?? String(error),
+      )
+      return next()
+    }
   })
 
   ctx.on('agent/request', async ({ agent, turn, step }, next) => {
@@ -326,12 +389,15 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
     if (applied !== undefined) return overrideConfig(seed, applied.to)
     const config = source()
     if (
-      config.enabled
+      hasChains
+      && config.enabled
       && config.alwaysModeRetryCap > 0
       && countRetryEvents(agent.session, turn, step, seed.provider) >= config.alwaysModeRetryCap
     ) {
-      // Cap tripped: a genuine switch intent — create the state lazily.
-      const decisionState = states.get(agent.id)
+      // Cap tripped: a genuine switch intent — but the state is still only
+      // grown when the decision actually commits (F-004: a null decision —
+      // e.g. all candidates filtered — leaves no entry behind).
+      const decisionState = states.peek(agent.id)
       const pending = await decide(
         agent,
         turn,
@@ -341,8 +407,9 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
         decisionState,
       )
       if (pending !== null) {
-        commit(agent, decisionState, pending, turn, step)
-        const appliedCap = states.applyPending(decisionState, turn, step)
+        const commitState = states.get(agent.id)
+        commit(agent, commitState, pending, turn, step)
+        const appliedCap = states.applyPending(commitState, turn, step)
         if (appliedCap !== undefined) return overrideConfig(seed, appliedCap.to)
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * dsh-llm-fallbacks host half (skeleton).
+ *
+ * Cordis function plugin mounted by the profile bundle patch row
+ * `llm-fallbacks` (see `bundle/cordis.patch.yml`). Task 1 ships the
+ * loadable skeleton only: the real work — `fallbacks` settings namespace,
+ * `agent/request-error` + `agent/request` waterfall decisions, per-agent
+ * state machine, `fallbacks/switch` session events — lands in Tasks 2/3.
+ *
+ * @module dsh-llm-fallbacks
+ */
+
+import type { Context } from 'cordis'
+import z from 'schemastery'
+
+/** The plugin row id mounted by the profile bundle patch. */
+export const name = 'llm-fallbacks'
+
+/** No host config in the skeleton — the `fallbacks` settings namespace arrives with Task 2/3. */
+export type Config = Readonly<Record<string, never>>
+
+/** Runtime schema for {@link Config}. */
+export const Config = z.object({}) as unknown as z<Config>
+
+export function apply(ctx: Context): void {
+  ctx.logger('llm-fallbacks').info('dsh-llm-fallbacks skeleton loaded — fallback logic lands in Tasks 2/3')
+}

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -1,0 +1,55 @@
+/**
+ * Role resolution for fallback chains (spec §3, ADR-3; plan Task 2).
+ *
+ * Precedence (first hit wins):
+ * 1. `agent.options.role` — the explicit role (dsh patch, Task 6);
+ * 2. the first `rules` entry whose specified origin/provider/model patterns
+ *    all match the agent;
+ * 3. `defaultRole` (`roles.default`, itself `'default'`).
+ *
+ * A missing agent origin is treated as `'root'` — root agents carry no
+ * `session.meta.origin`. Unspecified rule fields do not constrain.
+ *
+ * @module dsh-llm-fallbacks/roles
+ */
+
+/** Agent origins understood by role rules (spec §3). */
+export type Origin = 'root' | 'subagent'
+
+/** One role rule: any subset of origin/provider/model patterns → role. */
+export interface RoleRule {
+  origin?: Origin
+  provider?: string
+  model?: string
+  role: string
+}
+
+/** Loose agent shape sufficient for role resolution (spec §3 / brief). */
+export interface AgentLike {
+  options?: {
+    role?: string
+    provider?: string
+    model?: string
+  }
+  session?: {
+    meta?: {
+      origin?: Origin
+    }
+  }
+}
+
+/**
+ * Resolve the fallback-chain role for an agent: explicit `options.role` →
+ * first matching rule (in listed order) → `defaultRole`.
+ */
+export function resolveRole(agent: AgentLike, rules: RoleRule[], defaultRole: string): string {
+  if (agent.options?.role) return agent.options.role
+  const origin = agent.session?.meta?.origin ?? 'root'
+  for (const rule of rules) {
+    if (rule.origin && rule.origin !== origin) continue
+    if (rule.provider && rule.provider !== agent.options?.provider) continue
+    if (rule.model && rule.model !== agent.options?.model) continue
+    return rule.role
+  }
+  return defaultRole
+}

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -1,5 +1,5 @@
 /**
- * Role resolution for fallback chains (spec §3, ADR-3; plan Task 2).
+ * Role resolution for fallback chains (spec §3, ADR-3; plan Task 2/3).
  *
  * Precedence (first hit wins):
  * 1. `agent.options.role` — the explicit role (dsh patch, Task 6);
@@ -7,8 +7,13 @@
  *    all match the agent;
  * 3. `defaultRole` (`roles.default`, itself `'default'`).
  *
- * A missing agent origin is treated as `'root'` — root agents carry no
- * `session.meta.origin`. Unspecified rule fields do not constrain.
+ * A missing agent origin is treated as `'root'`. Origin is read from
+ * `session.header.origin` — the durable `SessionHeader` field the store folds
+ * from `CreateSessionOptions.meta.origin` (`packages/core/session/src/
+ * index.ts:899`); subagent children set it via `childSessionMeta`
+ * (`packages/subagent/subagent/src/child-agent.ts:93`), root agents carry
+ * none. (Task 3 contract refinement: the live `Session` exposes `header`, not
+ * a `meta` field.)
  *
  * @module dsh-llm-fallbacks/roles
  */
@@ -32,7 +37,7 @@ export interface AgentLike {
     model?: string
   }
   session?: {
-    meta?: {
+    header?: {
       origin?: Origin
     }
   }
@@ -44,7 +49,7 @@ export interface AgentLike {
  */
 export function resolveRole(agent: AgentLike, rules: RoleRule[], defaultRole: string): string {
   if (agent.options?.role) return agent.options.role
-  const origin = agent.session?.meta?.origin ?? 'root'
+  const origin = agent.session?.header?.origin ?? 'root'
   for (const rule of rules) {
     if (rule.origin && rule.origin !== origin) continue
     if (rule.provider && rule.provider !== agent.options?.provider) continue

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -45,9 +45,12 @@ export function parseSelector(input: string): Selector {
   if (slash <= 0 || slash === trimmed.length - 1) {
     throw new SelectorError(`invalid selector "${input}": expected "provider/model" or "provider/*"`)
   }
-  const provider = trimmed.slice(0, slash)
-  const modelPart = trimmed.slice(slash + 1)
-  if (!provider.trim() || !modelPart.trim()) {
+  // Trim inside each segment too (T2 review Minor #1): 'openai/ gpt-4o' and
+  // ' openai /gpt-4o ' must parse to canonical provider/model instead of
+  // silently carrying whitespace into a never-matching candidate/chain key.
+  const provider = trimmed.slice(0, slash).trim()
+  const modelPart = trimmed.slice(slash + 1).trim()
+  if (!provider || !modelPart) {
     throw new SelectorError(`invalid selector "${input}": empty provider or model`)
   }
   if (modelPart.includes('/')) {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,0 +1,66 @@
+/**
+ * Selector parsing for `fallbacks` chains (spec §4, plan Task 2).
+ *
+ * Grammar: `provider/model` (exact) and `provider/*` (wildcard — the parsed
+ * `model` is `undefined`). Illegal selectors throw {@link SelectorError} —
+ * the catchable "config warning" path; warn-and-continue lives in Task 3.
+ * These modules never crash on their own.
+ *
+ * @module dsh-llm-fallbacks/selectors
+ */
+
+/** A parsed selector: `provider` + optional `model` (`undefined` = wildcard). */
+export interface Selector {
+  provider: string
+  model?: string
+  /** Original selector string, kept for diagnostics/logging. */
+  raw: string
+}
+
+/** Catchable error for illegal/unknown selectors (config-warning path). */
+export class SelectorError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SelectorError'
+  }
+}
+
+/** Canonical key: `provider/model`, or `provider/*` for a wildcard model. */
+export function selectorKey(provider: string, model?: string): string {
+  return model === undefined ? `${provider}/*` : `${provider}/${model}`
+}
+
+/**
+ * Parse a chain key or entry selector.
+ *
+ * Accepts `provider/model` and `provider/*`; throws {@link SelectorError}
+ * on anything else (missing separator, empty parts, extra separators).
+ */
+export function parseSelector(input: string): Selector {
+  if (typeof input !== 'string') {
+    throw new SelectorError(`invalid selector ${String(input)}: expected "provider/model" or "provider/*"`)
+  }
+  const trimmed = input.trim()
+  const slash = trimmed.indexOf('/')
+  if (slash <= 0 || slash === trimmed.length - 1) {
+    throw new SelectorError(`invalid selector "${input}": expected "provider/model" or "provider/*"`)
+  }
+  const provider = trimmed.slice(0, slash)
+  const modelPart = trimmed.slice(slash + 1)
+  if (!provider.trim() || !modelPart.trim()) {
+    throw new SelectorError(`invalid selector "${input}": empty provider or model`)
+  }
+  if (modelPart.includes('/')) {
+    throw new SelectorError(`invalid selector "${input}": unexpected extra separator`)
+  }
+  const model = modelPart === '*' ? undefined : modelPart
+  return { provider, model, raw: trimmed }
+}
+
+/**
+ * Wildcard-entry resolution: keep the failing model id, swap only the
+ * provider (`provider/*` entry semantics, spec §2 clause 2).
+ */
+export function resolveWildcardEntry(failingModel: string, provider: string): Selector {
+  return { provider, model: failingModel, raw: `${provider}/${failingModel}` }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-agent fallback state machine (spec §5.1; plan Task 3).
+ *
+ * One `AgentFallbackState` per `agent.id`, held in a `FallbackStateStore`
+ * created at plugin apply, removed on `agent/disposed`, defensively pruned on
+ * `agent/status` idle, and cleared wholesale on plugin dispose (spec §6:
+ * 无残留状态).
+ *
+ * **pendingSwitch lifecycle** (spec §5.1):
+ * 1. **Produce** (decision point — request-error trigger-code or
+ *    agent/request always-cap): `writePending` stores the decision and clears
+ *    `appliedTurnStep`, so a *fresh* decision is always applicable at the
+ *    current (turn, step) — required for chains (decision B→C must apply even
+ *    though A→B was already applied at the same (turn, step)).
+ * 2. **Apply** (`agent/request`): `applyPending` returns the pending switch
+ *    when one exists and has not already been applied at the current
+ *    (turn, step), records `appliedTurnStep`, and clears `pendingSwitch`
+ *    (anti-replay guard).
+ * 3. **Discard**: chain exhaustion / safety valve → the caller delegates
+ *    (`next()`) and the pending state dies with the agent.
+ *
+ * **stepFailures** resets whenever (turn, step) advances (`syncStep`);
+ * **cooldown** (`CooldownStore`) is a `provider/model → expiry epoch ms` map
+ * with lazy expiry (`revertPolicy: 'never'` = `Infinity` TTL). The time-boxed
+ * cooldown deliberately survives idle cleanup so `cooldown-expiry` revert
+ * (US-4 / T4 integration) works across turns.
+ *
+ * @module dsh-llm-fallbacks/state
+ */
+
+import type { FallbackSwitchReason } from './events.ts'
+import { CooldownStore, StepFailureSet } from './cooldown.ts'
+
+/** Decision awaiting application at the next `agent/request` boundary (spec §5.1). */
+export interface PendingSwitch {
+  from: { provider: string; model: string }
+  to: { provider: string; model: string }
+  role: string
+  reason: FallbackSwitchReason
+}
+
+/** The current (turn, step)'s failed-model set and switch budget (spec §5.1). */
+export interface StepFailures {
+  turn: number
+  step: number
+  /** `${provider}/${model}` keys failed in this step (double suppression with cooldown). */
+  failed: StepFailureSet
+  /** Switches committed in this step; the caller judges it against `maxSwitchesPerStep`. */
+  switchCount: number
+}
+
+/** One agent's whole fallback runtime state (spec §5.1). */
+export interface AgentFallbackState {
+  /** Decision produced but not yet applied at an `agent/request` boundary. */
+  pendingSwitch?: PendingSwitch
+  /** The (turn, step) the last pending switch was applied to — anti-replay. */
+  appliedTurnStep?: { turn: number; step: number }
+  /** Current (turn, step)'s failure bookkeeping. */
+  stepFailures: StepFailures
+  /** `provider/model → expiry epoch ms`; lazily expired on read. */
+  cooldown: CooldownStore
+}
+
+/**
+ * The `Map<agent.id, AgentFallbackState>` store plus the state-machine
+ * operations (spec §5.1).
+ */
+export class FallbackStateStore {
+  private readonly states = new Map<string, AgentFallbackState>()
+
+  /** Number of tracked agents. */
+  get size(): number {
+    return this.states.size
+  }
+
+  has(agentId: string): boolean {
+    return this.states.has(agentId)
+  }
+
+  /** Read without creating; `undefined` for unknown agents. */
+  peek(agentId: string): AgentFallbackState | undefined {
+    return this.states.get(agentId)
+  }
+
+  /** Read, creating an empty state on first sight. */
+  get(agentId: string): AgentFallbackState {
+    let state = this.states.get(agentId)
+    if (state === undefined) {
+      state = {
+        stepFailures: { turn: 0, step: 0, failed: new StepFailureSet(), switchCount: 0 },
+        cooldown: new CooldownStore(),
+      }
+      this.states.set(agentId, state)
+    }
+    return state
+  }
+
+  /** Remove one agent's state (`agent/disposed`). */
+  delete(agentId: string): void {
+    this.states.delete(agentId)
+  }
+
+  /** Remove every agent's state (plugin dispose — no residual state). */
+  clear(): void {
+    this.states.clear()
+  }
+
+  /** Reset step-scoped bookkeeping when (turn, step) advances (spec §5.1). */
+  syncStep(state: AgentFallbackState, turn: number, step: number): void {
+    const { stepFailures } = state
+    if (stepFailures.turn === turn && stepFailures.step === step) return
+    stepFailures.turn = turn
+    stepFailures.step = step
+    stepFailures.failed.reset()
+    stepFailures.switchCount = 0
+  }
+
+  /** Record the current model as failed in this step (spec §5.1). */
+  recordFailure(state: AgentFallbackState, key: string): void {
+    state.stepFailures.failed.add(key)
+  }
+
+  /** Bump the step's switch budget (spec §5.1). */
+  recordSwitch(state: AgentFallbackState): void {
+    state.stepFailures.switchCount += 1
+  }
+
+  /**
+   * Produce a pending switch. A fresh decision always supersedes a previous
+   * one and must be applicable at the current (turn, step), so the applied
+   * marker is cleared here (see module doc — chains).
+   */
+  writePending(state: AgentFallbackState, pending: PendingSwitch): void {
+    state.pendingSwitch = pending
+    state.appliedTurnStep = undefined
+  }
+
+  /**
+   * Apply the pending switch at (turn, step) when one exists and has not
+   * already been applied there; records the applied marker and clears the
+   * pending switch (spec §5.1 lifecycle step 2).
+   */
+  applyPending(state: AgentFallbackState, turn: number, step: number): PendingSwitch | undefined {
+    const pending = state.pendingSwitch
+    if (pending === undefined) return undefined
+    const applied = state.appliedTurnStep
+    if (applied !== undefined && applied.turn === turn && applied.step === step) return undefined
+    state.appliedTurnStep = { turn, step }
+    state.pendingSwitch = undefined
+    return pending
+  }
+
+  /**
+   * Defensive `agent/status` idle cleanup: drop per-step state. The time-boxed
+   * cooldown survives so `cooldown-expiry` revert works across turns (US-4).
+   */
+  clearStepState(state: AgentFallbackState): void {
+    state.pendingSwitch = undefined
+    state.appliedTurnStep = undefined
+    state.stepFailures.failed.reset()
+    state.stepFailures.switchCount = 0
+  }
+
+  /** Suppress `key` until `untilEpochMs` (`Infinity` for `revertPolicy: 'never'`). */
+  suppress(state: AgentFallbackState, key: string, untilEpochMs: number): void {
+    state.cooldown.suppress(key, untilEpochMs)
+  }
+
+  /** Lazy cooldown read: expired entries are dropped on read (spec §5.1). */
+  isSuppressed(state: AgentFallbackState, key: string, now: number = Date.now()): boolean {
+    return state.cooldown.isSuppressed(key, now)
+  }
+}

--- a/tests/always-mode.spec.ts
+++ b/tests/always-mode.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Always-mode cap matrix (plan Task 4, Step 2; spec §2 clause 5 / ADR-2).
+ *
+ * The cap lives at the `agent/request` boundary: count durable `llm/retry`
+ * events for the current (turn, step, provider) with `mode: 'always'`, and
+ * switch once the count reaches `alwaysModeRetryCap` (0 disables). The
+ * request-error listener must NOT preempt the always backoff — llm-retry's
+ * always mode delegates downstream first, so non-triggerCode failures pass
+ * through (the fallback only acts on trigger codes there).
+ *
+ * Task 4 appends `llm/retry` events in the **real** event shape (retryId /
+ * policyKey / retry / delayMs / failure …) so the counting is exercised
+ * against the real bundle's payload — the `mode` discriminator must survive
+ * the full shape (T3 fix review ⚠️2), and normal-mode retries must never
+ * count toward the cap.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Context } from 'cordis'
+import type { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import { apply } from '../src/index.ts'
+import { resetSettingsStub } from './support/settings-stub.ts'
+import { installLlmRetryStub } from './support/llm-retry-stub.ts'
+import {
+  alwaysPolicy,
+  appendLlmRetry,
+  cfg,
+  dispatchRequest,
+  dispatchRequestError,
+  llmRetryEvents,
+  makeAgent,
+  runAgentStep,
+  switchEvents,
+} from './support/harness.ts'
+
+let ctx: Context
+
+beforeEach(() => {
+  resetSettingsStub()
+  ctx = new Context()
+})
+
+afterEach(async () => {
+  await ctx.fiber.dispose()
+})
+
+describe('always-mode cap at the agent/request boundary (spec §2 clause 5 / ADR-2)', () => {
+  it('switches only once always-mode retries reach the cap; below the cap the request passes unchanged and request-error is not preempted', async () => {
+    const { agent } = makeAgent('cap-gate', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 3 }))
+
+    // Below the cap (2 always retries): the request passes unchanged, effort
+    // and all; a non-trigger request-error (the always backoff path) is NOT
+    // preempted by the fallback.
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 1 })
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 2 })
+    const below = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+    })
+    expect(below).toEqual({ provider: 'mock', model: 'gpt-4o', reasoningEffort: 'high' as ReasoningEffortId })
+    expect(switchEvents(agent)).toHaveLength(0)
+    expect(await dispatchRequestError(ctx, agent, { failure: { message: 'busy', code: 'SERVER' } })).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // At the cap (3rd always retry): the next buildRequest switches — and the
+    // inherited reasoningEffort is dropped with the override.
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 3 })
+    const switched = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+    })
+    expect(switched).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data).toMatchObject({
+      turn: 1,
+      step: 1,
+      from: { provider: 'mock', model: 'gpt-4o' },
+      to: { provider: 'other', model: 'gpt-4o' },
+      reason: 'always-cap',
+    })
+  })
+
+  it('counts only always-mode events under the real llm/retry event shape (T3 fix review ⚠️2)', async () => {
+    const { agent } = makeAgent('cap-shape', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 3 }))
+
+    // Full-shape normal-mode retries (a bounded RATE_LIMIT budget): they
+    // belong to llm-retry and must never count toward the cap.
+    for (let retry = 1; retry <= 3; retry += 1) {
+      appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'normal', retry, maxRetries: 5 })
+    }
+    expect(await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' }))
+      .toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // Two full-shape always-mode retries — still below cap 3.
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 1 })
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 2 })
+    expect(await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' }))
+      .toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // The third always-mode retry reaches the cap → switch.
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 3 })
+    expect(await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' }))
+      .toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data.reason).toBe('always-cap')
+  })
+
+  it('scopes the count to the current (turn, step, provider)', async () => {
+    const { agent } = makeAgent('cap-scope', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 3 }))
+
+    // Retries for other (turn, step) pairs and other providers must not trip
+    // the cap at (1, 1, mock) — appended in chronological order (older first).
+    for (let retry = 1; retry <= 5; retry += 1) {
+      appendLlmRetry(agent, { turn: 1, step: 2, provider: 'other', mode: 'always', retry })
+      appendLlmRetry(agent, { turn: 2, step: 1, provider: 'mock', mode: 'always', retry })
+      appendLlmRetry(agent, { turn: 1, step: 1, provider: 'other', mode: 'always', retry })
+    }
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('disables the mechanism when alwaysModeRetryCap is 0', async () => {
+    const { agent } = makeAgent('cap-zero', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 0 }))
+
+    for (let retry = 1; retry <= 5; retry += 1) {
+      appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry })
+    }
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('end to end: the llm-retry stub retries always-mode failures until the cap trips at the next build', async () => {
+    // Full composition: the stub (always policy, registered first) backoffs on
+    // every non-trigger failure; the fallback passes each through (ADR-2); the
+    // durable always-mode llm/retry events accumulate until the cap trips at
+    // the next buildRequest — then the switch applies and the step succeeds.
+    installLlmRetryStub(ctx)
+    const { agent, setRoute } = makeAgent('cap-e2e', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 3 }))
+
+    const result = await runAgentStep(ctx, { agent, setRoute }, [
+      { message: 'busy', code: 'SERVER' },
+      { message: 'busy', code: 'SERVER' },
+      { message: 'busy', code: 'SERVER' },
+      undefined,
+    ], { retryPolicy: alwaysPolicy() })
+
+    expect(result.outcome).toBe('success')
+    expect(result.requests.map((request) => request.provider)).toEqual(['mock', 'mock', 'mock', 'other'])
+    expect(llmRetryEvents(agent)).toHaveLength(3)
+    expect(llmRetryEvents(agent).every((event) => event.data.mode === 'always')).toBe(true)
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data.reason).toBe('always-cap')
+  })
+})

--- a/tests/chains.spec.ts
+++ b/tests/chains.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Chain resolution unit tests (Task 2).
+ *
+ * Covers specificity ordering (exact `provider/model` → `provider/*` → role
+ * → `default`), wildcard keys and wildcard entries (keep failing model id,
+ * swap provider only), entry-level skip logic (`resolveCandidate` with
+ * `modelExists`), malformed-entry resilience, and the caller-side candidate
+ * filter (cooldown / failed-set / same-as-current / absent model id).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { CooldownStore, StepFailureSet } from '../src/cooldown.ts'
+import type { Selector } from '../src/selectors.ts'
+import {
+  createCandidateFilter,
+  resolveCandidate,
+  resolveChain,
+} from '../src/chains.ts'
+
+describe('resolveChain — specificity ordering', () => {
+  const chains = {
+    'openai/gpt-4o': ['anthropic/claude-3-5-sonnet'],
+    'openai/*': ['google/*'],
+    coder: ['mistral/*'],
+    default: ['local/*'],
+  }
+
+  it('orders candidates exact → provider/* → role → default', () => {
+    const candidates = resolveChain(chains, 'coder', 'openai', 'gpt-4o')
+    expect(candidates.map((c) => c.raw)).toEqual([
+      'anthropic/claude-3-5-sonnet', // exact key
+      'google/gpt-4o', // provider/* key, failing model kept
+      'mistral/gpt-4o', // role key
+      'local/gpt-4o', // default key
+    ])
+  })
+
+  it('keeps entry order within a key', () => {
+    const multi = { default: ['a/x', 'b/y', 'c/z'] }
+    expect(resolveChain(multi, 'coder', 'openai', 'gpt-4o').map((c) => c.raw)).toEqual([
+      'a/x',
+      'b/y',
+      'c/z',
+    ])
+  })
+
+  it('falls back to the role key when no provider-specific key exists', () => {
+    const chains = { coder: ['mistral/*'], default: ['local/*'] }
+    expect(resolveChain(chains, 'coder', 'openai', 'gpt-4o').map((c) => c.raw)).toEqual([
+      'mistral/gpt-4o',
+      'local/gpt-4o',
+    ])
+  })
+
+  it('falls back to default when no role key exists', () => {
+    const chains = { default: ['local/*'] }
+    expect(resolveChain(chains, 'coder', 'openai', 'gpt-4o').map((c) => c.raw)).toEqual([
+      'local/gpt-4o',
+    ])
+  })
+
+  it('returns an empty list when nothing matches', () => {
+    expect(resolveChain({}, 'coder', 'openai', 'gpt-4o')).toEqual([])
+  })
+
+  it('does not duplicate the default key when the role is "default"', () => {
+    const chains = { default: ['local/*'] }
+    expect(resolveChain(chains, 'default', 'openai', 'gpt-4o').map((c) => c.raw)).toEqual([
+      'local/gpt-4o',
+    ])
+  })
+})
+
+describe('resolveChain — wildcard keys and entries', () => {
+  it('matches the provider/* key for any model of that provider', () => {
+    const chains = { 'openai/*': ['anthropic/*'] }
+    for (const model of ['gpt-4o', 'gpt-4-turbo']) {
+      const candidates = resolveChain(chains, 'coder', 'openai', model)
+      expect(candidates).toHaveLength(1)
+      expect(candidates[0]).toEqual({
+        provider: 'anthropic',
+        model,
+        raw: `anthropic/${model}`,
+      })
+    }
+  })
+
+  it('does not match the provider/* key for another provider', () => {
+    const chains = { 'openai/*': ['anthropic/*'] }
+    expect(resolveChain(chains, 'coder', 'anthropic', 'claude-3-5-sonnet')).toEqual([])
+  })
+
+  it('resolves wildcard entries to concrete selectors keeping the failing model id', () => {
+    const chains = { 'openai/gpt-4o': ['anthropic/*'] }
+    expect(resolveChain(chains, 'coder', 'openai', 'gpt-4o')[0]).toEqual({
+      provider: 'anthropic',
+      model: 'gpt-4o',
+      raw: 'anthropic/gpt-4o',
+    })
+  })
+
+  it('skips malformed entries without throwing (they do not take effect)', () => {
+    const chains = { default: ['bogus', 'provider/', 'openai/gpt-4o', ''] }
+    expect(resolveChain(chains, 'coder', 'openai', 'gpt-4o').map((c) => c.raw)).toEqual([
+      'openai/gpt-4o',
+    ])
+  })
+})
+
+describe('resolveChain — filter', () => {
+  it('applies an optional caller filter to the ordered candidates', () => {
+    const chains = { default: ['a/x', 'b/y', 'c/z'] }
+    const filtered = resolveChain(chains, 'coder', 'openai', 'gpt-4o', (c) => c.provider !== 'b')
+    expect(filtered.map((c) => c.raw)).toEqual(['a/x', 'c/z'])
+  })
+})
+
+describe('resolveCandidate — wildcard skip by absent model id', () => {
+  const failing = { provider: 'openai', model: 'gpt-4o' }
+
+  it('returns the exact entry untouched, ignoring modelExists', () => {
+    const candidate = resolveCandidate('anthropic/claude-3-5-sonnet', failing, () => false)
+    expect(candidate).toEqual({ provider: 'anthropic', model: 'claude-3-5-sonnet', raw: 'anthropic/claude-3-5-sonnet' })
+  })
+
+  it('resolves a wildcard entry when the target provider has the model id', () => {
+    const candidate = resolveCandidate('anthropic/*', failing, (provider, model) => provider === 'anthropic' && model === 'gpt-4o')
+    expect(candidate).toEqual({ provider: 'anthropic', model: 'gpt-4o', raw: 'anthropic/gpt-4o' })
+  })
+
+  it('returns null when the target provider has no such model id', () => {
+    expect(resolveCandidate('anthropic/*', failing, () => false)).toBeNull()
+  })
+
+  it('resolves wildcard entries without modelExists (caller decides)', () => {
+    expect(resolveCandidate('anthropic/*', failing)).toEqual({
+      provider: 'anthropic',
+      model: 'gpt-4o',
+      raw: 'anthropic/gpt-4o',
+    })
+  })
+
+  it('returns null for malformed entries', () => {
+    expect(resolveCandidate('bogus', failing)).toBeNull()
+    expect(resolveCandidate('', failing)).toBeNull()
+  })
+})
+
+describe('createCandidateFilter — caller-side candidate filtering', () => {
+  const failing = { provider: 'openai', model: 'gpt-4o' }
+
+  function makeFilter(overrides: Partial<Parameters<typeof createCandidateFilter>[0]> = {}) {
+    const cooldown = new CooldownStore()
+    const failed = new StepFailureSet()
+    return createCandidateFilter({
+      current: failing,
+      cooldown,
+      failed,
+      modelExists: () => true,
+      ...overrides,
+    })
+  }
+
+  it('accepts a usable candidate', () => {
+    expect(makeFilter()({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(true)
+  })
+
+  it('skips a candidate equal to the current model', () => {
+    expect(makeFilter()({ provider: 'openai', model: 'gpt-4o' })).toBe(false)
+  })
+
+  it('keeps a candidate that shares only the provider with the current model', () => {
+    expect(makeFilter()({ provider: 'openai', model: 'gpt-4-turbo' })).toBe(true)
+  })
+
+  it('skips cooldown-suppressed candidates (keyed provider/model)', () => {
+    const cooldown = new CooldownStore()
+    cooldown.suppress('anthropic/claude-3-5-sonnet', Infinity)
+    const filter = makeFilter({ cooldown })
+    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(false)
+    expect(filter({ provider: 'google', model: 'gemini-1.5-pro' })).toBe(true)
+  })
+
+  it('skips candidates already failed in this step', () => {
+    const failed = new StepFailureSet()
+    failed.add('anthropic/claude-3-5-sonnet')
+    const filter = makeFilter({ failed })
+    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(false)
+    expect(filter({ provider: 'google', model: 'gemini-1.5-pro' })).toBe(true)
+  })
+
+  it('skips candidates whose model id is absent on the target provider', () => {
+    const filter = makeFilter({ modelExists: (_p, m) => m !== 'gpt-4o' })
+    expect(filter({ provider: 'anthropic', model: 'gpt-4o' })).toBe(false)
+    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(true)
+  })
+
+  it('does not require modelExists (wildcard absence decided by caller)', () => {
+    const cooldown = new CooldownStore()
+    const failed = new StepFailureSet()
+    const filter = createCandidateFilter({ current: failing, cooldown, failed })
+    const candidate: Selector = { provider: 'anthropic', model: 'gpt-4o', raw: 'anthropic/gpt-4o' }
+    expect(filter(candidate)).toBe(true)
+  })
+})

--- a/tests/chains.spec.ts
+++ b/tests/chains.spec.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest'
 import { CooldownStore, StepFailureSet } from '../src/cooldown.ts'
 import type { Selector } from '../src/selectors.ts'
 import {
+  annotateCandidates,
   createCandidateFilter,
   resolveCandidate,
   resolveChain,
@@ -162,37 +163,37 @@ describe('createCandidateFilter — caller-side candidate filtering', () => {
   }
 
   it('accepts a usable candidate', () => {
-    expect(makeFilter()({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(true)
+    expect(makeFilter()({ provider: 'anthropic', model: 'claude-3-5-sonnet', raw: 'anthropic/claude-3-5-sonnet' })).toBe(true)
   })
 
   it('skips a candidate equal to the current model', () => {
-    expect(makeFilter()({ provider: 'openai', model: 'gpt-4o' })).toBe(false)
+    expect(makeFilter()({ provider: 'openai', model: 'gpt-4o', raw: 'openai/gpt-4o' })).toBe(false)
   })
 
   it('keeps a candidate that shares only the provider with the current model', () => {
-    expect(makeFilter()({ provider: 'openai', model: 'gpt-4-turbo' })).toBe(true)
+    expect(makeFilter()({ provider: 'openai', model: 'gpt-4-turbo', raw: 'openai/gpt-4-turbo' })).toBe(true)
   })
 
   it('skips cooldown-suppressed candidates (keyed provider/model)', () => {
     const cooldown = new CooldownStore()
     cooldown.suppress('anthropic/claude-3-5-sonnet', Infinity)
     const filter = makeFilter({ cooldown })
-    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(false)
-    expect(filter({ provider: 'google', model: 'gemini-1.5-pro' })).toBe(true)
+    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet', raw: 'anthropic/claude-3-5-sonnet' })).toBe(false)
+    expect(filter({ provider: 'google', model: 'gemini-1.5-pro', raw: 'google/gemini-1.5-pro' })).toBe(true)
   })
 
   it('skips candidates already failed in this step', () => {
     const failed = new StepFailureSet()
     failed.add('anthropic/claude-3-5-sonnet')
     const filter = makeFilter({ failed })
-    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(false)
-    expect(filter({ provider: 'google', model: 'gemini-1.5-pro' })).toBe(true)
+    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet', raw: 'anthropic/claude-3-5-sonnet' })).toBe(false)
+    expect(filter({ provider: 'google', model: 'gemini-1.5-pro', raw: 'google/gemini-1.5-pro' })).toBe(true)
   })
 
   it('skips candidates whose model id is absent on the target provider', () => {
     const filter = makeFilter({ modelExists: (_p, m) => m !== 'gpt-4o' })
-    expect(filter({ provider: 'anthropic', model: 'gpt-4o' })).toBe(false)
-    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet' })).toBe(true)
+    expect(filter({ provider: 'anthropic', model: 'gpt-4o', raw: 'anthropic/gpt-4o' })).toBe(false)
+    expect(filter({ provider: 'anthropic', model: 'claude-3-5-sonnet', raw: 'anthropic/claude-3-5-sonnet' })).toBe(true)
   })
 
   it('does not require modelExists (wildcard absence decided by caller)', () => {
@@ -201,5 +202,68 @@ describe('createCandidateFilter — caller-side candidate filtering', () => {
     const filter = createCandidateFilter({ current: failing, cooldown, failed })
     const candidate: Selector = { provider: 'anthropic', model: 'gpt-4o', raw: 'anthropic/gpt-4o' }
     expect(filter(candidate)).toBe(true)
+  })
+})
+
+describe('annotateCandidates — per-candidate skip reasons (T3 review Minor 1)', () => {
+  const failing = { provider: 'openai', model: 'gpt-4o' }
+
+  function makeBase() {
+    const cooldown = new CooldownStore()
+    const failed = new StepFailureSet()
+    return {
+      options: { current: failing, cooldown, failed },
+      cooldown,
+      failed,
+    }
+  }
+
+  it('labels each skipped candidate with its concrete reason and leaves survivors unlabelled', () => {
+    const { options, cooldown, failed } = makeBase()
+    cooldown.suppress('google/gemini-1.5-pro', Infinity)
+    failed.add('anthropic/claude-3-5-sonnet')
+    const candidates: Selector[] = [
+      { provider: 'openai', model: 'gpt-4o', raw: 'openai/gpt-4o' },
+      { provider: 'google', model: 'gemini-1.5-pro', raw: 'google/gemini-1.5-pro' },
+      { provider: 'anthropic', model: 'claude-3-5-sonnet', raw: 'anthropic/claude-3-5-sonnet' },
+      { provider: 'mistral', model: 'mistral-large', raw: 'mistral/mistral-large' },
+    ]
+    const annotated = annotateCandidates(candidates, [candidates[3]!], options)
+    expect(annotated.map(({ candidate, skip }) => [candidate.raw, skip])).toEqual([
+      ['openai/gpt-4o', 'same-as-current'],
+      ['google/gemini-1.5-pro', 'cooldown'],
+      ['anthropic/claude-3-5-sonnet', 'step-failed'],
+      ['mistral/mistral-large', undefined],
+    ])
+  })
+
+  it('labels a wildcard entry dropped only by the existence probe as missing-id', () => {
+    const { options } = makeBase()
+    // The caller resolved with modelExists, so the wildcard entry whose target
+    // provider lacks the id is absent from `surviving` (exact entries are
+    // never existence-probed — T2 contract; they stay in `surviving`).
+    const candidates: Selector[] = [
+      { provider: 'anthropic', model: 'gpt-4o', raw: 'anthropic/gpt-4o' },
+      { provider: 'local', model: 'gpt-4o', raw: 'local/gpt-4o' },
+    ]
+    const annotated = annotateCandidates(candidates, [candidates[1]!], options)
+    expect(annotated[0]?.skip).toBe('missing-id')
+    expect(annotated[1]?.skip).toBeUndefined()
+  })
+
+  it('keeps the considered order and preserves duplicates', () => {
+    const { options, cooldown } = makeBase()
+    cooldown.suppress('a/x', Infinity)
+    const candidates: Selector[] = [
+      { provider: 'a', model: 'x', raw: 'a/x' },
+      { provider: 'b', model: 'y', raw: 'b/y' },
+      { provider: 'a', model: 'x', raw: 'a/x' },
+    ]
+    const annotated = annotateCandidates(candidates, [candidates[1]!], options)
+    expect(annotated.map(({ candidate, skip }) => [candidate.raw, skip])).toEqual([
+      ['a/x', 'cooldown'],
+      ['b/y', undefined],
+      ['a/x', 'cooldown'],
+    ])
   })
 })

--- a/tests/coexist-llm-retry.spec.ts
+++ b/tests/coexist-llm-retry.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Dual-plugin coexistence matrix (plan Task 4, Step 1): the llm-retry
+ * semantic double (`tests/support/llm-retry-stub.ts`) registered on the same
+ * ctx BEFORE the real fallback plugin `apply()` — the bundle composition
+ * order (`bundle/cordis.patch.yml` inserts `llm-fallbacks` after
+ * `llm-retry`).
+ *
+ * Asserts (spec §2 clause 1, §5 waterfall order, ADR-2):
+ * - retryable codes are owned by llm-retry first (`llm/retry` events appear)
+ *   until its budget is exhausted, then the fallback switches;
+ * - never-retryable codes (AUTH/QUOTA) delegate immediately and switch
+ *   directly;
+ * - `mode: 'always'` delegates downstream first (`next()`), so the fallback
+ *   passes non-triggerCode failures through and only trigger codes switch;
+ * - the reverse registration order (fallback first) is pinned as the
+ *   bundle-order risk: the fallback then owns trigger codes outright.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Context } from 'cordis'
+import { apply } from '../src/index.ts'
+import { resetSettingsStub } from './support/settings-stub.ts'
+import { installLlmRetryStub } from './support/llm-retry-stub.ts'
+import {
+  alwaysPolicy,
+  cfg,
+  dispatchRequestError,
+  llmRetryEvents,
+  makeAgent,
+  normalPolicy,
+  switchEvents,
+} from './support/harness.ts'
+
+let ctx: Context
+
+beforeEach(() => {
+  resetSettingsStub()
+  ctx = new Context()
+})
+
+afterEach(async () => {
+  await ctx.fiber.dispose()
+})
+
+describe('dual-plugin coexistence: llm-retry stub registered first (bundle order)', () => {
+  it('normal mode: llm-retry owns retryable codes until its budget is exhausted, then fallback switches', async () => {
+    const { agent } = makeAgent('coexist-normal', { provider: 'mock', model: 'gpt-4o' })
+    installLlmRetryStub(ctx)
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+    const policy = normalPolicy({ maxRetries: 2, retryableCodes: ['RATE_LIMIT', 'SERVER'] })
+
+    // Retry 1 and 2: within budget → llm-retry owns recovery (durable
+    // llm/retry events), the fallback never runs.
+    for (let retry = 1; retry <= 2; retry += 1) {
+      const action = await dispatchRequestError(ctx, agent, {
+        failure: { message: '429', code: 'RATE_LIMIT' },
+        retryPolicy: policy,
+      })
+      expect(action).toEqual({ kind: 'retry' })
+    }
+    expect(llmRetryEvents(agent)).toHaveLength(2)
+    expect(llmRetryEvents(agent).every((event) => event.data.mode === 'normal')).toBe(true)
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // Retry 3: budget exhausted → llm-retry delegates (next()) → the trigger
+    // code reaches the fallback → switch.
+    const delegated = await dispatchRequestError(ctx, agent, {
+      failure: { message: '429', code: 'RATE_LIMIT' },
+      retryPolicy: policy,
+    })
+    expect(delegated).toEqual({ kind: 'retry' })
+    expect(llmRetryEvents(agent)).toHaveLength(2)
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data.reason).toBe('trigger-code')
+    expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+  })
+
+  it('never-retryable codes (AUTH/QUOTA) bypass llm-retry and switch directly', async () => {
+    const { agent } = makeAgent('coexist-auth', { provider: 'mock', model: 'gpt-4o' })
+    installLlmRetryStub(ctx)
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+    const policy = normalPolicy({ maxRetries: 2, retryableCodes: ['RATE_LIMIT'] })
+
+    for (const code of ['AUTH', 'QUOTA'] as const) {
+      const action = await dispatchRequestError(ctx, agent, {
+        failure: { message: `${code.toLowerCase()} failure`, code },
+        retryPolicy: policy,
+      })
+      expect(action).toEqual({ kind: 'retry' })
+    }
+    // Neither code is retryable → the stub never scheduled a backoff; both
+    // failures switched directly through the fallback.
+    expect(llmRetryEvents(agent)).toHaveLength(0)
+    expect(switchEvents(agent)).toHaveLength(2)
+    expect(switchEvents(agent).every((event) => event.data.reason === 'trigger-code')).toBe(true)
+  })
+
+  it('always mode: llm-retry delegates downstream first — non-trigger failures backoff, trigger codes switch (ADR-2)', async () => {
+    const { agent } = makeAgent('coexist-always', { provider: 'mock', model: 'gpt-4o' })
+    installLlmRetryStub(ctx)
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+    const policy = alwaysPolicy()
+
+    // Non-trigger failure (SERVER): the stub calls next() first → the fallback
+    // passes it through (SERVER ∉ triggerCodes) → the stub backoffs
+    // (llm/retry, always) and owns the retry. No fallbacks/switch — the
+    // fallback did NOT preempt the always backoff.
+    const nonTrigger = await dispatchRequestError(ctx, agent, {
+      failure: { message: 'busy', code: 'SERVER' },
+      retryPolicy: policy,
+    })
+    expect(nonTrigger).toEqual({ kind: 'retry' })
+    expect(llmRetryEvents(agent)).toHaveLength(1)
+    expect(llmRetryEvents(agent)[0]?.data.mode).toBe('always')
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // Trigger code (AUTH): the stub delegates first → the fallback decides →
+    // the stub honors the downstream retry (downstream priority) — no extra
+    // llm/retry event, the switch happens.
+    const trigger = await dispatchRequestError(ctx, agent, {
+      failure: { message: 'bad key', code: 'AUTH' },
+      retryPolicy: policy,
+    })
+    expect(trigger).toEqual({ kind: 'retry' })
+    expect(llmRetryEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data.reason).toBe('trigger-code')
+  })
+
+  it('pins the reverse order: fallback registered first owns trigger codes (bundle-order risk)', async () => {
+    const { agent } = makeAgent('coexist-reversed', { provider: 'mock', model: 'gpt-4o' })
+    // Wrong composition order (the risk the patch insert position guards
+    // against): the fallback now runs before llm-retry, so a retryable trigger
+    // code reaches it first and it owns the switch — llm-retry never backoffs.
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+    installLlmRetryStub(ctx)
+    const policy = normalPolicy({ maxRetries: 2, retryableCodes: ['RATE_LIMIT', 'SERVER'] })
+
+    const action = await dispatchRequestError(ctx, agent, {
+      failure: { message: '429', code: 'RATE_LIMIT' },
+      retryPolicy: policy,
+    })
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(llmRetryEvents(agent)).toHaveLength(0)
+  })
+})

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Config schema invariants (spec §4; T2 review Minor #2 — persistent
+ * regression protection for the AC-8 no-op default).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Config, defaultFallbacksConfig, type FallbacksConfig } from '../src/config.ts'
+
+describe('fallbacks Config schema', () => {
+  it('resolves the empty section to the spec defaults (AC-8 no-op invariant)', () => {
+    // The schema call signature is typed for the resolved shape; the empty
+    // section is what the settings service / bundle row actually hands it.
+    expect(Config({} as FallbacksConfig)).toEqual(defaultFallbacksConfig)
+  })
+
+  it('layers partial input over the spec defaults', () => {
+    const resolved = Config({
+      cooldownMs: 1_000,
+      chains: { default: ['other/gpt-4o'] },
+    } as unknown as FallbacksConfig)
+    expect(resolved.cooldownMs).toBe(1_000)
+    expect(resolved.chains).toEqual({ default: ['other/gpt-4o'] })
+    expect(resolved.enabled).toBe(true)
+    expect(resolved.triggerCodes).toEqual(['AUTH', 'QUOTA', 'RATE_LIMIT'])
+  })
+})

--- a/tests/cooldown.spec.ts
+++ b/tests/cooldown.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Cooldown store + step-failure-set unit tests (Task 2).
+ *
+ * Covers lazy expiry (cooldown-expiry revert), the `revertPolicy: 'never'`
+ * infinite-TTL path, and the StepFailureSet add/has/reset contract. The
+ * switchCount / maxSwitchesPerStep judgement belongs to the caller (Task 3).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { CooldownStore, StepFailureSet } from '../src/cooldown.ts'
+
+describe('CooldownStore', () => {
+  it('reports a freshly suppressed key as suppressed', () => {
+    const store = new CooldownStore()
+    store.suppress('openai/gpt-4o', 1000)
+    expect(store.isSuppressed('openai/gpt-4o', 500)).toBe(true)
+  })
+
+  it('reverts when the cooldown expires (until <= now)', () => {
+    const store = new CooldownStore()
+    store.suppress('openai/gpt-4o', 1000)
+    expect(store.isSuppressed('openai/gpt-4o', 999)).toBe(true)
+    expect(store.isSuppressed('openai/gpt-4o', 1000)).toBe(false)
+    expect(store.isSuppressed('openai/gpt-4o', 2000)).toBe(false)
+  })
+
+  it('lazily drops expired entries on read', () => {
+    const store = new CooldownStore()
+    store.suppress('openai/gpt-4o', 1000)
+    store.suppress('anthropic/claude-3-5-sonnet', 5000)
+    expect(store.size).toBe(2)
+    store.isSuppressed('openai/gpt-4o', 2000) // expired → removed
+    expect(store.size).toBe(1)
+    expect(store.isSuppressed('anthropic/claude-3-5-sonnet', 2000)).toBe(true)
+  })
+
+  it('never reverts with an infinite TTL (revertPolicy "never")', () => {
+    const store = new CooldownStore()
+    store.suppress('openai/gpt-4o', Infinity)
+    expect(store.isSuppressed('openai/gpt-4o', 0)).toBe(true)
+    expect(store.isSuppressed('openai/gpt-4o', Date.now() + 1000 * 60 * 60 * 24 * 365)).toBe(true)
+    expect(store.isSuppressed('openai/gpt-4o', Number.MAX_SAFE_INTEGER)).toBe(true)
+  })
+
+  it('keeps keys independent of each other', () => {
+    const store = new CooldownStore()
+    store.suppress('openai/gpt-4o', 1000)
+    expect(store.isSuppressed('anthropic/claude-3-5-sonnet', 500)).toBe(false)
+  })
+
+  it('is not suppressed for unknown keys', () => {
+    const store = new CooldownStore()
+    expect(store.isSuppressed('openai/gpt-4o', Date.now())).toBe(false)
+  })
+
+  it('uses Date.now() when no explicit now is given', () => {
+    const store = new CooldownStore()
+    store.suppress('openai/gpt-4o', Date.now() + 10_000)
+    expect(store.isSuppressed('openai/gpt-4o')).toBe(true)
+  })
+})
+
+describe('StepFailureSet', () => {
+  it('adds, reports, and resets keys', () => {
+    const set = new StepFailureSet()
+    expect(set.has('openai/gpt-4o')).toBe(false)
+    set.add('openai/gpt-4o')
+    expect(set.has('openai/gpt-4o')).toBe(true)
+    expect(set.has('anthropic/claude-3-5-sonnet')).toBe(false)
+    set.reset()
+    expect(set.has('openai/gpt-4o')).toBe(false)
+  })
+
+  it('tracks its size', () => {
+    const set = new StepFailureSet()
+    set.add('a/x')
+    set.add('b/y')
+    set.add('a/x') // duplicate is idempotent
+    expect(set.size).toBe(2)
+    set.reset()
+    expect(set.size).toBe(0)
+  })
+})

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * `fallbacks/switch` event contract (plan Task 3 Step 1/6).
+ *
+ * The augmentation makes the plugin's data type the session-event-map payload
+ * for the key (the llm-retry "keeps the payload identical to the session
+ * event" assertion pattern), and the payload itself must be lossless-JSON —
+ * `Session.append` runtime-validates every event with `isJsonValue`.
+ */
+
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { SessionEventMap } from '@deepseek-ai/dsh-session'
+import { FallbacksSwitchEventData, FallbackSwitchReason } from '../src/events.ts'
+
+describe('fallbacks/switch session event', () => {
+  it('augments SessionEventMap with the exact event payload type', () => {
+    expectTypeOf<SessionEventMap['fallbacks/switch']>().toEqualTypeOf<FallbacksSwitchEventData>()
+  })
+
+  it('carries turn/step/from/to/role/reason fields', () => {
+    const data: FallbacksSwitchEventData = {
+      turn: 1,
+      step: 2,
+      from: { provider: 'mock', model: 'gpt-4o' },
+      to: { provider: 'other', model: 'gpt-4o' },
+      role: 'default',
+      reason: 'trigger-code',
+    }
+    expect(data.from).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(data.role).toBe('default')
+    expect(['trigger-code', 'always-cap']).toContain(data.reason)
+  })
+
+  it('round-trips through JSON (Session.append isJsonValue-safe)', () => {
+    const data: FallbacksSwitchEventData = {
+      turn: 7,
+      step: 3,
+      from: { provider: 'a', model: 'm1' },
+      to: { provider: 'b', model: 'm2' },
+      role: 'reviewer',
+      reason: 'always-cap',
+    }
+    expect(JSON.parse(JSON.stringify(data))).toEqual(data)
+  })
+
+  it('only admits the two spec reasons', () => {
+    const reasons: FallbackSwitchReason[] = ['trigger-code', 'always-cap']
+    expect(reasons).toHaveLength(2)
+  })
+})

--- a/tests/fallbacks-store.spec.ts
+++ b/tests/fallbacks-store.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * Client-half store unit tests (plan Task 5, Validation Plan client row).
+ *
+ * Covers the testable client surface: descriptor parsing (the redactSecrets
+ * read face — `view.value` folded against spec §4 defaults, malformed
+ * descriptors rejected), the `settings-conflict` wire-error recognition and
+ * revision extraction, the chain/rule row editors' pure round-trips, and the
+ * controller's load/save/reset lifecycle (expectedRevision writes, conflict
+ * presentation, generation guards). Component rendering has no DOM test
+ * environment here — the section's build-level validation is the client
+ * bundle (build-client) + tsc; runtime UI verification lands with T8.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { SettingsNamespaceView } from '@deepseek-ai/dsh-client-connection/client'
+import { defaultFallbacksConfig, type FallbacksConfig } from '../src/config.ts'
+import {
+  chainsToRows,
+  conflictDetailsOf,
+  FallbacksSettingsController,
+  formatEntries,
+  isSettingsConflict,
+  parseEntryLines,
+  parseFallbacksConfig,
+  rowsToChains,
+  rowsToRules,
+  rulesToRows,
+  FALLBACKS_SETTINGS_NS,
+} from '../src/client/fallbacks-store.ts'
+
+/** Build a fallbacks descriptor view with spec-default value unless overridden. */
+function viewOf(overrides: Partial<SettingsNamespaceView> = {}): SettingsNamespaceView {
+  return {
+    ns: FALLBACKS_SETTINGS_NS,
+    schema: {},
+    value: defaultFallbacksConfig,
+    applies: 'live',
+    secrets: [],
+    revision: 1,
+    ...overrides,
+  }
+}
+
+/** A settings wire face whose methods are spies. */
+function makeApi() {
+  return {
+    settings: {
+      describe: vi.fn(),
+      update: vi.fn(),
+      replace: vi.fn(),
+      mutate: vi.fn(),
+    },
+  }
+}
+
+function ok(value: unknown) {
+  return { result: { ok: true, value } }
+}
+
+function error(code: string, message: string, details?: unknown) {
+  return { result: { ok: false, error: { code, message, ...(details === undefined ? {} : { details }) } } }
+}
+
+describe('parseFallbacksConfig (descriptor read, redactSecrets face)', () => {
+  it('passes a complete config through unchanged', () => {
+    const config: FallbacksConfig = {
+      enabled: false,
+      triggerCodes: ['AUTH'],
+      chains: { default: ['openai/gpt-4o', 'openai/*'] },
+      roles: { default: 'reviewer', rules: [{ origin: 'subagent', provider: 'openai', role: 'reviewer' }] },
+      cooldownMs: 60_000,
+      revertPolicy: 'never',
+      maxSwitchesPerStep: 4,
+      alwaysModeRetryCap: 0,
+    }
+    expect(parseFallbacksConfig(config)).toEqual(config)
+  })
+
+  it('folds spec §4 defaults for missing optional fields', () => {
+    const parsed = parseFallbacksConfig({})
+    expect(parsed).toEqual(defaultFallbacksConfig)
+  })
+
+  it('drops unknown extra fields and keeps only declared keys', () => {
+    const parsed = parseFallbacksConfig({ enabled: false, extra: 'junk' })
+    expect(parsed).toEqual({ ...defaultFallbacksConfig, enabled: false })
+    expect('extra' in parsed).toBe(false)
+  })
+
+  it('rejects a non-object descriptor value', () => {
+    expect(() => parseFallbacksConfig('nope')).toThrow(TypeError)
+    expect(() => parseFallbacksConfig(null)).toThrow(TypeError)
+    expect(() => parseFallbacksConfig([])).toThrow(TypeError)
+  })
+
+  it('rejects malformed typed fields', () => {
+    expect(() => parseFallbacksConfig({ triggerCodes: 'AUTH' })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ triggerCodes: [1] })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ chains: { default: 'gpt-4o' } })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ roles: { rules: [{ provider: 'openai' }] } })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ roles: { rules: [{ origin: 'host', role: 'x' }] } })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ revertPolicy: 'sometimes' })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ cooldownMs: 'soon' })).toThrow(TypeError)
+    expect(() => parseFallbacksConfig({ enabled: 'yes' })).toThrow(TypeError)
+  })
+})
+
+describe('settings-conflict recognition', () => {
+  it('recognizes the settings-conflict wire code', () => {
+    expect(isSettingsConflict({ code: 'settings-conflict' })).toBe(true)
+    expect(isSettingsConflict({ code: 'settings-rejected' })).toBe(false)
+    expect(isSettingsConflict(null)).toBe(false)
+    expect(isSettingsConflict(undefined)).toBe(false)
+  })
+
+  it('extracts expected/actual revisions from the wire details', () => {
+    const details = conflictDetailsOf({
+      code: 'settings-conflict',
+      details: { ns: 'fallbacks', expected: 1, actual: 3 },
+    })
+    expect(details).toEqual({ expected: 1, actual: 3 })
+  })
+
+  it('returns null for non-conflict or malformed details', () => {
+    expect(conflictDetailsOf({ code: 'settings-rejected', details: {} })).toBeNull()
+    expect(conflictDetailsOf({ code: 'settings-conflict', details: {} })).toBeNull()
+  })
+})
+
+describe('chain/role row editors (pure round-trips)', () => {
+  it('splits entry textarea bodies into trimmed non-empty lines', () => {
+    expect(parseEntryLines('  openai/gpt-4o \n\nanthropic/*\n')).toEqual(['openai/gpt-4o', 'anthropic/*'])
+    expect(formatEntries(['a', 'b'])).toBe('a\nb')
+  })
+
+  it('round-trips chains through rows; empty keys drop out', () => {
+    const chains = { default: ['openai/gpt-4o', 'openai/*'], 'anthropic/*': ['anthropic/claude-3-5-sonnet'] }
+    const rows = chainsToRows(chains)
+    expect(rows).toHaveLength(2)
+    expect(rowsToChains(rows)).toEqual(chains)
+    expect(rowsToChains([...rows, { key: '   ', entries: 'openai/gpt-4o' }])).toEqual(chains)
+  })
+
+  it('round-trips role rules through rows; empty optional fields drop out', () => {
+    const rules = [
+      { origin: 'subagent' as const, provider: 'openai', model: '', role: 'reviewer' },
+      { origin: undefined, provider: undefined, model: undefined, role: 'default' },
+    ]
+    const rows = rulesToRows(rules)
+    expect(rows[0]).toEqual({ origin: 'subagent', provider: 'openai', model: '', role: 'reviewer' })
+    expect(rows[1]).toEqual({ origin: '', provider: '', model: '', role: 'default' })
+    expect(rowsToRules(rows)).toEqual([
+      { origin: 'subagent', provider: 'openai', role: 'reviewer' },
+      { role: 'default' },
+    ])
+  })
+})
+
+describe('FallbacksSettingsController', () => {
+  it('loads the descriptor into a ready state', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({
+      writable: true,
+      hasDocument: false,
+      namespaces: [viewOf({ value: { ...defaultFallbacksConfig, enabled: false }, revision: 7 })],
+    }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('ready')
+    expect(state.writable).toBe(true)
+    expect(state.revision).toBe(7)
+    expect(state.config.enabled).toBe(false)
+    expect(api.settings.describe).toHaveBeenCalledWith({})
+  })
+
+  it('reports unavailable when the namespace is missing from the descriptor', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [] }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('unavailable')
+    expect(state.writable).toBe(false)
+  })
+
+  it('surfaces a failed describe as an error state', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(error('settings-rejected', 'read refused', { ns: 'fallbacks' }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('error')
+    expect(state.error).toBe('read refused')
+    expect(state.conflict).toBeNull()
+  })
+
+  it('saves a full config via settings.update with expectedRevision', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [viewOf({ revision: 4 })] }))
+    api.settings.update.mockResolvedValue(ok(viewOf({ value: { ...defaultFallbacksConfig, cooldownMs: 99_000 }, revision: 5 })))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.save({ ...defaultFallbacksConfig, cooldownMs: 99_000 })
+    expect(api.settings.update).toHaveBeenCalledWith({
+      ns: 'fallbacks',
+      patch: { ...defaultFallbacksConfig, cooldownMs: 99_000 },
+      expectedRevision: 4,
+    })
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('ready')
+    expect(state.revision).toBe(5)
+    expect(state.config.cooldownMs).toBe(99_000)
+  })
+
+  it('presents a settings-conflict write as a conflict state with revisions', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [viewOf({ revision: 4 })] }))
+    api.settings.update.mockResolvedValue(error(
+      'settings-conflict',
+      'changed since read',
+      { ns: 'fallbacks', expected: 4, actual: 6 },
+    ))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.save(defaultFallbacksConfig)
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('error')
+    expect(state.conflict).toEqual({ expected: 4, actual: 6 })
+    expect(state.error).toBe('changed since read')
+  })
+
+  it('surfaces a non-conflict write failure without a conflict record', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [viewOf()] }))
+    api.settings.update.mockResolvedValue(error('settings-rejected', 'schema violation', { ns: 'fallbacks' }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.save(defaultFallbacksConfig)
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('error')
+    expect(state.conflict).toBeNull()
+    expect(state.error).toBe('schema violation')
+  })
+
+  it('resets to defaults via settings.replace with an empty section', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [viewOf({ revision: 2 })] }))
+    api.settings.replace.mockResolvedValue(ok(viewOf({ value: defaultFallbacksConfig, revision: 3 })))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.resetToDefaults()
+    expect(api.settings.replace).toHaveBeenCalledWith({ ns: 'fallbacks', section: {}, expectedRevision: 2 })
+    expect(controller.store.getSnapshot().revision).toBe(3)
+  })
+
+  it('refuses writes when the namespace is missing or not writable', async () => {
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: false, hasDocument: false, namespaces: [viewOf()] }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.save(defaultFallbacksConfig)
+    await controller.resetToDefaults()
+    expect(api.settings.update).not.toHaveBeenCalled()
+    expect(api.settings.replace).not.toHaveBeenCalled()
+  })
+
+  it('drops in-flight responses after dispose (generation guard)', async () => {
+    const api = makeApi()
+    let resolveDescribe: (value: unknown) => void = () => {}
+    api.settings.describe.mockReturnValue(new Promise(resolve => { resolveDescribe = resolve }))
+    const controller = new FallbacksSettingsController(api)
+    const loading = controller.load()
+    controller.dispose()
+    resolveDescribe(ok({ writable: true, hasDocument: false, namespaces: [viewOf({ revision: 9 })] }))
+    await loading
+    const state = controller.store.getSnapshot()
+    // The stale response never published: the store stays on the loading
+    // state it was left in, with the initial revision (never accepted).
+    expect(state.status).not.toBe('ready')
+    expect(state.revision).toBe(0)
+  })
+})

--- a/tests/fallbacks-store.spec.ts
+++ b/tests/fallbacks-store.spec.ts
@@ -11,9 +11,13 @@
  * bundle (build-client) + tsc; runtime UI verification lands with T8.
  */
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Context } from 'cordis'
+import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import type { SettingsNamespaceView } from '@deepseek-ai/dsh-client-connection/client'
 import { defaultFallbacksConfig, type FallbacksConfig } from '../src/config.ts'
+import { KNOWN_TRIGGER_CODES, TRIGGER_CODE_LABELS } from '../src/client/locales.ts'
+import { apply as applyClient } from '../src/client/index.ts'
 import {
   chainsToRows,
   conflictDetailsOf,
@@ -277,6 +281,64 @@ describe('FallbacksSettingsController', () => {
     const state = controller.store.getSnapshot()
     // The stale response never published: the store stays on the loading
     // state it was left in, with the initial revision (never accepted).
+    expect(state.status).not.toBe('ready')
+    expect(state.revision).toBe(0)
+  })
+})
+
+describe('known trigger codes (M-04 single source)', () => {
+  it('derives the toggle set from the host defaults', () => {
+    expect(KNOWN_TRIGGER_CODES).toEqual(defaultFallbacksConfig.triggerCodes)
+  })
+
+  it('labels every derived code', () => {
+    for (const code of KNOWN_TRIGGER_CODES) {
+      expect(TRIGGER_CODE_LABELS[code]).toBeDefined()
+    }
+  })
+})
+
+describe('client apply disposal wiring (F-006 / M-01)', () => {
+  let ctx: Context
+
+  beforeEach(() => {
+    ctx = new Context()
+  })
+
+  afterEach(async () => {
+    await ctx.fiber.dispose()
+  })
+
+  it('stops in-flight settings responses from publishing after the fiber is disposed', async () => {
+    // Locale service double: register + bind (bind returns a translate thunk).
+    ctx.provide('locale', { register: () => () => {}, bind: () => () => '' })
+    // Connection service double: a controllable settings.describe.
+    let resolveDescribe: (value: unknown) => void = () => {}
+    const describe = vi.fn(() => new Promise<unknown>(resolve => { resolveDescribe = resolve }))
+    ctx.provide('connection', {
+      api: { settings: { describe, update: vi.fn(), replace: vi.fn(), mutate: vi.fn() } },
+    })
+    // Slots service double: run the section-registration thunk and capture the
+    // injected controller — the seam apply() uses to hand the controller over.
+    let controller: FallbacksSettingsController | undefined
+    ctx.provide('slots', {
+      inject: (_name: string, thunk: () => unknown) => { thunk() },
+      register: (options: { inject: () => unknown }) => {
+        controller = (options.inject() as { controller: FallbacksSettingsController }).controller
+        return {}
+      },
+    })
+    applyClient(ctx as unknown as ClientContext)
+    expect(controller).toBeDefined()
+
+    // A load is in flight when the plugin unloads (HMR / dispose).
+    const loading = controller!.load()
+    await ctx.fiber.dispose()
+    // The response arrives after unload: the dispose wiring must bump the
+    // generation so the stale response never publishes to the dead store.
+    resolveDescribe(ok({ writable: true, hasDocument: false, namespaces: [viewOf({ revision: 9 })] }))
+    await loading
+    const state = controller!.store.getSnapshot()
     expect(state.status).not.toBe('ready')
     expect(state.revision).toBe(0)
   })

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,0 +1,334 @@
+/**
+ * End-to-end re-integration tests for the real plugin `apply()` (plan Task 4 —
+ * Task 3's "small integration" upgraded to full composition coverage).
+ *
+ * Covers, through real waterfall dispatches against a mock ctx:
+ * - the request-error → request closed loop (spec §5 table / ADR-4),
+ * - the per-agent state machine (spec §5.1): pendingSwitch apply → clear →
+ *   anti-replay, fresh-decision-supersedes, step-advance reset,
+ *   `agent/disposed` + plugin dispose no-residual (spec §6),
+ * - cooldown / revert integration (US-4): cooled-out exclusion,
+ *   `cooldown-expiry` revert to the main model, `never` no-revert,
+ * - the safety valve (spec §2 clause 4): the terminal `LlmError` keeps the
+ *   original code and message (spec §6),
+ * - the AC-8 no-op regression (unconfigured / disabled → zero events),
+ * - the composition order with a model-selection listener (T3 review ⚠️3:
+ *   the real bundle registers agent-default-model's `installModelSelection`
+ *   before this plugin — both orders must keep fallback switching intact).
+ *
+ * The dual-plugin matrix with the llm-retry semantic double lives in
+ * `tests/coexist-llm-retry.spec.ts`; the always-mode cap matrix lives in
+ * `tests/always-mode.spec.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Context } from 'cordis'
+import type { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import { apply, stateStore } from '../src/index.ts'
+import { resetSettingsStub } from './support/settings-stub.ts'
+import {
+  appendLlmRetry,
+  cfg,
+  dispatchRequest,
+  dispatchRequestError,
+  LlmError,
+  makeAgent,
+  runAgentStep,
+  switchEvents,
+} from './support/harness.ts'
+import { installModelSelectionStub, type ModelSelectionRef } from './support/model-selection-stub.ts'
+
+let ctx: Context
+
+beforeEach(() => {
+  resetSettingsStub()
+  ctx = new Context()
+})
+
+afterEach(async () => {
+  vi.useRealTimers()
+  await ctx.fiber.dispose()
+})
+
+describe('closed loop through the request boundary (real apply, ADR-4)', () => {
+  it('switches on a trigger code and continues the same step on the target model', async () => {
+    const { agent, setRoute } = makeAgent('loop-quota', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    const result = await runAgentStep(ctx, { agent, setRoute }, [
+      { message: 'quota exceeded', code: 'QUOTA' },
+      undefined,
+    ])
+    expect(result.outcome).toBe('success')
+    expect(result.requests.map((request) => request.provider)).toEqual(['mock', 'other'])
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data).toEqual({
+      turn: 1,
+      step: 1,
+      from: { provider: 'mock', model: 'gpt-4o' },
+      to: { provider: 'other', model: 'gpt-4o' },
+      role: 'default',
+      reason: 'trigger-code',
+    })
+  })
+
+  it('drops an inherited reasoningEffort when applying a switch (withoutInheritedEffort pattern)', async () => {
+    const { agent } = makeAgent('loop-effort', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent)).toEqual({ kind: 'retry' })
+    const config = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+      temperature: 0.7,
+    })
+    expect(config).toEqual({ provider: 'other', model: 'gpt-4o', temperature: 0.7 })
+  })
+})
+
+describe('per-agent state machine integration (spec §5.1)', () => {
+  it('clears the pending switch after application and never replays it at the same (turn, step)', async () => {
+    const { agent } = makeAgent('sm-replay', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent)).toEqual({ kind: 'retry' })
+    const store = stateStore(ctx)
+    expect(store?.peek(agent.id)?.pendingSwitch).toBeDefined()
+
+    const applied = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(applied).toEqual({ provider: 'other', model: 'gpt-4o' })
+    // Applied → cleared, with the (turn, step) recorded (anti-replay).
+    expect(store?.peek(agent.id)?.pendingSwitch).toBeUndefined()
+    expect(store?.peek(agent.id)?.appliedTurnStep).toEqual({ turn: 1, step: 1 })
+
+    // Same (turn, step) again: no replay — the seed passes through untouched.
+    const again = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(again).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('applies a chain decision B→C at the same (turn, step) after A→B (fresh decision supersedes)', async () => {
+    const { agent, setRoute } = makeAgent('sm-chain', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['b/x', 'c/x'] } }))
+
+    const result = await runAgentStep(ctx, { agent, setRoute }, [
+      { message: 'auth one', code: 'AUTH' },
+      { message: 'auth two', code: 'AUTH' },
+      undefined,
+    ])
+    expect(result.outcome).toBe('success')
+    expect(result.requests.map((request) => `${request.provider}/${request.model}`)).toEqual([
+      'mock/gpt-4o',
+      'b/x',
+      'c/x',
+    ])
+    expect(switchEvents(agent).map((event) => event.data.to)).toEqual([
+      { provider: 'b', model: 'x' },
+      { provider: 'c', model: 'x' },
+    ])
+  })
+
+  it('resets the failed set when the step advances (revert to main on a later step)', async () => {
+    const { agent, setRoute } = makeAgent('sm-step-reset', { provider: 'mock', model: 'gpt-4o' })
+    // cooldownMs 0: the cooldown expires immediately, isolating the failed-set
+    // reset as the deciding mechanism at the new step.
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] }, cooldownMs: 0 }))
+
+    // Step 1: mock fails → switch to other (mock is step-failed at step 1).
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 1 })).toEqual({ kind: 'retry' })
+    setRoute('other', 'gpt-4o')
+
+    // Step 2 (advanced): other fails → mock is re-eligible — syncStep reset the
+    // failed set for (1, 2) → revert to the main model.
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 2, provider: 'other' })).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[1]?.data.to).toEqual({ provider: 'mock', model: 'gpt-4o' })
+  })
+
+  it('leaves no residual state after agent/disposed and plugin dispose (spec §6)', async () => {
+    const { agent, setRoute } = makeAgent('sm-residual', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent)).toEqual({ kind: 'retry' })
+    const store = stateStore(ctx)
+    expect(store?.size).toBe(1)
+
+    // agent/disposed removes the agent's state: the cooldown no longer suppresses.
+    ctx.emit('agent/disposed', { agent })
+    expect(store?.size).toBe(0)
+    setRoute('other', 'gpt-4o')
+    expect(await dispatchRequestError(ctx, agent, { provider: 'other' })).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(2)
+
+    // Plugin dispose (the effect cleanup runs with the fiber) clears everything.
+    await ctx.fiber.dispose()
+    expect(store?.size).toBe(0)
+  })
+})
+
+describe('cooldown / revert integration (US-4)', () => {
+  it('excludes a cooled model until its cooldown expires', async () => {
+    const { agent, setRoute } = makeAgent('cooldown-cooled', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] }, cooldownMs: 60_000 }))
+
+    // mock fails → switch to other; mock is cooled for 60s.
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 1 })).toEqual({ kind: 'retry' })
+    setRoute('other', 'gpt-4o')
+
+    // Same step, other fails: mock is cooled AND step-failed → no candidate.
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 1, provider: 'other' })).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('reverts to the main model once the cooldown expires (cooldown-expiry, positive case)', async () => {
+    vi.useFakeTimers()
+    const { agent, setRoute } = makeAgent('revert-expiry', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] }, cooldownMs: 10_000 }))
+
+    // Step 1: mock fails → switch to other (mock cooled until T0 + 10s).
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 1 })).toEqual({ kind: 'retry' })
+    setRoute('other', 'gpt-4o')
+
+    // Still inside the cooldown: mock is excluded → passthrough.
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 1, provider: 'other' })).toBeUndefined()
+
+    // Cooldown expires → step 2: other fails → mock re-eligible → revert to main.
+    vi.advanceTimersByTime(10_001)
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 2, provider: 'other' })).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[1]?.data.to).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)[1]?.data.reason).toBe('trigger-code')
+  })
+
+  it('never keeps the session on the fallback (no revert within the session)', async () => {
+    const { agent, setRoute } = makeAgent('revert-never', { provider: 'mock', model: 'gpt-4o' })
+    // Even with an instantly expiring cooldown, `revertPolicy: 'never'` means
+    // Infinity TTL — mock never comes back within the session.
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] }, revertPolicy: 'never', cooldownMs: 0 }))
+
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 1 })).toEqual({ kind: 'retry' })
+    setRoute('other', 'gpt-4o')
+
+    expect(await dispatchRequestError(ctx, agent, { turn: 1, step: 2, provider: 'other' })).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+})
+
+describe('safety valve (spec §2 clause 4)', () => {
+  it('stops switching after maxSwitchesPerStep and keeps the original LlmError code/message', async () => {
+    const { agent, setRoute } = makeAgent('valve', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['b/x', 'c/x', 'd/x'] }, maxSwitchesPerStep: 2 }))
+
+    const result = await runAgentStep(ctx, { agent, setRoute }, [
+      { message: 'quota exceeded', code: 'QUOTA' },
+      { message: 'quota exceeded', code: 'QUOTA' },
+      { message: 'quota exceeded', code: 'QUOTA' },
+    ])
+    // Two switches (mock→b, b→c), then the valve trips: d/x is available but
+    // switchCount 2 ≥ maxSwitchesPerStep 2 → passthrough → terminal error.
+    expect(result.outcome).toBe('error')
+    expect(result.requests.map((request) => request.provider)).toEqual(['mock', 'b', 'c'])
+    expect(switchEvents(agent)).toHaveLength(2)
+    expect(result.error).toBeInstanceOf(LlmError)
+    expect(result.error?.code).toBe('QUOTA')
+    expect(result.error?.message).toBe('quota exceeded')
+  })
+})
+
+describe('no-op regression (AC-8)', () => {
+  it('unconfigured chains: zero events, request path unchanged', async () => {
+    const { agent } = makeAgent('noop', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg())
+
+    // Failure path: no chains → no decision → passthrough, no events.
+    expect(await dispatchRequestError(ctx, agent, { failure: { message: 'denied', code: 'AUTH' } })).toBeUndefined()
+    expect(await dispatchRequestError(ctx, agent, { failure: { message: 'no quota', code: 'QUOTA' } })).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // Request path: no pending switch, no cap → the seed passes through.
+    const seed = { provider: 'mock', model: 'gpt-4o', temperature: 0.7 }
+    expect(await dispatchRequest(ctx, agent, seed)).toEqual(seed)
+  })
+
+  it('disabled: zero events even with chains configured', async () => {
+    const { agent } = makeAgent('noop-disabled', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ enabled: false, chains: { default: ['other/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent, { failure: { message: 'denied', code: 'AUTH' } })).toBeUndefined()
+    expect(await dispatchRequestError(ctx, agent, { failure: { message: '429', code: 'RATE_LIMIT' } })).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+})
+
+describe('composition order with model-selection (T3 review ⚠️3)', () => {
+  /** The default composition: an active selection exists only when the user picked one. */
+  function noSelection(): ModelSelectionRef {
+    return { current: undefined, assembled: undefined }
+  }
+
+  it('keeps fallback switching intact when model-selection is registered first (real bundle order)', async () => {
+    const { agent } = makeAgent('ms-first', { provider: 'mock', model: 'gpt-4o' })
+    // Real bundle: agent-default-model's installModelSelection runs before the
+    // fallback plugin (bundle insert after llm-retry). With no active
+    // selection the model-selection listener passes the resolved config
+    // through, so the fallback switch must survive the composition.
+    installModelSelectionStub(ctx, noSelection())
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent)).toEqual({ kind: 'retry' })
+    const config = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+    })
+    expect(config).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('keeps the always-cap path intact under the same composition (model-selection first)', async () => {
+    const { agent } = makeAgent('ms-first-cap', { provider: 'mock', model: 'gpt-4o' })
+    installModelSelectionStub(ctx, noSelection())
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 1 }))
+
+    appendLlmRetry(agent, { turn: 1, step: 1, provider: 'mock', mode: 'always', retry: 1 })
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data.reason).toBe('always-cap')
+  })
+
+  it('keeps fallback switching intact when model-selection is registered after the plugin', async () => {
+    const { agent } = makeAgent('ms-last', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+    installModelSelectionStub(ctx, noSelection())
+
+    expect(await dispatchRequestError(ctx, agent)).toEqual({ kind: 'retry' })
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('pins the documented corner: an active selection (registered first) overrides the fallback routing', async () => {
+    const { agent } = makeAgent('ms-active', { provider: 'mock', model: 'gpt-4o' })
+    // T3 review ⚠️3: "先于本插件注册且存在活跃 selection 的 model-selection 会
+    // 最终覆写 fallback 的切换" — the real listener re-applies the assembled
+    // selection on top of the resolved config. Pin that exact semantics here so
+    // it stays explicit (this is the documented real-host composition, not a
+    // plugin defect): the switch decision is still recorded and its pending
+    // state is still applied/cleared, but the outer selection wins routing.
+    const selection: ModelSelectionRef = {
+      current: undefined,
+      assembled: { provider: 'sel', model: 'm' },
+    }
+    installModelSelectionStub(ctx, selection)
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent)).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'sel', model: 'm' })
+    // The pending switch was applied and cleared — no replay on the next request.
+    const again = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(again).toEqual({ provider: 'sel', model: 'm' })
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+})

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -234,6 +234,27 @@ describe('safety valve (spec §2 clause 4)', () => {
   })
 })
 
+describe('decision-path failure defense (F-005)', () => {
+  it('passes the original failure through when the decision path throws', async () => {
+    const { agent } = makeAgent('defensive', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    // The durable append inside commit() explodes: the request-error listener
+    // must catch, log, and delegate — the original failure semantics (spec §6)
+    // survive and no switch event is recorded.
+    const session = agent.session as unknown as { append: (type: string, data: unknown) => unknown }
+    const originalAppend = session.append
+    session.append = () => { throw new Error('append exploded') }
+    try {
+      const action = await dispatchRequestError(ctx, agent, { failure: { message: 'denied', code: 'AUTH' } })
+      expect(action).toBeUndefined()
+    } finally {
+      session.append = originalAppend
+    }
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+})
+
 describe('no-op regression (AC-8)', () => {
   it('unconfigured chains: zero events, request path unchanged', async () => {
     const { agent } = makeAgent('noop', { provider: 'mock', model: 'gpt-4o' })

--- a/tests/roles.spec.ts
+++ b/tests/roles.spec.ts
@@ -21,7 +21,7 @@ describe('resolveRole', () => {
   it('prefers the explicit agent.options.role over rules and default', () => {
     const agent: AgentLike = {
       options: { role: 'explicit-role', provider: 'openai', model: 'gpt-4o' },
-      session: { meta: { origin: 'root' } },
+      session: { header: { origin: 'root' } },
     }
     expect(resolveRole(agent, RULES, 'default')).toBe('explicit-role')
   })
@@ -29,7 +29,7 @@ describe('resolveRole', () => {
   it('matches the first rule in listed order for a subagent', () => {
     const agent: AgentLike = {
       options: { provider: 'openai', model: 'gpt-4o' },
-      session: { meta: { origin: 'subagent' } },
+      session: { header: { origin: 'subagent' } },
     }
     expect(resolveRole(agent, RULES, 'default')).toBe('code-review')
   })
@@ -44,7 +44,7 @@ describe('resolveRole', () => {
     // second ({origin:'root', provider:'openai'}) → third rule matches.
     const agent: AgentLike = {
       options: { provider: 'anthropic', model: 'claude-3-5-sonnet' },
-      session: { meta: { origin: 'root' } },
+      session: { header: { origin: 'root' } },
     }
     expect(resolveRole(agent, RULES, 'default')).toBe('anthropic-only')
   })
@@ -52,7 +52,7 @@ describe('resolveRole', () => {
   it('matches a model-only rule', () => {
     const agent: AgentLike = {
       options: { provider: 'google', model: 'gpt-4o' },
-      session: { meta: { origin: 'root' } },
+      session: { header: { origin: 'root' } },
     }
     expect(resolveRole(agent, RULES, 'default')).toBe('gpt4o-only')
   })
@@ -66,14 +66,14 @@ describe('resolveRole', () => {
   it('returns the default role when nothing matches', () => {
     const agent: AgentLike = {
       options: { provider: 'google', model: 'gemini-1.5-pro' },
-      session: { meta: { origin: 'root' } },
+      session: { header: { origin: 'root' } },
     }
     expect(resolveRole(agent, RULES, 'default')).toBe('default')
   })
 
   it('matches an unconstrained rule (catch-all) for any agent', () => {
     const rules: RoleRule[] = [{ role: 'catch-all' }]
-    const agent: AgentLike = { options: { provider: 'x', model: 'y' }, session: { meta: { origin: 'subagent' } } }
+    const agent: AgentLike = { options: { provider: 'x', model: 'y' }, session: { header: { origin: 'subagent' } } }
     expect(resolveRole(agent, rules, 'default')).toBe('catch-all')
   })
 

--- a/tests/roles.spec.ts
+++ b/tests/roles.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Role resolution unit tests (Task 2).
+ *
+ * Covers the spec §3 / ADR-3 precedence — `agent.options.role` (explicit,
+ * after the dsh patch) → first matching `roles.rules` entry (order matters)
+ * → `roles.default` — including origin / provider / model pattern matching.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { AgentLike, RoleRule } from '../src/roles.ts'
+import { resolveRole } from '../src/roles.ts'
+
+const RULES: RoleRule[] = [
+  { origin: 'subagent', role: 'code-review' },
+  { origin: 'root', provider: 'openai', role: 'root-openai' },
+  { provider: 'anthropic', role: 'anthropic-only' },
+  { model: 'gpt-4o', role: 'gpt4o-only' },
+]
+
+describe('resolveRole', () => {
+  it('prefers the explicit agent.options.role over rules and default', () => {
+    const agent: AgentLike = {
+      options: { role: 'explicit-role', provider: 'openai', model: 'gpt-4o' },
+      session: { meta: { origin: 'root' } },
+    }
+    expect(resolveRole(agent, RULES, 'default')).toBe('explicit-role')
+  })
+
+  it('matches the first rule in listed order for a subagent', () => {
+    const agent: AgentLike = {
+      options: { provider: 'openai', model: 'gpt-4o' },
+      session: { meta: { origin: 'subagent' } },
+    }
+    expect(resolveRole(agent, RULES, 'default')).toBe('code-review')
+  })
+
+  it('matches an origin+provider rule for a root agent', () => {
+    const agent: AgentLike = { options: { provider: 'openai', model: 'gpt-4o' } }
+    expect(resolveRole(agent, RULES, 'default')).toBe('root-openai')
+  })
+
+  it('matches a provider-only rule (later rule, no earlier match)', () => {
+    // origin 'root' skips the first rule; provider 'anthropic' skips the
+    // second ({origin:'root', provider:'openai'}) → third rule matches.
+    const agent: AgentLike = {
+      options: { provider: 'anthropic', model: 'claude-3-5-sonnet' },
+      session: { meta: { origin: 'root' } },
+    }
+    expect(resolveRole(agent, RULES, 'default')).toBe('anthropic-only')
+  })
+
+  it('matches a model-only rule', () => {
+    const agent: AgentLike = {
+      options: { provider: 'google', model: 'gpt-4o' },
+      session: { meta: { origin: 'root' } },
+    }
+    expect(resolveRole(agent, RULES, 'default')).toBe('gpt4o-only')
+  })
+
+  it('treats a missing origin as root (root agents carry no origin)', () => {
+    const rules: RoleRule[] = [{ origin: 'root', role: 'root-chain' }]
+    const agent: AgentLike = { options: { provider: 'openai', model: 'gpt-4o' } }
+    expect(resolveRole(agent, rules, 'default')).toBe('root-chain')
+  })
+
+  it('returns the default role when nothing matches', () => {
+    const agent: AgentLike = {
+      options: { provider: 'google', model: 'gemini-1.5-pro' },
+      session: { meta: { origin: 'root' } },
+    }
+    expect(resolveRole(agent, RULES, 'default')).toBe('default')
+  })
+
+  it('matches an unconstrained rule (catch-all) for any agent', () => {
+    const rules: RoleRule[] = [{ role: 'catch-all' }]
+    const agent: AgentLike = { options: { provider: 'x', model: 'y' }, session: { meta: { origin: 'subagent' } } }
+    expect(resolveRole(agent, rules, 'default')).toBe('catch-all')
+  })
+
+  it('respects rule order: first match wins', () => {
+    const rules: RoleRule[] = [
+      { model: 'gpt-4o', role: 'first' },
+      { model: 'gpt-4o', role: 'second' },
+    ]
+    const agent: AgentLike = { options: { model: 'gpt-4o' } }
+    expect(resolveRole(agent, rules, 'default')).toBe('first')
+  })
+
+  it('handles a completely bare agent shape', () => {
+    expect(resolveRole({}, RULES, 'fallback')).toBe('fallback')
+  })
+})

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1,0 +1,440 @@
+/**
+ * Small-integration runtime tests for the plugin `apply()` (plan Task 3
+ * Step 6): real cordis waterfall dispatch + fake agent/session, the settings
+ * seam aliased to `tests/support/settings-stub.ts`.
+ *
+ * Covers the request-error → request switch closed loop, coexistence order
+ * with an llm-retry-like listener, always-mode downstream-first delegation
+ * (ADR-2), always-cap at the request boundary, the no-op invariant (AC-8),
+ * the T2-review Important #1 decision-path contract (wildcard
+ * missing-id filtering, cooldown / step-failed exclusion), the per-step
+ * safety valve, state lifecycle cleanup, live settings re-read, and the
+ * illegal-selector warning path.
+ *
+ * The heavier coexistence/integration matrix (full llm-retry semantics, real
+ * agent loop) is Task 4 (`tests/coexist-llm-retry.spec.ts` etc.).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Context, type Logger } from 'cordis'
+import type { Agent, RequestErrorAction } from '@deepseek-ai/dsh-agent'
+import type { LlmCallConfig, LlmFailure, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { apply, normalizeChains } from '../src/index.ts'
+import { defaultFallbacksConfig, type FallbacksConfig } from '../src/config.ts'
+import { registrations, resetSettingsStub } from './support/settings-stub.ts'
+
+/** Config helper: spec defaults + overrides (the plugin re-resolves through the schema). */
+function cfg(overrides: Partial<FallbacksConfig> = {}): FallbacksConfig {
+  return { ...defaultFallbacksConfig, ...overrides }
+}
+
+/** Fake agent + session; `setRoute` simulates the loop logging a new request header after a switch. */
+function makeAgent(id: string, options: { provider?: string; model?: string } = {}) {
+  const route: { provider?: string; model?: string } = { ...options }
+  const events: Array<{ type: string; data: Record<string, unknown> }> = []
+  const agent = {
+    id,
+    options,
+    status: 'idle' as const,
+    session: {
+      id,
+      events,
+      append(type: string, data: Record<string, unknown>) {
+        events.push({ type, data })
+        return { seq: events.length, type, data }
+      },
+      requestHeader: () => (route.provider === undefined ? undefined : { config: route }),
+    },
+  }
+  return {
+    agent: agent as unknown as Agent,
+    setRoute(provider: string, model: string): void {
+      route.provider = provider
+      route.model = model
+    },
+  }
+}
+
+/** Ordered `fallbacks/switch` events on an agent's session. */
+function switchEvents(agent: Agent): SessionEvent<'fallbacks/switch'>[] {
+  return agent.session.events.filter((event) => event.type === 'fallbacks/switch') as SessionEvent<'fallbacks/switch'>[]
+}
+
+function dispatchRequestError(
+  ctx: Context,
+  agent: Agent,
+  overrides: { turn?: number; step?: number; provider?: string; failure?: LlmFailure } = {},
+): Promise<RequestErrorAction> {
+  return ctx.waterfall('agent/request-error', {
+    agent,
+    turn: overrides.turn ?? 1,
+    step: overrides.step ?? 1,
+    provider: overrides.provider ?? 'mock',
+    failure: overrides.failure ?? { message: 'boom', code: 'AUTH' },
+    retryPolicy: undefined,
+    signal: new AbortController().signal,
+  }, () => Promise.resolve(undefined))
+}
+
+function dispatchRequest(
+  ctx: Context,
+  agent: Agent,
+  seed: LlmCallConfig,
+  overrides: { turn?: number; step?: number } = {},
+): Promise<LlmCallConfig> {
+  return ctx.waterfall('agent/request', {
+    agent,
+    turn: overrides.turn ?? 1,
+    step: overrides.step ?? 1,
+    signal: new AbortController().signal,
+  }, () => Promise.resolve(seed))
+}
+
+let ctx: Context
+
+beforeEach(() => {
+  resetSettingsStub()
+  ctx = new Context()
+})
+
+afterEach(async () => {
+  await ctx.fiber.dispose()
+})
+
+describe('request-error → request switch closed loop', () => {
+  it('decides on a trigger code, records the switch, and applies it at the next request', async () => {
+    const { agent } = makeAgent('agent-loop', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data).toEqual({
+      turn: 1,
+      step: 1,
+      from: { provider: 'mock', model: 'gpt-4o' },
+      to: { provider: 'other', model: 'gpt-4o' },
+      role: 'default',
+      reason: 'trigger-code',
+    })
+
+    // Retry buildRequest: the pending switch overrides provider/model and
+    // drops any inherited reasoningEffort (installModelSelection pattern).
+    const config = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+    })
+    expect(config).toEqual({ provider: 'other', model: 'gpt-4o' })
+
+    // Applied + cleared: a later request at the same (turn, step) is untouched.
+    const again = await dispatchRequest(ctx, agent, { provider: 'other', model: 'gpt-4o' })
+    expect(again).toEqual({ provider: 'other', model: 'gpt-4o' })
+  })
+
+  it('passes through non-trigger codes (retryable codes stay with llm-retry)', async () => {
+    const { agent } = makeAgent('agent-nontrigger', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    const action = await dispatchRequestError(ctx, agent, { failure: { message: 'busy', code: 'SERVER' } })
+    expect(action).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('is a no-op without chains (AC-8 regression invariant)', async () => {
+    const { agent } = makeAgent('agent-noop', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg())
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('passes through when disabled', async () => {
+    const { agent } = makeAgent('agent-disabled', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ enabled: false, chains: { default: ['other/gpt-4o'] } }))
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+})
+
+describe('coexistence order with llm-retry (registered first)', () => {
+  it('lets llm-retry own retryable failures until its budget is exhausted', async () => {
+    const { agent } = makeAgent('agent-coexist', { provider: 'mock', model: 'gpt-4o' })
+    let budget = 1
+    ctx.on('agent/request-error', async (payload, next) => {
+      if (payload.failure.code === 'RATE_LIMIT' && budget > 0) {
+        budget -= 1
+        return { kind: 'retry' }
+      }
+      return next()
+    })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    // Retryable code within budget: llm-retry owns recovery, fallback never runs.
+    const owned = await dispatchRequestError(ctx, agent, { failure: { message: '429', code: 'RATE_LIMIT' } })
+    expect(owned).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // Budget exhausted: llm-retry delegates; the trigger code reaches fallback.
+    const delegated = await dispatchRequestError(ctx, agent, { failure: { message: '429', code: 'RATE_LIMIT' } })
+    expect(delegated).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data.reason).toBe('trigger-code')
+
+    // Never-retryable code (AUTH): llm-retry delegates immediately.
+    const auth = await dispatchRequestError(ctx, agent, { failure: { message: 'bad key', code: 'AUTH' } })
+    expect(auth).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(2)
+  })
+})
+
+describe('always mode: downstream first, cap at agent/request (ADR-2)', () => {
+  it('passes non-trigger failures through (llm-retry always backoff owns them)', async () => {
+    const { agent } = makeAgent('agent-always', { provider: 'mock', model: 'gpt-4o' })
+    ctx.on('agent/request-error', async (payload, next) => {
+      const downstream = await next()
+      if (downstream?.kind === 'retry') return downstream
+      agent.session.append('llm/retry', {
+        turn: payload.turn,
+        step: payload.step,
+        provider: payload.provider,
+        policyKey: 'always',
+        retry: 1,
+      })
+      return { kind: 'retry' }
+    })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    // Non-trigger code under always mode: fallback must NOT preempt the backoff.
+    const action = await dispatchRequestError(ctx, agent, { failure: { message: 'busy', code: 'SERVER' } })
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // Trigger code: the downstream (fallback) decision wins, llm-retry honors it.
+    const auth = await dispatchRequestError(ctx, agent, { failure: { message: 'bad key', code: 'AUTH' } })
+    expect(auth).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('switches at the request boundary once llm/retry events reach the cap', async () => {
+    const { agent } = makeAgent('agent-cap', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 5 }))
+
+    for (let retry = 1; retry <= 4; retry += 1) {
+      agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', policyKey: 'always', retry })
+    }
+    const below = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+    })
+    expect(below).toEqual({ provider: 'mock', model: 'gpt-4o', reasoningEffort: 'high' as ReasoningEffortId })
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', policyKey: 'always', retry: 5 })
+    const switched = await dispatchRequest(ctx, agent, {
+      provider: 'mock',
+      model: 'gpt-4o',
+      reasoningEffort: 'high' as ReasoningEffortId,
+    })
+    expect(switched).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(1)
+    expect(switchEvents(agent)[0]?.data).toMatchObject({
+      turn: 1,
+      step: 1,
+      from: { provider: 'mock', model: 'gpt-4o' },
+      to: { provider: 'other', model: 'gpt-4o' },
+      reason: 'always-cap',
+    })
+  })
+
+  it('counts retries scoped to (turn, step, provider)', async () => {
+    const { agent } = makeAgent('agent-cap-scope', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 3 }))
+
+    // Five retries but for a different step/provider — cap must not trip.
+    for (let retry = 1; retry <= 5; retry += 1) {
+      agent.session.append('llm/retry', { turn: 1, step: 2, provider: 'other', policyKey: 'always', retry })
+    }
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('disables the cap when alwaysModeRetryCap is 0', async () => {
+    const { agent } = makeAgent('agent-cap-zero', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 0 }))
+
+    for (let retry = 1; retry <= 5; retry += 1) {
+      agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', policyKey: 'always', retry })
+    }
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+})
+
+describe('decision-path candidate filtering (T2 review Important #1)', () => {
+  it('filters provider/* entries whose target provider lacks the failing model id', async () => {
+    ctx.provide('llm', {
+      listModels: async (provider: string) =>
+        (provider === 'other' ? [] : [{ provider, id: 'gpt-4o', name: 'gpt-4o' }]),
+    })
+    const { agent } = makeAgent('agent-wild-missing', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { 'mock/*': ['other/*'] } }))
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('resolves provider/* entries when the target provider has the model id', async () => {
+    ctx.provide('llm', {
+      listModels: async (provider: string) =>
+        (provider === 'other' ? [{ provider, id: 'gpt-4o', name: 'gpt-4o' }] : []),
+    })
+    const { agent } = makeAgent('agent-wild-present', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { 'mock/*': ['other/*'] } }))
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+  })
+
+  it('never existence-filters explicitly listed exact entries (spec §2 clause 2)', async () => {
+    ctx.provide('llm', { listModels: async () => [] })
+    const { agent } = makeAgent('agent-exact', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { 'mock/*': ['other/gpt-4o'] } }))
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+  })
+
+  it('excludes cooldown-suppressed and step-failed candidates (double suppression)', async () => {
+    const { agent, setRoute } = makeAgent('agent-suppress', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] } }))
+
+    // Failure 1: mock/gpt-4o → other/gpt-4o (mock is now cooled AND step-failed).
+    const first = await dispatchRequestError(ctx, agent)
+    expect(first).toEqual({ kind: 'retry' })
+    setRoute('other', 'gpt-4o')
+
+    // Failure 2 in the same step: mock (cooldown + failed) and other (== current)
+    // are both excluded → no candidate → passthrough, original error semantics.
+    const second = await dispatchRequestError(ctx, agent, { provider: 'other' })
+    expect(second).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('keeps cooldown suppression across a step advance (failed set resets, cooldown persists)', async () => {
+    const { agent, setRoute } = makeAgent('agent-cooldown', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] } }))
+
+    const first = await dispatchRequestError(ctx, agent)
+    expect(first).toEqual({ kind: 'retry' })
+    setRoute('other', 'gpt-4o')
+
+    // New step: the failed set reset, but mock is still in cooldown → still no
+    // switch back (revert waits for cooldown expiry — US-4).
+    const second = await dispatchRequestError(ctx, agent, { provider: 'other', step: 2 })
+    expect(second).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+
+  it('stops switching once the per-step safety valve is exceeded', async () => {
+    const { agent, setRoute } = makeAgent('agent-valve', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['b/x', 'c/x', 'd/x'] }, maxSwitchesPerStep: 2 }))
+
+    expect((await dispatchRequestError(ctx, agent))).toEqual({ kind: 'retry' })
+    setRoute('b', 'x')
+    expect((await dispatchRequestError(ctx, agent, { provider: 'b' }))).toEqual({ kind: 'retry' })
+    setRoute('c', 'x')
+    // switchCount is 2 ≥ 2 → no decision even though d/x is available.
+    const third = await dispatchRequestError(ctx, agent, { provider: 'c' })
+    expect(third).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(2)
+  })
+})
+
+describe('per-agent state lifecycle', () => {
+  it('clears state on agent/disposed (cooldown no longer suppresses)', async () => {
+    const { agent, setRoute } = makeAgent('agent-disposed', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] } }))
+
+    expect((await dispatchRequestError(ctx, agent))).toEqual({ kind: 'retry' })
+    ctx.emit('agent/disposed', { agent })
+    setRoute('other', 'gpt-4o')
+
+    // State gone: mock is no longer cooled/failed → switch back is possible.
+    const after = await dispatchRequestError(ctx, agent, { provider: 'other' })
+    expect(after).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)).toHaveLength(2)
+  })
+
+  it('prunes a pending switch on agent/status idle (defensive)', async () => {
+    const { agent } = makeAgent('agent-idle', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    expect((await dispatchRequestError(ctx, agent))).toEqual({ kind: 'retry' })
+    ctx.emit('agent/status', { agent, status: 'idle' })
+
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+  })
+})
+
+describe('settings live re-read', () => {
+  it('re-reads chains and enabled from the settings source on change', async () => {
+    const { agent } = makeAgent('agent-settings', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+    const registration = registrations[0]
+    expect(registration).toBeDefined()
+    expect(registration?.ns).toBe('fallbacks')
+
+    registration?.hooks.setSource(() => cfg({ chains: { default: ['third/x'] } }))
+    registration?.hooks.onChange()
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'third', model: 'x' })
+
+    registration?.hooks.setSource(() => cfg({ enabled: false, chains: { default: ['third/x'] } }))
+    registration?.hooks.onChange()
+
+    const disabled = await dispatchRequestError(ctx, agent)
+    expect(disabled).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(1)
+  })
+})
+
+describe('illegal selector warnings (spec §4: warn, never crash)', () => {
+  it('normalizes whitespace-padded selector keys and warns on illegal ones', () => {
+    const warns: string[] = []
+    const fakeLogger = { warn: (message: string) => warns.push(message) } as unknown as Logger
+    const normalized = normalizeChains({
+      default: ['other/gpt-4o'],
+      'openai/': ['openai/gpt-4o'],
+      'openai/ gpt-4o': ['nope', 'openai/gpt-4o'],
+    }, fakeLogger)
+    expect(normalized).toEqual({
+      default: ['other/gpt-4o'],
+      'openai/gpt-4o': ['nope', 'openai/gpt-4o'],
+    })
+    expect(warns.some((message) => message.includes('openai/'))).toBe(true)
+    expect(warns.some((message) => message.includes('nope'))).toBe(true)
+  })
+
+  it('does not crash at startup with illegal selectors and treats them as inert', async () => {
+    const { agent } = makeAgent('agent-invalid', { provider: 'mock', model: 'gpt-4o' })
+    expect(() => apply(ctx, cfg({ chains: { 'openai/': ['nope'] } }))).not.toThrow()
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+})

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -12,84 +12,27 @@
  * illegal-selector warning path.
  *
  * The heavier coexistence/integration matrix (full llm-retry semantics, real
- * agent loop) is Task 4 (`tests/coexist-llm-retry.spec.ts` etc.).
+ * agent loop) is Task 4 (`tests/plugin.spec.ts`,
+ * `tests/coexist-llm-retry.spec.ts`, `tests/always-mode.spec.ts`).
+ *
+ * The waterfall drivers / fake agent / config helper were extracted to
+ * `tests/support/harness.ts` (Task 4) and are imported here — the Task 4
+ * spec files reuse the same seam.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Context, type Logger } from 'cordis'
-import type { Agent, RequestErrorAction } from '@deepseek-ai/dsh-agent'
-import type { LlmCallConfig, LlmFailure, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import type { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { apply, countRetryEvents, normalizeChains, stateStore } from '../src/index.ts'
-import { defaultFallbacksConfig, type FallbacksConfig } from '../src/config.ts'
 import { registrations, resetSettingsStub } from './support/settings-stub.ts'
-
-/** Config helper: spec defaults + overrides (the plugin re-resolves through the schema). */
-function cfg(overrides: Partial<FallbacksConfig> = {}): FallbacksConfig {
-  return { ...defaultFallbacksConfig, ...overrides }
-}
-
-/** Fake agent + session; `setRoute` simulates the loop logging a new request header after a switch. */
-function makeAgent(id: string, options: { provider?: string; model?: string } = {}) {
-  const route: { provider?: string; model?: string } = { ...options }
-  const events: Array<{ type: string; data: Record<string, unknown> }> = []
-  const agent = {
-    id,
-    options,
-    status: 'idle' as const,
-    session: {
-      id,
-      events,
-      append(type: string, data: Record<string, unknown>) {
-        events.push({ type, data })
-        return { seq: events.length, type, data }
-      },
-      requestHeader: () => (route.provider === undefined ? undefined : { config: route }),
-    },
-  }
-  return {
-    agent: agent as unknown as Agent,
-    setRoute(provider: string, model: string): void {
-      route.provider = provider
-      route.model = model
-    },
-  }
-}
-
-/** Ordered `fallbacks/switch` events on an agent's session. */
-function switchEvents(agent: Agent): SessionEvent<'fallbacks/switch'>[] {
-  return agent.session.events.filter((event) => event.type === 'fallbacks/switch') as SessionEvent<'fallbacks/switch'>[]
-}
-
-function dispatchRequestError(
-  ctx: Context,
-  agent: Agent,
-  overrides: { turn?: number; step?: number; provider?: string; failure?: LlmFailure } = {},
-): Promise<RequestErrorAction> {
-  return ctx.waterfall('agent/request-error', {
-    agent,
-    turn: overrides.turn ?? 1,
-    step: overrides.step ?? 1,
-    provider: overrides.provider ?? 'mock',
-    failure: overrides.failure ?? { message: 'boom', code: 'AUTH' },
-    retryPolicy: undefined,
-    signal: new AbortController().signal,
-  }, () => Promise.resolve(undefined))
-}
-
-function dispatchRequest(
-  ctx: Context,
-  agent: Agent,
-  seed: LlmCallConfig,
-  overrides: { turn?: number; step?: number } = {},
-): Promise<LlmCallConfig> {
-  return ctx.waterfall('agent/request', {
-    agent,
-    turn: overrides.turn ?? 1,
-    step: overrides.step ?? 1,
-    signal: new AbortController().signal,
-  }, () => Promise.resolve(seed))
-}
+import {
+  cfg,
+  dispatchRequest,
+  dispatchRequestError,
+  makeAgent,
+  switchEvents,
+} from './support/harness.ts'
 
 let ctx: Context
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -20,7 +20,7 @@ import { Context, type Logger } from 'cordis'
 import type { Agent, RequestErrorAction } from '@deepseek-ai/dsh-agent'
 import type { LlmCallConfig, LlmFailure, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
-import { apply, normalizeChains } from '../src/index.ts'
+import { apply, countRetryEvents, normalizeChains, stateStore } from '../src/index.ts'
 import { defaultFallbacksConfig, type FallbacksConfig } from '../src/config.ts'
 import { registrations, resetSettingsStub } from './support/settings-stub.ts'
 
@@ -202,6 +202,7 @@ describe('always mode: downstream first, cap at agent/request (ADR-2)', () => {
         turn: payload.turn,
         step: payload.step,
         provider: payload.provider,
+        mode: 'always',
         policyKey: 'always',
         retry: 1,
       })
@@ -225,7 +226,7 @@ describe('always mode: downstream first, cap at agent/request (ADR-2)', () => {
     apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 5 }))
 
     for (let retry = 1; retry <= 4; retry += 1) {
-      agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', policyKey: 'always', retry })
+      agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', mode: 'always', policyKey: 'always', retry })
     }
     const below = await dispatchRequest(ctx, agent, {
       provider: 'mock',
@@ -235,7 +236,7 @@ describe('always mode: downstream first, cap at agent/request (ADR-2)', () => {
     expect(below).toEqual({ provider: 'mock', model: 'gpt-4o', reasoningEffort: 'high' as ReasoningEffortId })
     expect(switchEvents(agent)).toHaveLength(0)
 
-    agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', policyKey: 'always', retry: 5 })
+    agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', mode: 'always', policyKey: 'always', retry: 5 })
     const switched = await dispatchRequest(ctx, agent, {
       provider: 'mock',
       model: 'gpt-4o',
@@ -258,7 +259,29 @@ describe('always mode: downstream first, cap at agent/request (ADR-2)', () => {
 
     // Five retries but for a different step/provider — cap must not trip.
     for (let retry = 1; retry <= 5; retry += 1) {
-      agent.session.append('llm/retry', { turn: 1, step: 2, provider: 'other', policyKey: 'always', retry })
+      agent.session.append('llm/retry', { turn: 1, step: 2, provider: 'other', mode: 'always', policyKey: 'always', retry })
+    }
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(switchEvents(agent)).toHaveLength(0)
+  })
+
+  it('does not count normal-mode retries toward the cap (llm-retry owns them)', async () => {
+    const { agent } = makeAgent('agent-cap-normal', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 3 }))
+
+    // A normal-mode provider retrying RATE_LIMIT with maxRetries ≥ cap: those
+    // bounded retries belong to llm-retry and must not preempt-switch the
+    // fallback (spec §2 clause 5 — the cap is an always-mode mechanism).
+    for (let retry = 1; retry <= 5; retry += 1) {
+      agent.session.append('llm/retry', {
+        turn: 1,
+        step: 1,
+        provider: 'mock',
+        mode: 'normal',
+        policyKey: 'normal',
+        retry,
+      })
     }
     const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
     expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
@@ -270,7 +293,7 @@ describe('always mode: downstream first, cap at agent/request (ADR-2)', () => {
     apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 0 }))
 
     for (let retry = 1; retry <= 5; retry += 1) {
-      agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', policyKey: 'always', retry })
+      agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', mode: 'always', policyKey: 'always', retry })
     }
     const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
     expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
@@ -358,6 +381,138 @@ describe('decision-path candidate filtering (T2 review Important #1)', () => {
     const third = await dispatchRequestError(ctx, agent, { provider: 'c' })
     expect(third).toBeUndefined()
     expect(switchEvents(agent)).toHaveLength(2)
+  })
+})
+
+describe('switch log skip reasons (spec §2 行为可见性; T3 review Minor 1)', () => {
+  /** The `candidates=%o` array arg of the nth switch info log line. */
+  function switchLogCandidates(logs: Array<{ type: string; args: unknown[] }>, index: number): unknown[] {
+    const switchLogs = logs.filter((message) => message.type === 'info' && String(message.args[0]).includes('switch'))
+    const candidates = switchLogs[index]?.args.find((arg) => Array.isArray(arg))
+    return (candidates ?? []) as unknown[]
+  }
+
+  it('annotates every considered candidate with its skip reason in order', async () => {
+    const logs: Array<{ type: string; args: unknown[] }> = []
+    ctx.logger.exporter({ export: (message) => logs.push(message) })
+    const { agent, setRoute } = makeAgent('agent-log', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o', 'third/x'] } }))
+
+    // Failure 1: mock is the current model → same-as-current; other/gpt-4o wins.
+    expect((await dispatchRequestError(ctx, agent))).toEqual({ kind: 'retry' })
+    expect(switchLogCandidates(logs, 0)).toEqual([
+      'mock/gpt-4o (skipped: same-as-current)',
+      'other/gpt-4o',
+      'third/x',
+    ])
+    setRoute('other', 'gpt-4o')
+
+    // Failure 2 at other (same step): mock is cooled AND step-failed (cooldown
+    // wins precedence), other == current → third/x wins.
+    expect((await dispatchRequestError(ctx, agent, { provider: 'other' }))).toEqual({ kind: 'retry' })
+    expect(switchLogCandidates(logs, 1)).toEqual([
+      'mock/gpt-4o (skipped: cooldown)',
+      'other/gpt-4o (skipped: same-as-current)',
+      'third/x',
+    ])
+  })
+
+  it('labels wildcard entries the target provider lacks as missing-id', async () => {
+    ctx.provide('llm', {
+      listModels: async (provider: string) =>
+        (provider === 'other' ? [] : [{ provider, id: 'gpt-4o', name: 'gpt-4o' }]),
+    })
+    const logs: Array<{ type: string; args: unknown[] }> = []
+    ctx.logger.exporter({ export: (message) => logs.push(message) })
+    const { agent } = makeAgent('agent-log-missing', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { 'mock/*': ['other/*', 'local/*'] } }))
+
+    expect((await dispatchRequestError(ctx, agent))).toEqual({ kind: 'retry' })
+    expect(switchLogCandidates(logs, 0)).toEqual([
+      'other/gpt-4o (skipped: missing-id)',
+      'local/gpt-4o',
+    ])
+  })
+})
+
+describe('countRetryEvents — always-mode counting + fast path (T3 review Minor 4)', () => {
+  /** Minimal session double — `countRetryEvents` only reads `session.events`. */
+  function sessionWith(events: Array<{ type: string; data: Record<string, unknown> }>): Session {
+    return { events: events as unknown as SessionEvent[] } as Session
+  }
+
+  it('returns 0 without scanning earlier turns when the target (turn, step) has no retries', () => {
+    const events: Array<{ type: string; data: Record<string, unknown> }> = []
+    for (let step = 1; step <= 50; step += 1) {
+      events.push({ type: 'llm/retry', data: { turn: 1, step, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 } })
+    }
+    // 50 old-turn events, target (2, 1): the reverse scan breaks on the first
+    // event older than the target and returns 0.
+    expect(countRetryEvents(sessionWith(events), 2, 1, 'mock')).toBe(0)
+  })
+
+  it('counts only always-mode retries at the exact (turn, step, provider)', () => {
+    // Append-ordered log (oldest first — the session log is append-only).
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [
+      { type: 'llm/retry', data: { turn: 1, step: 9, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 } },
+      { type: 'llm/retry', data: { turn: 2, step: 3, provider: 'mock', mode: 'normal', policyKey: 'normal', retry: 1 } },
+      { type: 'llm/retry', data: { turn: 2, step: 3, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 } },
+      { type: 'llm/retry', data: { turn: 2, step: 3, provider: 'mock', mode: 'always', policyKey: 'always', retry: 2 } },
+      { type: 'llm/retry', data: { turn: 2, step: 3, provider: 'other', mode: 'always', policyKey: 'always', retry: 1 } },
+    ]
+    expect(countRetryEvents(sessionWith(events), 2, 3, 'mock')).toBe(2)
+  })
+
+  it('does not let events after the target (turn, step) leak into the count', () => {
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [
+      { type: 'llm/retry', data: { turn: 2, step: 3, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 } },
+      { type: 'llm/retry', data: { turn: 2, step: 4, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 } },
+    ]
+    expect(countRetryEvents(sessionWith(events), 2, 3, 'mock')).toBe(1)
+  })
+})
+
+describe('lazy per-agent state on agent/request (T3 review Minor 3)', () => {
+  it('keeps the store empty after a no-op request (no chains)', async () => {
+    const { agent } = makeAgent('agent-lazy-noop', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg())
+    await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(0)
+  })
+
+  it('keeps the store empty after a request while disabled', async () => {
+    const { agent } = makeAgent('agent-lazy-disabled', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ enabled: false, chains: { default: ['other/gpt-4o'] } }))
+    await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(0)
+  })
+
+  it('creates state lazily only once the always-cap path has a real switch intent', async () => {
+    const { agent } = makeAgent('agent-lazy-cap', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] }, alwaysModeRetryCap: 2 }))
+
+    // Below cap: no switch intent yet → still no state entry.
+    agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 })
+    const below = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(below).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(0)
+
+    // At cap: genuine switch intent → state created and the switch applied.
+    agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', mode: 'always', policyKey: 'always', retry: 2 })
+    const switched = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(switched).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(1)
+  })
+
+  it('applies a pending switch from request-error without growing the store', async () => {
+    const { agent } = makeAgent('agent-lazy-pending', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    expect((await dispatchRequestError(ctx, agent))).toEqual({ kind: 'retry' })
+    expect(stateStore(ctx)?.size).toBe(1)
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(1)
   })
 })
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -20,7 +20,7 @@
  * spec files reuse the same seam.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Context, type Logger } from 'cordis'
 import type { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
@@ -281,6 +281,34 @@ describe('decision-path candidate filtering (T2 review Important #1)', () => {
     expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
   })
 
+  it('does not probe the model catalog when no candidate is a wildcard (F-002)', async () => {
+    const listModels = vi.fn()
+    ctx.provide('llm', { listModels })
+    const { agent } = makeAgent('f002-exact', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['other/gpt-4o'] } }))
+
+    // Exact-entry chains only: the existence probe is pure waste on the
+    // error-recovery critical path — it must not run at all.
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(listModels).not.toHaveBeenCalled()
+  })
+
+  it('probes the catalog once per decision when a wildcard candidate exists (F-002)', async () => {
+    const listModels = vi.fn(async (provider: string) =>
+      (provider === 'other' ? [{ id: 'gpt-4o' }] : []))
+    ctx.provide('llm', { listModels })
+    const { agent } = makeAgent('f002-wild', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { 'mock/*': ['other/*'] } }))
+
+    const action = await dispatchRequestError(ctx, agent)
+    expect(action).toEqual({ kind: 'retry' })
+    expect(switchEvents(agent)[0]?.data.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+    expect(listModels).toHaveBeenCalledTimes(1)
+    expect(listModels).toHaveBeenCalledWith('other')
+  })
+
   it('excludes cooldown-suppressed and step-failed candidates (double suppression)', async () => {
     const { agent, setRoute } = makeAgent('agent-suppress', { provider: 'mock', model: 'gpt-4o' })
     apply(ctx, cfg({ chains: { default: ['mock/gpt-4o', 'other/gpt-4o'] } }))
@@ -420,6 +448,56 @@ describe('lazy per-agent state on agent/request (T3 review Minor 3)', () => {
     const { agent } = makeAgent('agent-lazy-noop', { provider: 'mock', model: 'gpt-4o' })
     apply(ctx, cfg())
     await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(0)
+  })
+
+  it('skips the always-cap session scan entirely when no chains are configured (F-001)', async () => {
+    const { agent } = makeAgent('f001-scan', { provider: 'mock', model: 'gpt-4o' })
+    // The no-op invariant promises a truly zero-cost request on an unconfigured
+    // install (AC-8). Watch for any read of the session event log during the
+    // request path: with default config (enabled + cap > 0 but chains {}) the
+    // always-cap counting must be short-circuited, not scanned per request.
+    let eventReads = 0
+    const events: Array<{ type: string; data: Record<string, unknown> }> = []
+    Object.defineProperty(agent.session, 'events', {
+      configurable: true,
+      get() {
+        eventReads += 1
+        return events
+      },
+    })
+    apply(ctx, cfg())
+    await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(eventReads).toBe(0)
+  })
+
+  it('does not create a state entry when the request-error decision yields no candidate (F-004)', async () => {
+    const { agent } = makeAgent('f004-noentry', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg())
+
+    expect(await dispatchRequestError(ctx, agent, { failure: { message: 'denied', code: 'AUTH' } })).toBeUndefined()
+    expect(stateStore(ctx)?.has(agent.id)).toBe(false)
+    expect(stateStore(ctx)?.size).toBe(0)
+  })
+
+  it('does not create a state entry when every candidate is filtered out (F-004)', async () => {
+    const { agent } = makeAgent('f004-filtered', { provider: 'mock', model: 'gpt-4o' })
+    // The only candidate equals the current model → filtered as same-as-current.
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o'] } }))
+
+    expect(await dispatchRequestError(ctx, agent)).toBeUndefined()
+    expect(stateStore(ctx)?.has(agent.id)).toBe(false)
+    expect(stateStore(ctx)?.size).toBe(0)
+  })
+
+  it('does not create a state entry when the always-cap decision yields no candidate (F-004)', async () => {
+    const { agent } = makeAgent('f004-cap', { provider: 'mock', model: 'gpt-4o' })
+    apply(ctx, cfg({ chains: { default: ['mock/gpt-4o'] }, alwaysModeRetryCap: 1 }))
+    agent.session.append('llm/retry', { turn: 1, step: 1, provider: 'mock', mode: 'always', policyKey: 'always', retry: 1 })
+
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.has(agent.id)).toBe(false)
     expect(stateStore(ctx)?.size).toBe(0)
   })
 

--- a/tests/selectors.spec.ts
+++ b/tests/selectors.spec.ts
@@ -39,6 +39,24 @@ describe('parseSelector', () => {
     })
   })
 
+  it('trims whitespace inside each segment (T2 review Minor #1)', () => {
+    expect(parseSelector('openai/ gpt-4o')).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o',
+      raw: 'openai/ gpt-4o',
+    })
+    expect(parseSelector(' openai /gpt-4o ')).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o',
+      raw: 'openai /gpt-4o',
+    })
+    expect(parseSelector('openai/ *')).toEqual({
+      provider: 'openai',
+      model: undefined,
+      raw: 'openai/ *',
+    })
+  })
+
   it('throws SelectorError on selectors without a provider/model separator', () => {
     for (const bad of ['', 'openai', '*', ' ', '  ']) {
       expect(() => parseSelector(bad), `selector ${JSON.stringify(bad)}`).toThrow(SelectorError)

--- a/tests/selectors.spec.ts
+++ b/tests/selectors.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Selector parsing unit tests (Task 2).
+ *
+ * Covers the `provider/model` and `provider/*` grammar, the wildcard-entry
+ * resolution helper, and the catchable-error path for illegal selectors
+ * (the "config warning" path — warn-and-continue lives in Task 3).
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  parseSelector,
+  resolveWildcardEntry,
+  SelectorError,
+  selectorKey,
+} from '../src/selectors.ts'
+
+describe('parseSelector', () => {
+  it('parses a concrete provider/model selector', () => {
+    expect(parseSelector('openai/gpt-4o')).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o',
+      raw: 'openai/gpt-4o',
+    })
+  })
+
+  it('parses a wildcard provider/* selector (model undefined)', () => {
+    expect(parseSelector('anthropic/*')).toEqual({
+      provider: 'anthropic',
+      model: undefined,
+      raw: 'anthropic/*',
+    })
+  })
+
+  it('trims surrounding whitespace but keeps the canonical raw string', () => {
+    expect(parseSelector('  openai/gpt-4o  ')).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o',
+      raw: 'openai/gpt-4o',
+    })
+  })
+
+  it('throws SelectorError on selectors without a provider/model separator', () => {
+    for (const bad of ['', 'openai', '*', ' ', '  ']) {
+      expect(() => parseSelector(bad), `selector ${JSON.stringify(bad)}`).toThrow(SelectorError)
+    }
+  })
+
+  it('throws SelectorError on empty provider or empty model', () => {
+    for (const bad of ['/model', 'provider/', '/*']) {
+      expect(() => parseSelector(bad), `selector ${JSON.stringify(bad)}`).toThrow(SelectorError)
+    }
+  })
+
+  it('throws SelectorError on extra separators', () => {
+    expect(() => parseSelector('provider/model/extra')).toThrow(SelectorError)
+    expect(() => parseSelector('provider/*/x')).toThrow(SelectorError)
+  })
+
+  it('exposes a catchable error type for the config-warning path', () => {
+    try {
+      parseSelector('nope')
+      expect.unreachable('parseSelector should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SelectorError)
+      expect((error as SelectorError).name).toBe('SelectorError')
+      expect((error as SelectorError).message).toContain('nope')
+    }
+  })
+})
+
+describe('selectorKey', () => {
+  it('builds the canonical concrete key', () => {
+    expect(selectorKey('openai', 'gpt-4o')).toBe('openai/gpt-4o')
+  })
+
+  it('builds the wildcard key when the model is missing', () => {
+    expect(selectorKey('openai')).toBe('openai/*')
+  })
+})
+
+describe('resolveWildcardEntry', () => {
+  it('keeps the failing model id and swaps only the provider', () => {
+    expect(resolveWildcardEntry('gpt-4o', 'anthropic')).toEqual({
+      provider: 'anthropic',
+      model: 'gpt-4o',
+      raw: 'anthropic/gpt-4o',
+    })
+  })
+})

--- a/tests/skeleton.spec.ts
+++ b/tests/skeleton.spec.ts
@@ -1,20 +1,21 @@
 /**
  * Skeleton smoke test (Task 1): keeps the declared `test` script green and
  * pins the bundle contract the later tasks build on — the plugin row id, the
- * (empty) config schema, and the client entry surface.
+ * fallbacks config schema (Task 3), and the client entry surface.
  */
 
 import { describe, expect, it } from 'vitest'
 import { apply, Config, name } from '../src/index.ts'
 import { apply as clientApply } from '../src/client/index.ts'
+import type { FallbacksConfig } from '../src/config.ts'
 
 describe('dsh-llm-fallbacks skeleton', () => {
   it('exposes the bundle patch row id', () => {
     expect(name).toBe('llm-fallbacks')
   })
 
-  it('accepts an empty config against the placeholder schema', () => {
-    expect(() => Config({})).not.toThrow()
+  it('accepts an empty config against the fallbacks schema (defaults apply)', () => {
+    expect(() => Config({} as FallbacksConfig)).not.toThrow()
   })
 
   it('exports host and client apply entries', () => {

--- a/tests/skeleton.spec.ts
+++ b/tests/skeleton.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Skeleton smoke test (Task 1): keeps the declared `test` script green and
+ * pins the bundle contract the later tasks build on — the plugin row id, the
+ * (empty) config schema, and the client entry surface.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { apply, Config, name } from '../src/index.ts'
+import { apply as clientApply } from '../src/client/index.ts'
+
+describe('dsh-llm-fallbacks skeleton', () => {
+  it('exposes the bundle patch row id', () => {
+    expect(name).toBe('llm-fallbacks')
+  })
+
+  it('accepts an empty config against the placeholder schema', () => {
+    expect(() => Config({})).not.toThrow()
+  })
+
+  it('exports host and client apply entries', () => {
+    expect(typeof apply).toBe('function')
+    expect(typeof clientApply).toBe('function')
+  })
+})

--- a/tests/state.spec.ts
+++ b/tests/state.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Per-agent fallback state machine (spec §5.1; plan Task 3 Step 5/6).
+ *
+ * Covers the contract the plugin runtime relies on: pendingSwitch
+ * produce → apply → clear, appliedTurnStep anti-replay (including chain
+ * supersession at the same (turn, step)), step-advance reset of
+ * stepFailures, cooldown lazy expiry, and disposed/idle cleanup.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { FallbackStateStore, type PendingSwitch } from '../src/state.ts'
+import { StepFailureSet } from '../src/cooldown.ts'
+
+const pending = (overrides: Partial<PendingSwitch> = {}): PendingSwitch => ({
+  from: { provider: 'mock', model: 'gpt-4o' },
+  to: { provider: 'other', model: 'gpt-4o' },
+  role: 'default',
+  reason: 'trigger-code',
+  ...overrides,
+})
+
+describe('FallbackStateStore — map lifecycle', () => {
+  it('creates an empty state on first get and reports size/has', () => {
+    const store = new FallbackStateStore()
+    expect(store.size).toBe(0)
+    expect(store.has('a')).toBe(false)
+    const state = store.get('a')
+    expect(store.has('a')).toBe(true)
+    expect(store.size).toBe(1)
+    expect(state.stepFailures).toEqual({
+      turn: 0,
+      step: 0,
+      failed: expect.any(StepFailureSet),
+      switchCount: 0,
+    })
+    expect(state.pendingSwitch).toBeUndefined()
+    expect(state.appliedTurnStep).toBeUndefined()
+  })
+
+  it('peek reads without creating', () => {
+    const store = new FallbackStateStore()
+    expect(store.peek('ghost')).toBeUndefined()
+    expect(store.size).toBe(0)
+    store.get('ghost')
+    expect(store.peek('ghost')).toBeDefined()
+  })
+
+  it('delete removes one agent and clear empties the store', () => {
+    const store = new FallbackStateStore()
+    store.get('a')
+    store.get('b')
+    store.delete('a')
+    expect(store.has('a')).toBe(false)
+    expect(store.size).toBe(1)
+    store.clear()
+    expect(store.size).toBe(0)
+  })
+})
+
+describe('FallbackStateStore — pendingSwitch lifecycle', () => {
+  it('writePending stores the decision and clears any applied marker', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.writePending(state, pending())
+    expect(state.pendingSwitch?.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+    // simulate a previously applied switch at the same (turn, step)
+    state.appliedTurnStep = { turn: 1, step: 1 }
+    store.writePending(state, pending({ to: { provider: 'third', model: 'x' } }))
+    expect(state.appliedTurnStep).toBeUndefined()
+  })
+
+  it('applyPending applies at a fresh (turn, step), records the marker, and clears the pending switch', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.writePending(state, pending())
+    const applied = store.applyPending(state, 1, 1)
+    expect(applied).toEqual(pending())
+    expect(state.pendingSwitch).toBeUndefined()
+    expect(state.appliedTurnStep).toEqual({ turn: 1, step: 1 })
+    // no pending switch remains → nothing to re-apply
+    expect(store.applyPending(state, 1, 1)).toBeUndefined()
+  })
+
+  it('applyPending refuses a switch already applied at the same (turn, step) (anti-replay)', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    state.pendingSwitch = pending()
+    state.appliedTurnStep = { turn: 1, step: 1 }
+    expect(store.applyPending(state, 1, 1)).toBeUndefined()
+    expect(state.pendingSwitch).toBeDefined()
+    // a later step applies it
+    expect(store.applyPending(state, 1, 2)?.to).toEqual({ provider: 'other', model: 'gpt-4o' })
+  })
+
+  it('a fresh decision supersedes an applied one at the same (turn, step) (chains)', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.writePending(state, pending({ to: { provider: 'b', model: 'm' } }))
+    store.applyPending(state, 1, 1)
+    // B fails again in the same step → new decision B→C must still apply
+    store.writePending(state, pending({
+      from: { provider: 'b', model: 'm' },
+      to: { provider: 'c', model: 'm' },
+    }))
+    expect(store.applyPending(state, 1, 1)?.to).toEqual({ provider: 'c', model: 'm' })
+  })
+
+  it('clearStepState drops pending + step bookkeeping but keeps the cooldown', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.syncStep(state, 1, 1)
+    store.writePending(state, pending())
+    store.suppress(state, 'mock/gpt-4o', Date.now() + 60_000)
+    store.recordFailure(state, 'mock/gpt-4o')
+    store.recordSwitch(state)
+    store.clearStepState(state)
+    expect(state.pendingSwitch).toBeUndefined()
+    expect(state.appliedTurnStep).toBeUndefined()
+    expect(state.stepFailures.failed.size).toBe(0)
+    expect(state.stepFailures.switchCount).toBe(0)
+    expect(store.isSuppressed(state, 'mock/gpt-4o')).toBe(true)
+  })
+})
+
+describe('FallbackStateStore — stepFailures', () => {
+  it('syncStep resets failed set and switch count when (turn, step) advances', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.syncStep(state, 1, 1)
+    store.recordFailure(state, 'mock/gpt-4o')
+    store.recordSwitch(state)
+    expect(state.stepFailures.failed.size).toBe(1)
+    expect(state.stepFailures.switchCount).toBe(1)
+    store.syncStep(state, 1, 2)
+    expect(state.stepFailures.failed.size).toBe(0)
+    expect(state.stepFailures.switchCount).toBe(0)
+    expect(state.stepFailures.turn).toBe(1)
+    expect(state.stepFailures.step).toBe(2)
+  })
+
+  it('syncStep is a no-op within the same (turn, step)', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.syncStep(state, 3, 5)
+    store.recordFailure(state, 'k')
+    store.recordSwitch(state)
+    store.syncStep(state, 3, 5)
+    expect(state.stepFailures.failed.size).toBe(1)
+    expect(state.stepFailures.switchCount).toBe(1)
+  })
+
+  it('tracks the failed set and the switch budget independently', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.syncStep(state, 1, 1)
+    store.recordFailure(state, 'a/x')
+    store.recordFailure(state, 'b/y')
+    store.recordSwitch(state)
+    store.recordSwitch(state)
+    expect(state.stepFailures.failed.has('a/x')).toBe(true)
+    expect(state.stepFailures.failed.has('b/y')).toBe(true)
+    expect(state.stepFailures.failed.has('c/z')).toBe(false)
+    expect(state.stepFailures.switchCount).toBe(2)
+  })
+})
+
+describe('FallbackStateStore — cooldown', () => {
+  it('suppress/isSuppressed with lazy expiry (expired entries dropped on read)', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.suppress(state, 'mock/gpt-4o', 1_000)
+    expect(store.isSuppressed(state, 'mock/gpt-4o', 999)).toBe(true)
+    expect(store.isSuppressed(state, 'mock/gpt-4o', 1_000)).toBe(false)
+    // expired entry removed on read
+    expect(store.isSuppressed(state, 'mock/gpt-4o', 2_000)).toBe(false)
+    expect(store.isSuppressed(state, 'unseen/model')).toBe(false)
+  })
+
+  it('Infinity TTL never expires within the session (revertPolicy: never)', () => {
+    const store = new FallbackStateStore()
+    const state = store.get('a')
+    store.suppress(state, 'mock/gpt-4o', Number.POSITIVE_INFINITY)
+    expect(store.isSuppressed(state, 'mock/gpt-4o', Number.MAX_SAFE_INTEGER)).toBe(true)
+  })
+})

--- a/tests/support/harness.ts
+++ b/tests/support/harness.ts
@@ -133,19 +133,34 @@ export function dispatchRequestError(
   }, () => Promise.resolve(undefined))
 }
 
-/** Drive one `agent/request` waterfall (the loop's buildRequest, spec §5 table). */
-export function dispatchRequest(
+/**
+ * Drive one `agent/request` waterfall (the loop's buildRequest, spec §5 table).
+ *
+ * M-02: mirrors the real agent loop, which folds (logs) the request header
+ * with the served route after buildRequest — the effective config returned by
+ * the waterfall is written back into the fake session's route, so
+ * `currentModel` reads the actually-served provider/model on the next
+ * `agent/request-error` without the test author hand-syncing `setRoute`.
+ * `setRoute` degrades to an explicit override for tests that route manually.
+ */
+export async function dispatchRequest(
   ctx: Context,
   agent: Agent,
   seed: LlmCallConfig,
   overrides: { turn?: number; step?: number } = {},
 ): Promise<LlmCallConfig> {
-  return ctx.waterfall('agent/request', {
+  const config = await ctx.waterfall('agent/request', {
     agent,
     turn: overrides.turn ?? 1,
     step: overrides.step ?? 1,
     signal: new AbortController().signal,
   }, () => Promise.resolve(seed))
+  const header = agent.session.requestHeader()
+  if (header !== undefined) {
+    header.config.provider = config.provider
+    header.config.model = config.model
+  }
+  return config
 }
 
 /** Provider retry policy with `mode: 'normal'` (llm-retry semantics; default retryable codes per spec §2 note). */

--- a/tests/support/harness.ts
+++ b/tests/support/harness.ts
@@ -1,0 +1,265 @@
+/**
+ * Shared integration-test harness (plan Task 4). The drivers here are
+ * extracted from Task 3's `tests/runtime.spec.ts` (real cordis waterfall
+ * dispatch + fake agent/session) and extended with a mini agent-loop driver
+ * that replays the loop's `buildRequest → stream → request-error → retry?`
+ * semantics (mirrored from `packages/core/agent-loop/src/agent.ts`: build the
+ * request through the `agent/request` waterfall, report the failure through
+ * `agent/request-error` with the serving provider, re-enter `buildRequest` on
+ * `{ kind: 'retry' }`, otherwise throw `new LlmError(failure.message,
+ * failure.code, failure)` — spec §6).
+ *
+ * The Task 4 spec files (`tests/plugin.spec.ts`, `tests/coexist-llm-retry
+ * .spec.ts`, `tests/always-mode.spec.ts`) drive the real plugin `apply()`
+ * against this harness.
+ *
+ * @module tests/support/harness
+ */
+
+import type { Context } from 'cordis'
+import type { Agent, RequestErrorAction } from '@deepseek-ai/dsh-agent'
+import type { LlmCallConfig, LlmFailure, ReasoningEffortId, ResolvedRetryPolicy } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { defaultFallbacksConfig, type FallbacksConfig } from '../../src/config.ts'
+
+/** Config helper: spec defaults + overrides (the plugin re-resolves through the schema). */
+export function cfg(overrides: Partial<FallbacksConfig> = {}): FallbacksConfig {
+  return { ...defaultFallbacksConfig, ...overrides }
+}
+
+/** Fake agent + session; `setRoute` simulates the loop logging a new request header after a switch. */
+export interface AgentHarness {
+  agent: Agent
+  setRoute(provider: string, model: string): void
+}
+
+export function makeAgent(id: string, options: { provider?: string; model?: string } = {}): AgentHarness {
+  const route: { provider?: string; model?: string } = { ...options }
+  const events: Array<{ type: string; data: Record<string, unknown> }> = []
+  const agent = {
+    id,
+    options,
+    status: 'idle' as const,
+    session: {
+      id,
+      events,
+      append(type: string, data: Record<string, unknown>) {
+        events.push({ type, data })
+        return { seq: events.length, type, data }
+      },
+      requestHeader: () => (route.provider === undefined ? undefined : { config: route }),
+    },
+  }
+  return {
+    agent: agent as unknown as Agent,
+    setRoute(provider: string, model: string): void {
+      route.provider = provider
+      route.model = model
+    },
+  }
+}
+
+/** Ordered `fallbacks/switch` events on an agent's session. */
+export function switchEvents(agent: Agent): SessionEvent<'fallbacks/switch'>[] {
+  return agent.session.events.filter((event) => event.type === 'fallbacks/switch') as SessionEvent<'fallbacks/switch'>[]
+}
+
+/** Ordered `llm/retry` events on an agent's session (the llm-retry stub's durable records). */
+export function llmRetryEvents(agent: Agent): SessionEvent<'llm/retry'>[] {
+  return agent.session.events.filter((event) => event.type === 'llm/retry') as SessionEvent<'llm/retry'>[]
+}
+
+/**
+ * Append one durable `llm/retry` event in the **real** llm-retry event shape
+ * (llm-retry `src/types.ts`: `retryId` / `turn` / `step` / `provider` /
+ * `mode` / `policyKey` / `retry` / [`maxRetries` for normal] / `delayMs` /
+ * `failure`). Task 4 uses the full shape so the always-cap counting is
+ * exercised against the real bundle's event shape (T3 fix review ⚠️2 — the
+ * `mode` discriminator must survive the real payload).
+ */
+export function appendLlmRetry(
+  agent: Agent,
+  data: {
+    turn: number
+    step: number
+    provider: string
+    mode: 'normal' | 'always'
+    retry?: number
+    policyKey?: string
+    maxRetries?: number
+    delayMs?: number
+    failure?: LlmFailure
+  },
+): void {
+  const { turn, step, provider, mode } = data
+  const retry = data.retry ?? 1
+  const policyKey = data.policyKey ?? (mode === 'always'
+    ? '["always",500,10000,0]'
+    : '["normal",2,["RATE_LIMIT"],500,10000,0]')
+  agent.session.append('llm/retry', {
+    retryId: `llm-retry:${provider}:${turn}:${step}:${retry}`,
+    turn,
+    step,
+    provider,
+    mode,
+    policyKey,
+    retry,
+    ...(mode === 'normal' && data.maxRetries !== undefined ? { maxRetries: data.maxRetries } : {}),
+    delayMs: data.delayMs ?? 500,
+    failure: data.failure ?? { message: 'busy', code: mode === 'normal' ? 'RATE_LIMIT' : 'SERVER' },
+  })
+}
+
+/** Drive one `agent/request-error` waterfall (the loop's dispatch, spec §5 table). */
+export function dispatchRequestError(
+  ctx: Context,
+  agent: Agent,
+  overrides: {
+    turn?: number
+    step?: number
+    provider?: string
+    failure?: LlmFailure
+    retryPolicy?: ResolvedRetryPolicy
+  } = {},
+): Promise<RequestErrorAction> {
+  return ctx.waterfall('agent/request-error', {
+    agent,
+    turn: overrides.turn ?? 1,
+    step: overrides.step ?? 1,
+    provider: overrides.provider ?? 'mock',
+    failure: overrides.failure ?? { message: 'boom', code: 'AUTH' },
+    retryPolicy: overrides.retryPolicy,
+    signal: new AbortController().signal,
+  }, () => Promise.resolve(undefined))
+}
+
+/** Drive one `agent/request` waterfall (the loop's buildRequest, spec §5 table). */
+export function dispatchRequest(
+  ctx: Context,
+  agent: Agent,
+  seed: LlmCallConfig,
+  overrides: { turn?: number; step?: number } = {},
+): Promise<LlmCallConfig> {
+  return ctx.waterfall('agent/request', {
+    agent,
+    turn: overrides.turn ?? 1,
+    step: overrides.step ?? 1,
+    signal: new AbortController().signal,
+  }, () => Promise.resolve(seed))
+}
+
+/** Provider retry policy with `mode: 'normal'` (llm-retry semantics; default retryable codes per spec §2 note). */
+export function normalPolicy(overrides: Partial<Omit<ResolvedRetryPolicy, 'mode'>> = {}): ResolvedRetryPolicy {
+  return {
+    mode: 'normal',
+    maxRetries: 2,
+    retryableCodes: ['EMPTY_RESPONSE', 'RATE_LIMIT', 'SERVER', 'TIMEOUT', 'TRANSPORT'],
+    initialDelayMs: 500,
+    maxDelayMs: 10_000,
+    jitterRatio: 0,
+    ...overrides,
+  }
+}
+
+/** Provider retry policy with `mode: 'always'` (unbounded retries — the cap mechanism's subject). */
+export function alwaysPolicy(overrides: Partial<Omit<ResolvedRetryPolicy, 'mode'>> = {}): ResolvedRetryPolicy {
+  return {
+    mode: 'always',
+    initialDelayMs: 500,
+    maxDelayMs: 10_000,
+    jitterRatio: 0,
+    ...overrides,
+  }
+}
+
+/**
+ * Runtime double for the declared `LlmError` surface (peer-stubs/
+ * `@deepseek-ai/dsh-llm`), mirroring the real class
+ * (`packages/llm/llm/src/index.ts`): `(message, code, options?)` with a
+ * frozen serializable `failure`. The loop constructs the terminal error as
+ * `new LlmError(failure.message, failure.code, failure)` (spec §6) — the
+ * failure object doubles as the options bag.
+ */
+export class LlmError extends Error {
+  readonly code: string
+  readonly failure: LlmFailure
+
+  constructor(
+    message: string,
+    code: string,
+    options: { status?: number; providerRetryAfterMs?: number; requestId?: string } = {},
+  ) {
+    super(message)
+    this.name = 'LlmError'
+    this.code = code
+    this.failure = Object.freeze({
+      message,
+      code,
+      ...(options.status === undefined ? {} : { status: options.status }),
+      ...(options.providerRetryAfterMs === undefined ? {} : { providerRetryAfterMs: options.providerRetryAfterMs }),
+      ...(options.requestId === undefined ? {} : { requestId: options.requestId }),
+    })
+  }
+}
+
+/** One scripted step attempt: `undefined` = the attempt succeeded. */
+export type StepAttempt = LlmFailure | undefined
+
+export interface StepResult {
+  outcome: 'success' | 'error'
+  /** Terminal `LlmError` when the step ended in error — original code/message preserved (spec §6). */
+  error?: LlmError
+  /** Request configs built per attempt (post-waterfall — reflects applied switches). */
+  requests: LlmCallConfig[]
+}
+
+export interface RunStepOptions {
+  /** Retry policy reported in every `agent/request-error` payload (the serving provider's policy). */
+  retryPolicy?: ResolvedRetryPolicy
+  /** Base config builder for each attempt; defaults to the current route. */
+  seed?: (route: { provider: string; model: string }) => LlmCallConfig
+}
+
+/**
+ * Mini agent-loop driver (mirrors `agent-loop/src/agent.ts` step()): build the
+ * request through `agent/request` (a pending switch applies here), report the
+ * scripted failure through `agent/request-error`, re-enter the build on
+ * `{ kind: 'retry' }`, and end the step with the original failure's `LlmError`
+ * on passthrough. The request header is logged (via `setRoute`) before each
+ * failure dispatch, as the real loop does.
+ */
+export async function runAgentStep(
+  ctx: Context,
+  handle: AgentHarness,
+  script: readonly StepAttempt[],
+  options: RunStepOptions = {},
+): Promise<StepResult> {
+  const { agent, setRoute } = handle
+  const route: { provider: string; model: string } = {
+    provider: agent.options.provider ?? 'mock',
+    model: agent.options.model ?? '',
+  }
+  const requests: LlmCallConfig[] = []
+  for (const failure of script) {
+    const config = await dispatchRequest(ctx, agent, options.seed ? options.seed(route) : { ...route })
+    requests.push(config)
+    // The loop logs the request header (with the served route) before dispatch.
+    setRoute(config.provider, config.model)
+    if (failure === undefined) return { outcome: 'success', requests }
+    const action = await dispatchRequestError(ctx, agent, {
+      provider: config.provider,
+      failure,
+      retryPolicy: options.retryPolicy,
+    })
+    if (action?.kind !== 'retry') {
+      return { outcome: 'error', error: new LlmError(failure.message, failure.code, failure), requests }
+    }
+  }
+  // Script exhausted with a trailing failure and no passthrough: the step ends
+  // with that failure's original error.
+  const last = script.at(-1)
+  if (last !== undefined) {
+    return { outcome: 'error', error: new LlmError(last.message, last.code, last), requests }
+  }
+  return { outcome: 'success', requests }
+}

--- a/tests/support/llm-retry-stub.ts
+++ b/tests/support/llm-retry-stub.ts
@@ -1,0 +1,125 @@
+/**
+ * In-test semantic double for `@deepseek-ai/dsh-llm-retry` (plan Task 4,
+ * Step 1 — dual-plugin coexistence). The real package is not installed here:
+ * it ships from the composed dsh app at runtime, so coexistence tests assert
+ * the contract against this double, which mirrors `llm-retry/src/index.ts`
+ * `recover()` faithfully:
+ *
+ * - `retryPolicy === undefined` → `next()` (no serving policy).
+ * - `mode: 'always'`: **downstream first** (`next()`, via `settleDownstream`),
+ *   honor a downstream `{ kind: 'retry' }`; otherwise schedule an always-mode
+ *   backoff (append `llm/retry`, return `{ kind: 'retry' }`) — ADR-2.
+ * - `mode: 'normal'`: non-retryable code → `next()`; retryable code within
+ *   the budget → schedule a normal-mode backoff; budget exhausted → `next()`.
+ *
+ * Backoffs append the real `LlmRetryEventData` shape (llm-retry types.ts) but
+ * do not actually wait — Task 4 asserts contract semantics, not timing.
+ *
+ * Register this listener BEFORE `apply(...)` of the fallback plugin to mirror
+ * the bundle composition order (`bundle/cordis.patch.yml` inserts
+ * `llm-fallbacks` after `llm-retry`).
+ *
+ * @module tests/support/llm-retry-stub
+ */
+
+import type { Context } from 'cordis'
+import type { Agent, RequestErrorAction } from '@deepseek-ai/dsh-agent'
+import type { LlmFailure, ResolvedRetryPolicy } from '@deepseek-ai/dsh-llm'
+
+/** Stable policy key mirroring llm-retry's `retryPolicyKey` (src/index.ts). */
+function policyKey(policy: ResolvedRetryPolicy): string {
+  return policy.mode === 'always'
+    ? JSON.stringify([policy.mode, policy.initialDelayMs, policy.maxDelayMs, policy.jitterRatio])
+    : JSON.stringify([
+      policy.mode,
+      policy.maxRetries,
+      [...policy.retryableCodes].sort(),
+      policy.initialDelayMs,
+      policy.maxDelayMs,
+      policy.jitterRatio,
+    ])
+}
+
+/** The last scheduled retry for (turn, step, provider, policy) — mirrors `priorPolicyRetry`. */
+function lastRetry(
+  agent: Agent,
+  turn: number,
+  step: number,
+  provider: string,
+  key: string,
+): { retry?: number; retryId?: string } | undefined {
+  const events = agent.session.events
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!
+    if (event.type !== 'llm/retry') continue
+    const data = event.data as { turn: number; step: number; provider: string; policyKey: string; retry: number; retryId: string }
+    if (data.turn === turn && data.step === step && data.provider === provider && data.policyKey === key) return data
+  }
+  return undefined
+}
+
+/** Schedule one backoff: durable `llm/retry` event in the real shape, then own the recovery. */
+function backoff(
+  agent: Agent,
+  turn: number,
+  step: number,
+  provider: string,
+  failure: LlmFailure,
+  policy: ResolvedRetryPolicy,
+  key: string,
+  retry: number,
+  retryId: string,
+): RequestErrorAction {
+  agent.session.append('llm/retry', {
+    retryId,
+    turn,
+    step,
+    provider,
+    mode: policy.mode,
+    policyKey: key,
+    retry,
+    // simplify: the stub never waits — Task 4 asserts contract semantics; the
+    // real backoff's delay/jitter math is covered by llm-retry's own suite.
+    ...(policy.mode === 'normal' && policy.maxRetries !== undefined ? { maxRetries: policy.maxRetries } : {}),
+    delayMs: policy.initialDelayMs,
+    failure,
+  })
+  return { kind: 'retry' }
+}
+
+export interface LlmRetryStubInternals {
+  /** Deterministic retry-id generator; defaults to a per-(provider,turn,step,key) counter. */
+  newRetryId?: (provider: string, turn: number, step: number, key: string, retry: number) => string
+}
+
+/**
+ * Install the llm-retry semantic double on `agent/request-error`.
+ * @returns the disposer (listeners also die with the context fiber).
+ */
+export function installLlmRetryStub(ctx: Context, internals: LlmRetryStubInternals = {}): () => void {
+  const newRetryId = internals.newRetryId
+    ?? ((provider: string, turn: number, step: number, key: string, retry: number) =>
+      `llm-retry-stub:${provider}:${turn}:${step}:${key}:${retry}`)
+  return ctx.on('agent/request-error', async (payload, next): Promise<RequestErrorAction> => {
+    const { agent, turn, step, provider, failure, retryPolicy: policy } = payload
+    if (policy === undefined) return next()
+    const key = policyKey(policy)
+    const prior = lastRetry(agent, turn, step, provider, key)
+    if (policy.mode === 'always') {
+      // Downstream first (ADR-2): settle `next()`; a downstream retry wins.
+      // A throwing downstream falls back to backoff (settleDownstream).
+      let decision: RequestErrorAction
+      try {
+        decision = await next()
+      } catch {
+        decision = undefined
+      }
+      if (decision?.kind === 'retry') return decision
+    } else {
+      if (!policy.retryableCodes.includes(failure.code)) return next()
+      if (policy.maxRetries !== undefined && (prior?.retry ?? 0) >= policy.maxRetries) return next()
+    }
+    const retry = (prior?.retry ?? 0) + 1
+    return backoff(agent, turn, step, provider, failure, policy, key, retry, newRetryId(provider, turn, step, key, retry))
+  })
+}

--- a/tests/support/model-selection-stub.ts
+++ b/tests/support/model-selection-stub.ts
@@ -1,0 +1,52 @@
+/**
+ * In-test semantic double for `installModelSelection`
+ * (`@deepseek-ai/dsh-agent/model-selection`; plan Task 4 — T3 review ⚠️3
+ * composition-order assertions). Mirrors the real listener's `agent/request`
+ * contract (packages/core/agent/src/model-selection.ts): `await next()`, then
+ * apply the assembled selection on top of the resolved config, dropping any
+ * inherited `reasoningEffort` (the `withoutInheritedEffort` pattern).
+ *
+ * The real one registers on an agent-scoped context; the double registers on
+ * the shared test context — waterfall registration order is exactly what the
+ * composition tests assert, so the shared context is the right seam.
+ *
+ * @module tests/support/model-selection-stub
+ */
+
+import type { Context } from 'cordis'
+import type { LlmCallConfig, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+
+/** Complete provider, model, and optional reasoning effort selected for one live Agent. */
+export interface ModelSelection {
+  provider: string
+  model: string
+  reasoningEffort?: ReasoningEffortId
+}
+
+/** Mutable model selection plus the value captured for the current step. */
+export interface ModelSelectionRef {
+  /** Model selected for the next step that enters prompt assembly. */
+  current: ModelSelection | undefined
+  /** Selection captured when the current step entered prompt assembly. */
+  assembled: ModelSelection | undefined
+}
+
+/**
+ * Install the model-selection double: an `agent/request` listener that applies
+ * `selection.assembled` on top of the resolved config when one exists.
+ * @returns the disposer (listeners also die with the context fiber).
+ */
+export function installModelSelectionStub(ctx: Context, selection: ModelSelectionRef): () => void {
+  return ctx.on('agent/request', async (_payload, next): Promise<LlmCallConfig> => {
+    const resolved = await next()
+    const selected = selection.assembled
+    if (selected === undefined) return resolved
+    const { reasoningEffort: _inheritedEffort, ...withoutInheritedEffort } = resolved
+    return {
+      ...withoutInheritedEffort,
+      provider: selected.provider,
+      model: selected.model,
+      ...(selected.reasoningEffort === undefined ? {} : { reasoningEffort: selected.reasoningEffort }),
+    }
+  })
+}

--- a/tests/support/runtime-stub.ts
+++ b/tests/support/runtime-stub.ts
@@ -1,0 +1,38 @@
+/**
+ * Instrumented double for the `@deepseek-ai/dsh-client-runtime/client` runtime
+ * seam (vitest `resolve.alias`, see `vitest.config.ts` and
+ * pm-note-type-access.md).
+ *
+ * The client half consumes exactly one runtime VALUE export:
+ * `createSnapshotStore` (the store engine the fallbacks controller's snapshot
+ * rides). This double mirrors the `SnapshotStore` contract (getSnapshot /
+ * subscribe / update / set); notifications are synchronous (the real engine
+ * microtask-batches — tests read the snapshot after awaiting the controller
+ * call, so the difference is invisible).
+ */
+import type { ObservableSnapshot, SnapshotStore } from '@deepseek-ai/dsh-client-runtime/client'
+
+export type { ObservableSnapshot, SnapshotStore }
+
+/** Minimal snapshot store: immer-free draft updates over a JSON clone. */
+export function createSnapshotStore<T>(init: T): SnapshotStore<T> {
+  let state = init
+  const listeners = new Set<() => void>()
+  return {
+    getSnapshot: () => state,
+    subscribe: (fn: () => void) => {
+      listeners.add(fn)
+      return () => { listeners.delete(fn) }
+    },
+    update: (mutator) => {
+      const next = JSON.parse(JSON.stringify(state)) as T
+      mutator(next)
+      state = next
+      for (const fn of [...listeners]) fn()
+    },
+    set: (next) => {
+      state = next
+      for (const fn of [...listeners]) fn()
+    },
+  }
+}

--- a/tests/support/settings-stub.ts
+++ b/tests/support/settings-stub.ts
@@ -1,0 +1,59 @@
+/**
+ * Instrumented double for the `@deepseek-ai/dsh-settings` runtime seam
+ * (vitest `resolve.alias`, see `vitest.config.ts` and pm-note-type-access.md).
+ *
+ * The plugin consumes exactly two exports:
+ * - `installSettingsSection(ctx, ns, schema, entry, hooks)` — the real
+ *   implementation registers a namespace with the settings service and wires
+ *   `setSource` / `onChange`. This double records every registration and
+ *   simulates a mounted service: the source resolves the composition entry
+ *   and `onChange` runs once at attach (startup selector validation).
+ * - `settingsNamespace(value)` — plain identity (the real one validates the
+ *   kebab-case pattern; `'fallbacks'` passes either way).
+ *
+ * Tests drive settings changes through the recorded `hooks.setSource` /
+ * `hooks.onChange` to prove the runtime re-reads live config.
+ */
+import type { Context } from 'cordis'
+
+/** Mirrors the peer-stub surface the plugin type-checks against. */
+export interface SettingsSectionHooks<T> {
+  setSource(current: () => T): void
+  onChange(): void
+  validate?: (value: T) => void
+}
+
+/** One recorded `installSettingsSection` invocation. */
+export interface SettingsRegistration<T = unknown> {
+  ctx: Context
+  ns: string
+  schema: unknown
+  entry: T
+  hooks: SettingsSectionHooks<T>
+}
+
+/** Registrations in attach order; reset per test. */
+export const registrations: SettingsRegistration<any>[] = []
+
+/** Plain identity stand-in for the branded namespace helper. */
+export function settingsNamespace(value: string): string {
+  return value
+}
+
+/** Record the registration and simulate a mounted settings service. */
+export function installSettingsSection<T>(
+  ctx: Context,
+  ns: string,
+  schema: unknown,
+  entry: T,
+  hooks: SettingsSectionHooks<T>,
+): void {
+  registrations.push({ ctx, ns, schema, entry, hooks })
+  hooks.setSource(() => entry)
+  hooks.onChange()
+}
+
+/** Clear recorded registrations between tests. */
+export function resetSettingsStub(): void {
+  registrations.length = 0
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,14 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "paths": {
+      "@deepseek-ai/dsh-agent": ["./peer-stubs/@deepseek-ai/dsh-agent/index.d.ts"],
+      "@deepseek-ai/dsh-llm": ["./peer-stubs/@deepseek-ai/dsh-llm/index.d.ts"],
+      "@deepseek-ai/dsh-settings": ["./peer-stubs/@deepseek-ai/dsh-settings/index.d.ts"],
+      "@deepseek-ai/dsh-session": ["./peer-stubs/@deepseek-ai/dsh-session/index.d.ts"],
+      "@deepseek-ai/dsh-session/types": ["./peer-stubs/@deepseek-ai/dsh-session/types.d.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "jsx": "react-jsx",
     "skipLibCheck": true,
-    "types": ["bun-types"],
+    "types": ["bun-types", "react"],
     "declaration": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
@@ -17,7 +17,15 @@
       "@deepseek-ai/dsh-llm": ["./peer-stubs/@deepseek-ai/dsh-llm/index.d.ts"],
       "@deepseek-ai/dsh-settings": ["./peer-stubs/@deepseek-ai/dsh-settings/index.d.ts"],
       "@deepseek-ai/dsh-session": ["./peer-stubs/@deepseek-ai/dsh-session/index.d.ts"],
-      "@deepseek-ai/dsh-session/types": ["./peer-stubs/@deepseek-ai/dsh-session/types.d.ts"]
+      "@deepseek-ai/dsh-session/types": ["./peer-stubs/@deepseek-ai/dsh-session/types.d.ts"],
+      "@deepseek-ai/dsh-client-ui-slots": ["./peer-stubs/@deepseek-ai/dsh-client-ui-slots/index.d.ts"],
+      "@deepseek-ai/dsh-client-ui-settings/client": ["./peer-stubs/@deepseek-ai/dsh-client-ui-settings/client.d.ts"],
+      "@deepseek-ai/dsh-client-runtime": ["./peer-stubs/@deepseek-ai/dsh-client-runtime/index.d.ts"],
+      "@deepseek-ai/dsh-client-runtime/client": ["./peer-stubs/@deepseek-ai/dsh-client-runtime/client.d.ts"],
+      "@deepseek-ai/dsh-client-locale": ["./peer-stubs/@deepseek-ai/dsh-client-locale/index.d.ts"],
+      "@deepseek-ai/dsh-client-locale/client": ["./peer-stubs/@deepseek-ai/dsh-client-locale/client.d.ts"],
+      "@deepseek-ai/dsh-client-connection": ["./peer-stubs/@deepseek-ai/dsh-client-connection/index.d.ts"],
+      "@deepseek-ai/dsh-client-connection/client": ["./peer-stubs/@deepseek-ai/dsh-client-connection/client.d.ts"]
     }
   },
   "include": ["src"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,14 @@
 /**
  * Vitest configuration (plan Global Constraints; pm-note-type-access.md).
  *
- * The plugin's only runtime `@deepseek-ai/*` import is
- * `@deepseek-ai/dsh-settings` (bun build keeps it external for the host to
- * resolve in-box); every other `@deepseek-ai/*` import is type-only and is
- * erased by the transform. Tests therefore alias just the settings seam to an
- * instrumented double. Type-level access flows through `peer-stubs/` +
- * tsconfig `paths` (skipLibCheck, so stub completeness is not enforced).
+ * The plugin's only runtime `@deepseek-ai/*` imports are
+ * `@deepseek-ai/dsh-settings` (host half) and
+ * `@deepseek-ai/dsh-client-runtime/client` (client half, the snapshot-store
+ * engine); bun keeps both external for the host to resolve in-box. Every
+ * other `@deepseek-ai/*` import is type-only and is erased by the transform.
+ * Tests therefore alias just those two seams to instrumented doubles.
+ * Type-level access flows through `peer-stubs/` + tsconfig `paths`
+ * (skipLibCheck, so stub completeness is not enforced).
  */
 import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
@@ -15,6 +17,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@deepseek-ai/dsh-settings': resolve(import.meta.dirname, 'tests/support/settings-stub.ts'),
+      '@deepseek-ai/dsh-client-runtime/client': resolve(import.meta.dirname, 'tests/support/runtime-stub.ts'),
     },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+/**
+ * Vitest configuration (plan Global Constraints; pm-note-type-access.md).
+ *
+ * The plugin's only runtime `@deepseek-ai/*` import is
+ * `@deepseek-ai/dsh-settings` (bun build keeps it external for the host to
+ * resolve in-box); every other `@deepseek-ai/*` import is type-only and is
+ * erased by the transform. Tests therefore alias just the settings seam to an
+ * instrumented double. Type-level access flows through `peer-stubs/` +
+ * tsconfig `paths` (skipLibCheck, so stub completeness is not enforced).
+ */
+import { resolve } from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@deepseek-ai/dsh-settings': resolve(import.meta.dirname, 'tests/support/settings-stub.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## 迭代 iter-20260810-llm-fallbacks 交付

把 omp 的 llm-fallbacks（`retry.modelFallback` + `retry.fallbackChains`）语义移植为 dsh 的 cordis 插件 **dsh-llm-fallbacks**：任意 root agent / subagent 在模型请求持续失败（重试耗尽、AUTH、配额、限流 429）时，按「exact `provider/model` → `provider/*` → 角色链 → `default`」链自动切换 provider/model，当前 step/turn 在目标模型上继续完成。

### 交付物
- **host 半**：`agent/request-error`（决策，llm-retry 委托/耗尽后介入）+ `agent/request`（应用切换）双 waterfall；每-agent 状态机（pendingSwitch/stepFailures/cooldown/appliedTurnStep）；冷却与 revert policy；`maxSwitchesPerStep` 安全阀；`mode:'always'` 重试 cap（ADR-2）；持久化 `fallbacks/switch` 事件。
- **settings 命名空间 `fallbacks`**：enabled / triggerCodes（默认 `['AUTH','QUOTA','RATE_LIMIT']`）/ chains / roles（default + rules）/ cooldownMs / revertPolicy / maxSwitchesPerStep / alwaysModeRetryCap。
- **web 设置页**（client 半）：`settings.section` slot id=`fallbacks`，zh/en 双语，冲突/恢复默认处理。
- **dsh 本体 role patch**：`patches/`（pnpm 格式）+ apply/revert/verify 脚本，为 subagent 提供显式 `agent.options.role` 来源。
- **知识沉淀**：3 篇 knowledge 文档 + CONCEPTS.md（详见 `.mstar/knowledge/`）。
- **测试**：163 用例全绿（单测 + 双插件共存 + always-cap + 状态机 + client store）；QC tri Approve；QA Accept。

### 已知限制（open residuals，next iteration）
- R1：设置页只读状态（最近切换摘要/当前生效模型）为占位——依赖 client 会话事件读取面决策。
- R2：活跃 model-selection 会最终覆写 fallback 路由——协调 seam 需 dsh 核心决策。

### 用户待执行（沙箱外）
真实 profile 装入（`dsh plugin --profile web add .`）、GUI 设置页验证、失败注入验证、`scripts/apply-dsh-patch.sh` 应用——步骤见 `docs/verification.md`。