### PR TITLE
feat: auto-apply dsh role patches on plugin install (autopatch)

### DIFF
--- a/docs/dsh-patch.md
+++ b/docs/dsh-patch.md
@@ -1,6 +1,6 @@
 # dsh 本体 role patch 指南
 
-`dsh-llm-fallbacks` 的角色解析以 `agent.options.role`（显式角色）为最高优先级来源（`options.role` → `roles.rules` → `roles.default`，见 [docs/configuration.md](docs/configuration.md)）。dsh 本体目前没有该字段，本仓库在 `patches/` 交付两个最小 git patch + 配套脚本（`scripts/apply-dsh-patch.sh` / `revert-dsh-patch.sh` / `verify-dsh-patch.sh`），把改动应用到**本机的 dsh 源码树**（本仓库不携带 dsh 源码）。
+`dsh-llm-fallbacks` 的角色解析以 `agent.options.role`（显式角色）为最高优先级来源（`options.role` → `roles.rules` → `roles.default`，见 [docs/configuration.md](docs/configuration.md)）。dsh 本体目前没有该字段，本仓库在 `patches/` 交付两个最小 git patch + 配套脚本（`scripts/apply-dsh-patch.sh` / `revert-dsh-patch.sh` / `verify-dsh-patch.sh` / `autopatch-install.sh`），把改动应用到**本机的 dsh 源码树**（本仓库不携带 dsh 源码）。`autopatch-install.sh` 在插件安装生命周期自动应用（见下文「自动应用」），其余脚本供手动应用 / 回滚 / 验证。
 
 ## 动机：subagent 显式角色
 
@@ -48,6 +48,19 @@ scripts/verify-dsh-patch.sh --absent
 - **`--check` 优先**：应用/回滚前先用 `--check` 确认目标树状态，零副作用。
 - **构建步骤**：`apply`/`revert` 会重建受影响包（`pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent` + `pnpm exec tsdown --env.DSH_BUILD_FACE host`）。目标树无 pnpm 环境时脚本明确提示并跳过构建、退出非 0（此时可 `--skip-build` 应用后手动构建）。
 - **验证探针**：agent 检查 `src/runtime-types.ts` 与构建产物 `lib/types/runtime-types.d.ts` 含 `role?: string`；tool-subagent 检查 `src/index.ts` 与构建产物 `lib/types/index.js` 含 `role: z.string()`（探针布局与真实构建产物一致，缺失记为 SKIP）。
+
+## 自动应用（安装期）
+
+插件在安装生命周期自动检测目标 dsh 源码树并**幂等应用**这两个 patch（脚本 `scripts/autopatch-install.sh`，与 `apply-dsh-patch.sh` 同构的三态判定：可应用 → apply；已应用 → skip；冲突 → warn），无需手动执行 `apply-dsh-patch.sh`：
+
+- **触发时机**：
+  - `postinstall`：插件作为依赖被安装时（git / tarball 安装）。pnpm ≥ 10 默认不执行依赖的构建脚本，需放行后才触发（见 [docs/install.md](docs/install.md) 的 allowBuilds 说明）；
+  - `prepare`：git 安装（pnpm 在克隆后构建）以及在本仓库目录执行 `pnpm install` 时；
+  - **本地 link 安装（`dsh plugin --profile <name> add .`）不触发生命周期脚本**（pnpm 对 `link:` 依赖不运行 prepare/postinstall，已实证）——此类安装后请手动执行一次 `bash scripts/autopatch-install.sh`（幂等，已应用则跳过）。
+- **开关**：环境变量 `DSH_LLM_FALLBACKS_AUTOPATCH`，默认开启（`1`）；`DSH_LLM_FALLBACKS_AUTOPATCH=0` 完全跳过（含 prepare 链的 autopatch 段）。
+- **目标解析**：`$DSH_SOURCE_DIR` 优先，缺省 `${DSH_HOME}/source/current`；目标缺失或非 git 树 → info 跳过（退出 0）。
+- **失败语义**：任何失败只 warn、**绝不导致安装失败**（退出 0）：patch 冲突 → warn 并提示手动处理（`apply-dsh-patch.sh`）；重建失败 / 缺 pnpm / 缺 node_modules → warn 并附手动重建命令；verify 探针未通过 → warn 附手动应用命令。幂等：已应用 / 已原生支持（`AgentOptions` 已含 `role`，verify 探针通过）→ 跳过。
+- **升级后重跑仍靠 `apply-dsh-patch.sh`**：自动应用只在插件安装时触发一次，dsh 升级重置本体改动后**不会**自动重打——升级后仍需按下文「dsh 升级后需重跑」手动执行 `apply-dsh-patch.sh` 并 `verify-dsh-patch.sh` 确认。
 
 ## dsh 升级后需重跑
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,6 +19,15 @@ dsh plugin --profile web add .
 
 `dsh plugin` 会把参数转发给该 profile 目录下的 pnpm（`add`、`remove`、`why` 等均可用），并将 `dsh-llm-fallbacks` 追加到 profile 的 bundle 层列表（`dsh.profile.bundles`）。
 
+> **自动 patch（本地 link 安装不触发）**：`add .` 走 pnpm 的 `link:` 依赖（node_modules 内为符号链接），**pnpm 不会为 `link:` 依赖运行 prepare/postinstall 生命周期脚本**（已实证）——因此安装期自动 patch（见 [docs/dsh-patch.md](docs/dsh-patch.md)「自动应用」）不会在此路径触发。若本机 dsh 源码树（`$DSH_SOURCE_DIR` / `${DSH_HOME}/source/current`）需要 role patch，安装后手动执行一次：
+
+```sh
+bash scripts/autopatch-install.sh    # 幂等：已应用/已原生支持则跳过；失败仅 warn
+# 或显式手动应用：scripts/apply-dsh-patch.sh && scripts/verify-dsh-patch.sh
+```
+
+如需完全禁用自动 patch（例如 git/tarball 安装时不想动 dsh 源码树），设环境变量 `DSH_LLM_FALLBACKS_AUTOPATCH=0` 再安装。
+
 ### bundle 层顺序（硬性要求）
 
 dsh 的 profile 由有序 bundle 层组合而成：`@deepseek-ai/dsh-base`（内含 llm-retry 插件）→ `@deepseek-ai/dsh-web-app` → `@mstar-harness/dsh` →（`add` 追加的）`dsh-llm-fallbacks`。
@@ -37,7 +46,8 @@ dsh plugin --profile web add https://github.com/<owner>/dsh-llm-fallbacks.git
 git 安装注意：
 
 - **prepare 自建**：pnpm 在安装 git 依赖时会执行包的 `prepare` 脚本（`bun run build`）自构建，安装机需要具备 bun；构建失败会导致装入未构建的包。
-- **allowBuilds（构建脚本放行）**：pnpm ≥ 10 默认不执行依赖的构建脚本。若安装被策略拦截、或装入后 `--dump-config` 看不到 `llm-fallbacks` 层 / 设置页不出现，请放行本包构建（如 `dsh plugin --profile web approve-builds`，或在该 profile 的 pnpm 配置中把 `dsh-llm-fallbacks` 加入 `onlyBuiltDependencies`）。确切行为以你所用 pnpm 版本的策略为准。
+- **自动 patch**：git 安装会执行 `prepare`（构建）并随后触发 `postinstall`——两处都会调用 `scripts/autopatch-install.sh` 自动检测并幂等应用 dsh 本体 role patch（目标 = `$DSH_SOURCE_DIR`，缺省 `${DSH_HOME}/source/current`；缺失/非 git 树则跳过；失败仅 warn 不中断安装）。可用 `DSH_LLM_FALLBACKS_AUTOPATCH=0` 禁用。详见 [docs/dsh-patch.md](docs/dsh-patch.md)「自动应用」。
+- **allowBuilds（构建脚本放行）**：pnpm ≥ 10 默认不执行依赖的构建脚本（含 `postinstall`）。若安装被策略拦截、或装入后 `--dump-config` 看不到 `llm-fallbacks` 层 / 设置页不出现 / 自动 patch 未触发，请放行本包构建（如 `dsh plugin --profile web approve-builds`，或在该 profile 的 pnpm 配置中把 `dsh-llm-fallbacks` 加入 `onlyBuiltDependencies`）。确切行为以你所用 pnpm 版本的策略为准。
 
 ## 3. 验证安装
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "files": [
     "dist",
-    "bundle"
+    "bundle",
+    "scripts",
+    "patches"
   ],
   "dsh": {
     "bundle": {
@@ -40,7 +42,8 @@
     "build": "rm -rf dist && bun build src/index.ts --target node --outdir dist --external cordis --external '@deepseek-ai/*' && bun run build-client && bunx tsc",
     "build-client": "bun run scripts/build-client.ts",
     "test": "vitest run",
-    "prepare": "bun run build"
+    "prepare": "bun run build && bash scripts/autopatch-install.sh",
+    "postinstall": "bash scripts/autopatch-install.sh"
   },
   "engines": {
     "node": ">=22",

--- a/scripts/autopatch-install.sh
+++ b/scripts/autopatch-install.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# autopatch-install.sh — 插件安装期自动应用 dsh 本体 role patch（幂等、失败仅 warn）。
+#
+# 背景：dsh-llm-fallbacks 需要 subagent 的显式角色来源（同 apply-dsh-patch.sh）。
+# 本脚本在插件安装生命周期（postinstall / prepare）自动检测目标 dsh 源码树并
+# 幂等应用两个 role patch，随后 best-effort 重建受影响包；任何失败只 warn、
+# 绝不导致插件安装失败（全局约束：不破坏安装）。
+#
+# 开关：DSH_LLM_FALLBACKS_AUTOPATCH（默认 1；设为 "0" 完全跳过，exit 0）。
+#
+# 目标解析（运行时，脚本本身不含本地绝对路径）：
+#   $DSH_SOURCE_DIR（若设置）→ 缺省 ${DSH_HOME}/source/current
+#   目标缺失或非 git 树 → info 跳过（exit 0）。
+#
+# 流程（对每个 patch，与 apply-dsh-patch.sh 同构的三态判定）：
+#   git apply --check 通过       → 尚未应用 → git apply 应用；
+#   git apply --reverse --check 通过 → 已应用 → 跳过（幂等）；
+#   两者都失败 → 记为冲突；全部 patch 处理完后统一判定：verify 探针通过（role 标记
+#   已就位，即 dsh 已原生支持/已等价应用）→ info 跳过；否则 → warn 提示手动处理
+#   （不中断安装）。
+# 应用后 best-effort 重建：tsc -b packages/core/agent packages/subagent/tool-subagent
+#   + tsdown --env.DSH_BUILD_FACE host（缺 pnpm / 缺 node_modules / 失败 → warn 不中断）。
+# 最后运行 verify 探针并提示结果（失败附手动命令）。
+#
+# 选项：
+#   --check        仅报告每个 patch 的状态，不修改任何文件、不构建、不验证。
+#   -h|--help      显示本帮助。
+#
+# 退出码：
+#   0  正常完成（含全部跳过 / 冲突 warn / 构建失败 warn —— 安装期绝不因本脚本失败）
+#   1  用法错误（未知选项）
+set -euo pipefail
+
+# 定位本脚本与仓库根（运行时推导，无硬编码绝对路径）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PATCHES_DIR="${REPO_ROOT}/patches"
+
+# 与 apply-dsh-patch.sh 相同的两个 pnpm 格式 patch
+PATCH_FILES=(
+  "@deepseek-ai+dsh-agent@0.0.1.patch"
+  "@deepseek-ai+dsh-tool-subagent@0.0.1.patch"
+)
+
+usage() {
+  sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+CHECK_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) CHECK_ONLY=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "ERROR: 未知选项: $1" >&2; usage 1 ;;
+  esac
+done
+
+# 输出统一带插件前缀，便于在 pnpm 安装日志中辨识
+log()  { printf '[dsh-llm-fallbacks:autopatch] %s\n' "$*"; }
+warn() { printf '[dsh-llm-fallbacks:autopatch] WARN: %s\n' "$*" >&2; }
+
+# 1) 环境开关：DSH_LLM_FALLBACKS_AUTOPATCH=0 → 完全跳过（含 prepare 链的 autopatch 段）
+if [[ "${DSH_LLM_FALLBACKS_AUTOPATCH:-1}" == "0" ]]; then
+  log "DSH_LLM_FALLBACKS_AUTOPATCH=0 — 跳过自动 patch 应用"
+  exit 0
+fi
+
+# 2) 目标解析：$DSH_SOURCE_DIR 优先，缺省 ${DSH_HOME}/source/current
+TARGET="${DSH_SOURCE_DIR:-${DSH_HOME:-}/source/current}"
+if [[ ! -d "$TARGET/.git" ]]; then
+  log "未找到 dsh 源码树（$TARGET 缺失或非 git 树），跳过自动 patch 应用（安装后可用 scripts/apply-dsh-patch.sh 手动应用）"
+  exit 0
+fi
+log "目标 dsh 源码树: $TARGET"
+
+# 返回单个 patch 的状态：needs-apply / applied / conflict（与 apply-dsh-patch.sh 同构）
+patch_status() {
+  local patch="$1"
+  if git -C "$TARGET" apply --check "${PATCHES_DIR}/${patch}" 2>/dev/null; then
+    echo "needs-apply"
+  elif git -C "$TARGET" apply --reverse --check "${PATCHES_DIR}/${patch}" 2>/dev/null; then
+    echo "applied"
+  else
+    echo "conflict"
+  fi
+}
+
+# 重建受影响包（tsc -b 增量 → tsdown host 打包）。best-effort：任何失败仅 warn 并返回 0。
+build_affected() {
+  local manual="cd \"$TARGET\" && pnpm install && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent && pnpm exec tsdown --env.DSH_BUILD_FACE host"
+  if ! command -v pnpm >/dev/null 2>&1; then
+    warn "PATH 中找不到 pnpm；patch 已应用但构建已跳过。请手动重建: ${manual}"
+    return 0
+  fi
+  if [[ ! -d "$TARGET/node_modules" ]]; then
+    warn "目标树缺少 node_modules（非 pnpm 工作区安装）；patch 已应用但构建已跳过。请手动重建: ${manual}"
+    return 0
+  fi
+  log "重建受影响包（tsc -b 增量 + tsdown host 打包）"
+  if ! ( cd "$TARGET" && pnpm exec tsc -b packages/core/agent packages/subagent/tool-subagent ); then
+    warn "tsc 增量构建失败（见上方输出），构建已跳过。请手动重建: ${manual}"
+    return 0
+  fi
+  if ! ( cd "$TARGET" && pnpm exec tsdown --env.DSH_BUILD_FACE host ); then
+    warn "tsdown 打包失败（见上方输出），构建已跳过。请手动重建: ${manual}"
+    return 0
+  fi
+  log "构建完成"
+}
+
+# verify 探针提示（失败附手动命令，不改变退出码）
+run_verify() {
+  if "${SCRIPT_DIR}/verify-dsh-patch.sh" -d "$TARGET" -q; then
+    log "verify 探针通过：role 标记已就位（源码/构建产物）"
+  else
+    warn "verify 探针未通过：role 标记未就位。请手动应用并验证: bash \"${SCRIPT_DIR}/apply-dsh-patch.sh\" && bash \"${SCRIPT_DIR}/verify-dsh-patch.sh\""
+  fi
+}
+
+HAD_CONFLICT=0
+APPLIED_ANY=0
+CONFLICTED_PATCHES=()
+
+for patch in "${PATCH_FILES[@]}"; do
+  if [[ ! -f "${PATCHES_DIR}/${patch}" ]]; then
+    warn "找不到 patch 文件: ${PATCHES_DIR}/${patch}（插件包可能不完整）— 跳过该 patch"
+    continue
+  fi
+  status="$(patch_status "$patch")"
+  case "$status" in
+    needs-apply)
+      if [[ "$CHECK_ONLY" -eq 1 ]]; then
+        log "[check] ${patch}: 可应用（目标尚未应用）"
+      else
+        log "应用 ${patch}"
+        if ! git -C "$TARGET" apply "${PATCHES_DIR}/${patch}"; then
+          warn "${patch}: git apply 失败（见上方输出），已跳过（安装继续）"
+          continue
+        fi
+        APPLIED_ANY=1
+      fi
+      ;;
+    applied)
+      log "[skip]  ${patch}: 已应用（幂等跳过）"
+      ;;
+    conflict)
+      if [[ "$CHECK_ONLY" -eq 1 ]]; then
+        log "[check] ${patch}: 冲突（无法正向应用或反向撤销）"
+      else
+        CONFLICTED_PATCHES+=("$patch")
+        HAD_CONFLICT=1
+      fi
+      ;;
+  esac
+done
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  log "检查完成（未修改任何文件）"
+  exit 0
+fi
+
+if [[ "$APPLIED_ANY" -eq 1 ]]; then
+  build_affected
+fi
+
+# 冲突统一判定：verify 探针通过 → dsh 已原生支持（或已等价应用）→ 降级为 info
+if [[ "$HAD_CONFLICT" -eq 1 ]] && "${SCRIPT_DIR}/verify-dsh-patch.sh" -d "$TARGET" -q >/dev/null 2>&1; then
+  log "存在冲突 patch，但 verify 探针通过（dsh 已原生支持/已等价应用），视为完成"
+  HAD_CONFLICT=0
+fi
+
+if [[ "$HAD_CONFLICT" -eq 1 ]]; then
+  warn "以下 patch 与目标树冲突（可能已手工改动或 dsh 升级偏移）: ${CONFLICTED_PATCHES[*]}"
+  warn "请手动处理: bash \"${SCRIPT_DIR}/apply-dsh-patch.sh\""
+  log "存在冲突 patch，跳过 verify 探针（请手动处理冲突后运行 scripts/apply-dsh-patch.sh）"
+else
+  run_verify
+fi
+
+log "完成（安装不受影响）"
+exit 0

--- a/scripts/autopatch-install.sh
+++ b/scripts/autopatch-install.sh
@@ -44,7 +44,7 @@ PATCH_FILES=(
 )
 
 usage() {
-  sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -111,9 +111,9 @@ build_affected() {
   log "构建完成"
 }
 
-# verify 探针提示（失败附手动命令，不改变退出码）
+# verify 探针结果提示（探针已在冲突判定前运行一次，此处仅按 VERIFY_OK 输出，不重复探测）
 run_verify() {
-  if "${SCRIPT_DIR}/verify-dsh-patch.sh" -d "$TARGET" -q; then
+  if [[ "$VERIFY_OK" -eq 1 ]]; then
     log "verify 探针通过：role 标记已就位（源码/构建产物）"
   else
     warn "verify 探针未通过：role 标记未就位。请手动应用并验证: bash \"${SCRIPT_DIR}/apply-dsh-patch.sh\" && bash \"${SCRIPT_DIR}/verify-dsh-patch.sh\""
@@ -166,8 +166,14 @@ if [[ "$APPLIED_ANY" -eq 1 ]]; then
   build_affected
 fi
 
+# verify 探针（只读、幂等）：只运行一次，结果存 VERIFY_OK，冲突降级判定与最终提示共用
+VERIFY_OK=0
+if "${SCRIPT_DIR}/verify-dsh-patch.sh" -d "$TARGET" -q >/dev/null 2>&1; then
+  VERIFY_OK=1
+fi
+
 # 冲突统一判定：verify 探针通过 → dsh 已原生支持（或已等价应用）→ 降级为 info
-if [[ "$HAD_CONFLICT" -eq 1 ]] && "${SCRIPT_DIR}/verify-dsh-patch.sh" -d "$TARGET" -q >/dev/null 2>&1; then
+if [[ "$HAD_CONFLICT" -eq 1 ]] && [[ "$VERIFY_OK" -eq 1 ]]; then
   log "存在冲突 patch，但 verify 探针通过（dsh 已原生支持/已等价应用），视为完成"
   HAD_CONFLICT=0
 fi


### PR DESCRIPTION
## 功能：安装期自动打补丁（install-time autopatch）

把 `patches/@deepseek-ai+dsh-{agent,tool-subagent}@0.0.1.patch` 的应用自动化：插件安装时（`postinstall`/`prepare` 生命周期）自动检测目标 dsh 树（`$DSH_SOURCE_DIR` → `$DSH_HOME/source/current`）并**幂等应用 + 重建**。

### 行为
- **默认开启**，`DSH_LLM_FALLBACKS_AUTOPATCH=0` 完全跳过；
- **幂等**：已应用 → skip；dsh 已原生支持（role 已就位）→ 冲突降级为 info；
- **不破坏安装**：所有失败路径仅 warn（含构建失败），脚本恒 exit 0；
- `--check` dry-run 零副作用；
- `files` 追加 `scripts`/`patches`，保证 tarball/git 安装产物内 autopatch 可用。

### 实证（沙箱 S1–S6 + 生命周期）
- pristine 应用 / 重跑幂等 / opt-out 零副作用 / 冲突 warn / dry-run 零副作用 / 原生支持降级 —— 全过；
- 生命周期：**本地 `add .`（link:）不触发生命周期脚本** → docs 已说明需手动执行一次；tarball（`file:`）需 `onlyBuiltDependencies` 放行；git 安装需 `allowBuilds` 放行（pnpm ≥10 规则，`docs/install.md` 已记载）。

### 质量
- Task review Approved；QC single Approve（2 nit 已微修）；QA **Accept（无 residual）**；`pnpm test` 163 全绿（不碰 src/）。