### PR TITLE
feat: bilingual README + always-visible fallbacks settings page (enabled switch default off)

### DIFF
--- a/.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md
+++ b/.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md
@@ -1,6 +1,7 @@
 ---
 module: dsh-plugin-authoring
 date: 2026-08-10
+last_updated: 2026-08-10
 problem_type: best_practice
 category: best-practices
 severity: low
@@ -45,6 +46,11 @@ dsh 插件 = npm 包，package.json 声明 dsh.bundle.patch（指向 bundle/cord
 
 - settings 命名空间：installSettingsSection(ctx, settingsNamespace(命名空间名), Config, entry, {setSource, onChange})（参照 agent-default-model）；composition entry 作 base、用户文档作覆盖层。
 - web 设置页：client 半 ctx.slots.inject('settings.section', …) 注册（name/id/order/locale-thunk label）；数据走自有 store（settings.describe/update/replace loopback + expectedRevision 冲突语义）；owner props 为空。
+- **设置页必须始终可用（不要死路）**：settings 的 describe 响应中 namespaces 缺失该命名空间 ≠ 页面该显示「无法读取」通知——首开无配置/命名空间未注册时也应渲染可操作骨架（标题/介绍/只读状态块/主开关/保存动作），以默认值种子展示，`writable` 跟随 describe 响应（不因缺失强制 false）。保存/恢复默认在无 view 时**省略 expectedRevision** 尝试写入（wire 契约该字段可选），host 接受→ready、拒绝→error 横幅如实呈现（不静默）。缺失状态可保留（语义为「未注册」，非死路），host 随后注册经 settings/changed 推送 → 重 describe → ready 原地升级。
+- **挂载即播种 + 首个 ready 重播种**：编辑状态从 defaultFallbacksConfig 初始化（不等待 ready），`seededRevision` 保持 null 直至首个 ready 描述符以服务端真值重播种；ready 之前控件可用性由 `writable` 驱动。注意：命名空间缺失但 `writable: true` 时用户可 pre-ready 编辑，中途推送升级会用服务端真值覆盖未保存 draft——这是设计的「骨架原地升级」，注释需如实说明，勿写「ready 前不可编辑」这类过期前提。
+- **功能级开关（feature master switch）模式**：用配置字段本身（如 fallbacks 命名空间的 `enabled` 字段）作页面显隐开关——OFF 时隐藏表单主体 + 显示提示（隐藏不丢弃：draft 保留、拨动即时显隐），ON 时显示完整配置界面；开关状态 = 用户配置字段（保存持久化、重载保持），不是纯 UI 本地态。默认值如需翻转（如 enabled true→false），单点改 defaultFallbacksConfig + schema。
+- **配置默认值翻转的测试基准**：翻转默认值会连带破坏所有走共享 cfg() 基准的用例——把测试基准显式钉到活跃态（cfg() = { ...defaults, enabled: true, ...overrides }），只翻转显式断言默认值的用例（config.spec），并新增「默认配置 → no-op」专项用例锁定回归不变量；store 单测的缺失命名空间用例按新语义拆分（writable 跟随 / 拒绝 / 无前置写入成功 / host 拒绝）。
+- **测试矩阵文档会漂移**：docs/verification.md 的用例计数在迭代中反复过期（153→163→168）——更新文档时顺手校准，或以 grep 计数为准。
 
 ### 关键坑
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This plugin aligns with omp's `retry.modelFallback` / `retry.fallbackChains` sem
 | `fallbacks.enabled` | `retry.modelFallback` | Feature switch. dsh defaults to `false` (empty chains are a no-op); omp does not trigger when off |
 | `fallbacks.chains` | `retry.fallbackChains` | Chain configuration. Key/entry selector syntax and specificity (exact → `provider/*` → role → default) match |
 | `fallbacks.revertPolicy` | `retry.fallbackRevertPolicy` | `cooldown-expiry` / `never` semantics match: return to primary on cooldown expiry / never within the session |
-| `fallbacks.roles`（default / rules / `agent.options.role`） | subagent model pattern list (first resolvable pattern is the primary model, the rest are fallbacks; no `agent:<name>` chain keys) | Both group chains by role/agent; dsh's explicit roles and rule matching are more precise and let subagents form their own chains |
+| `fallbacks.roles`(default / rules / `agent.options.role`) | subagent model pattern list (first resolvable pattern is the primary model, the rest are fallbacks; no `agent:<name>` chain keys) | Both group chains by role/agent; dsh's explicit roles and rule matching are more precise and let subagents form their own chains |
 | `fallbacks.triggerCodes` | no public counterpart (triggered by failure type) | dsh exposes the trigger failure-code set as configurable, defaulting to `['AUTH', 'QUOTA', 'RATE_LIMIT']` |
 | `fallbacks.cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap` | no public counterpart (cooldown is built-in) | dsh-side configurable cooldown duration, per-step safety valve, and always-mode retry cap |
 
@@ -82,6 +82,8 @@ fallbacks:
 Roles are the grouping key for chains: `roles.default` is the fallback role; `roles.rules` match origin/provider/model in order to a concrete role (first match wins); an explicit `agent.options.role` (subagents via `agentOptions.role`, requires the dsh role patch, see [docs/dsh-patch.md](docs/dsh-patch.md)) has the highest priority — once a `reviewer` chain is configured, agents in that role use their own fallback chain.
 
 Save and restart the web session for the changes to take effect. The feature switch `fallbacks.enabled` **defaults to off (`false`)** — the plugin only engages once it is turned on; `triggerCodes` defaults to `AUTH` / `QUOTA` / `RATE_LIMIT`; and with **no chains configured the behavior is identical to not having the plugin installed**. More examples (role chains, provider wildcard keys, roles rules) → [docs/configuration.md](docs/configuration.md).
+
+> **Upgrade note (behavior change)**: an existing `fallbacks:` section **without an explicit `enabled` key** now resolves to `false` after upgrading — add `enabled: true` to keep the plugin active.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,86 +1,97 @@
 # dsh-llm-fallbacks
 
-dsh（DeepSeek Harness）的自动模型降级插件：当 root agent 或 subagent 的模型请求持续失败（重试耗尽、权限、配额超限、限流 429）时，按角色/模型 fallback 链自动切换 provider/model，当前 step/turn 在目标模型上继续完成——任务不因模型问题中断。
+[English](README.md) | [中文](README.zh-CN.md)
 
-> 本插件与 omp 的 `retry.modelFallback` / `retry.fallbackChains` 语义对齐（对照见下），dsh 侧以 `fallbacks` settings 命名空间承载配置。
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![node](https://img.shields.io/badge/node-%3E%3D22-339933.svg)
+![bun](https://img.shields.io/badge/bun-%3E%3D1.2.17-fbf0df.svg)
+![dsh](https://img.shields.io/badge/dsh-DeepSeek%20Harness%20compatible-4B32C3.svg)
 
-## 能力一览
+Automatic provider/model fallback chains for dsh (DeepSeek Harness): when an agent's LLM requests keep failing — retries exhausted, auth errors, quota exceeded, rate limiting (429) — the plugin switches provider/model along the fallback chain for the current role, and the current step/turn continues on the target model: tasks are not interrupted by model problems.
 
-- **root / subagent 自动降级**：任意 agent 在模型故障下按链切换到下一个可用 provider/model，无需手动换模型。
-- **角色链**：subagent 可走独立于 root 的 fallback 链——显式 `agent.options.role`（需 dsh role patch）→ `roles.rules` 顺序匹配 → `roles.default`，首个命中即停。
-- **链 specificity**：exact `provider/model` 键 → `provider/*` 键 → 角色链 → `default` 链；`provider/*` 条目保留失败模型 id 仅换 provider。
-- **冷却与回主**：被切离/失败的模型在冷却期内不再入选；`revertPolicy: cooldown-expiry` 冷却到期后自动回主模型，`never` 会话内不回。
-- **行为可见**：每次切换追加持久化会话事件 `fallbacks/switch`（from/to/role/reason），配合 info 级日志（候选尝试顺序与跳过原因）与 web 设置页只读状态，无静默换模型。
-- **安全阀**：每 step 的 `maxSwitchesPerStep` 超限后停止切换、保持原错误语义，防止链循环放大延迟；`mode: 'always'` 的 provider 另有重试上限（`alwaysModeRetryCap`）。
-- **无配置回归**：`enabled` 默认开启，但空链 / 未命中触发码 / 角色解析失败时插件完全 no-op——行为与未安装时一致，不产生任何事件。
-
-## 与 omp `retry.modelFallback` / `fallbackChains` 语义对照
-
-| dsh-llm-fallbacks | omp | 语义对照 |
-|---|---|---|
-| `fallbacks.enabled` | `retry.modelFallback` | 功能总开关。dsh 默认 `true`（空链即 no-op）；omp 关闭即不触发 |
-| `fallbacks.chains` | `retry.fallbackChains` | 链配置。键/条目 selector 语法与 specificity（exact → `provider/*` → 角色 → default）一致 |
-| `fallbacks.revertPolicy` | `retry.fallbackRevertPolicy` | `cooldown-expiry` / `never` 语义一致：冷却到期回主 / 会话内不回 |
-| `fallbacks.roles`（default / rules / `agent.options.role`） | 子代理模型 pattern 列表（首个可解析 pattern 为主模型、其余为 fallback；无 `agent:<name>` 链键） | 都以「角色/agent」为链分组维度；dsh 的显式 role 与规则匹配更精确，可让 subagent 独立成链 |
-| `fallbacks.triggerCodes` | 无公开对应配置（按失败类型触发） | dsh 将触发失败码集合开放为可配置项，默认 `['AUTH', 'QUOTA', 'RATE_LIMIT']` |
-| `fallbacks.cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap` | 无公开对应配置（冷却为内置行为） | dsh 侧可配置的冷却时长、单步安全阀、always 模式重试上限 |
-
-> omp 侧语义以 omp 自身文档为准；本表仅列出本插件与之对齐/差异的部分，dsh 侧字段定义见 [docs/configuration.md](docs/configuration.md)。
-
-## 快速开始
-
-### 安装
-
-本地目录安装（推荐开发/验证）：
+Install with a single command:
 
 ```sh
-# 1) 在插件仓库目录构建（prepare 自构建需要 bun）
+dsh plugin --profile web add https://github.com/dsh-external/dsh-llm-fallbacks.git
+```
+
+## Features
+
+- **Automatic fallback for root and subagents**: any agent switches down the chain to the next available provider/model on model failure — no manual model switching.
+- **Role-based chains**: subagents can use their own fallback chain, independent of the root agent — explicit `agent.options.role` (requires the dsh role patch) → `roles.rules` matching in order → `roles.default`; first match wins.
+- **Chain specificity**: exact `provider/model` keys → `provider/*` keys → role chains → `default` chain; `provider/*` entries keep the failed model id and only switch provider.
+- **Cooldown and revert**: models that were switched away from / failed are not re-selected during the cooldown period; `revertPolicy: cooldown-expiry` automatically returns to the primary model when the cooldown expires, while `never` does not return within the session.
+- **Visible behavior**: every switch appends a persisted session event `fallbacks/switch` (from/to/role/reason), alongside info-level logs (candidate attempt order and skip reasons) and the read-only status block on the web settings page — no silent model switching.
+- **Safety valves**: switching stops and the original error semantics are kept once `maxSwitchesPerStep` is exceeded for a step, preventing chain loops from amplifying latency; `mode: 'always'` providers additionally have a retry cap (`alwaysModeRetryCap`).
+- **No-config no-op**: `enabled` defaults to off (`false`); with empty chains, unmatched trigger codes, or unresolved roles the plugin is a complete no-op — identical to not being installed, and no events are emitted.
+
+## Comparison with omp `retry.modelFallback` / `fallbackChains`
+
+This plugin aligns with omp's `retry.modelFallback` / `retry.fallbackChains` semantics (see the table below); on the dsh side, configuration lives in the `fallbacks` settings namespace.
+
+| dsh-llm-fallbacks | omp | Semantics |
+|---|---|---|
+| `fallbacks.enabled` | `retry.modelFallback` | Feature switch. dsh defaults to `false` (empty chains are a no-op); omp does not trigger when off |
+| `fallbacks.chains` | `retry.fallbackChains` | Chain configuration. Key/entry selector syntax and specificity (exact → `provider/*` → role → default) match |
+| `fallbacks.revertPolicy` | `retry.fallbackRevertPolicy` | `cooldown-expiry` / `never` semantics match: return to primary on cooldown expiry / never within the session |
+| `fallbacks.roles`（default / rules / `agent.options.role`） | subagent model pattern list (first resolvable pattern is the primary model, the rest are fallbacks; no `agent:<name>` chain keys) | Both group chains by role/agent; dsh's explicit roles and rule matching are more precise and let subagents form their own chains |
+| `fallbacks.triggerCodes` | no public counterpart (triggered by failure type) | dsh exposes the trigger failure-code set as configurable, defaulting to `['AUTH', 'QUOTA', 'RATE_LIMIT']` |
+| `fallbacks.cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap` | no public counterpart (cooldown is built-in) | dsh-side configurable cooldown duration, per-step safety valve, and always-mode retry cap |
+
+> omp-side semantics follow omp's own docs; this table only lists where this plugin aligns with or differs from them. dsh-side field definitions → [docs/configuration.md](docs/configuration.md).
+
+## Install
+
+### One-line URL install
+
+```sh
+dsh plugin --profile web add https://github.com/dsh-external/dsh-llm-fallbacks.git
+```
+
+### Local directory install (recommended for development / verification)
+
+```sh
+# 1) Build in the plugin repo (the prepare self-build needs bun)
 pnpm install
-# 2) 装入目标 profile（示例为 web）
+# 2) Add to the target profile (example: web)
 dsh plugin --profile web add .
 ```
 
-git 安装：
+> No npm registry install command is provided (this iteration does not publish to npm). Both methods, uninstall, and `--dump-config` verification — including the bundle-layer ordering requirements — are covered in [docs/install.md](docs/install.md).
 
-```sh
-dsh plugin --profile web add https://github.com/<owner>/dsh-llm-fallbacks.git
-```
+## Quick start
 
-> 两种安装方式与验证步骤详见 [docs/install.md](docs/install.md)（含 bundle 层顺序要求与 `--dump-config` 验证）。
+### Minimal configuration
 
-### 最小配置
-
-在 dsh 的设置文档（默认 `$DSH_HOME/settings.yaml`）中添加 `fallbacks:` 分节：
+Add a `fallbacks:` section to the dsh settings document (default `$DSH_HOME/settings.yaml`):
 
 ```yaml
 fallbacks:
+  enabled: true            # feature switch; defaults to false — set explicitly to enable
   chains:
-    default:            # 角色 default 链：主模型失败后按顺序尝试
+    default:               # default role chain: tried in order after the primary model fails
       - anthropic/claude-3-5-sonnet
       - openai/*
   roles:
     default: default
     rules:
-      - origin: subagent   # 所有 subagent → reviewer 角色（走独立链）
+      - origin: subagent   # all subagents → reviewer role (own chain)
         role: reviewer
 ```
 
-角色是链的分组键：`roles.default` 为兜底角色，`roles.rules` 按 origin/provider/model
-顺序匹配到具体角色（首个命中即停）；显式 `agent.options.role`（subagent 经
-`agentOptions.role` 传入，需 dsh role patch，见 [docs/dsh-patch.md](docs/dsh-patch.md)）
-优先级最高——配置了 `reviewer` 链后，归属该角色的 agent 走独立 fallback 链。
+Roles are the grouping key for chains: `roles.default` is the fallback role; `roles.rules` match origin/provider/model in order to a concrete role (first match wins); an explicit `agent.options.role` (subagents via `agentOptions.role`, requires the dsh role patch, see [docs/dsh-patch.md](docs/dsh-patch.md)) has the highest priority — once a `reviewer` chain is configured, agents in that role use their own fallback chain.
 
-保存并重启 web 会话后生效。插件默认已启用（`enabled: true`），`triggerCodes` 默认覆盖 `AUTH` / `QUOTA` / `RATE_LIMIT`，**未配置任何链时行为与未安装插件完全一致**。更多示例（角色链、provider 通配键、roles 规则）见 [docs/configuration.md](docs/configuration.md)。
+Save and restart the web session for the changes to take effect. The feature switch `fallbacks.enabled` **defaults to off (`false`)** — the plugin only engages once it is turned on; `triggerCodes` defaults to `AUTH` / `QUOTA` / `RATE_LIMIT`; and with **no chains configured the behavior is identical to not having the plugin installed**. More examples (role chains, provider wildcard keys, roles rules) → [docs/configuration.md](docs/configuration.md).
 
-## 文档
+## Documentation
 
-| 文档 | 内容 |
+| Doc | Content |
 |---|---|
-| [docs/install.md](docs/install.md) | profile 安装 / git 安装 / 卸载 / `--dump-config` 验证 |
-| [docs/configuration.md](docs/configuration.md) | `fallbacks` 命名空间全字段、selector 语法、示例 YAML、设置页使用、行为说明 |
-| [docs/dsh-patch.md](docs/dsh-patch.md) | subagent 显式角色 patch 的动机、应用/回滚/验证、dsh 升级后重跑 |
-| [patches/README.md](patches/README.md) | patch 清单与原理（与 docs/dsh-patch.md 配套） |
+| [docs/install.md](docs/install.md) | profile install / git install / uninstall / `--dump-config` verification |
+| [docs/configuration.md](docs/configuration.md) | full `fallbacks` namespace reference, selector syntax, example YAML, settings page usage, behavior notes |
+| [docs/dsh-patch.md](docs/dsh-patch.md) | motivation for the subagent explicit-role patch, apply / revert / verify, re-running after dsh upgrades |
+| [patches/README.md](patches/README.md) | patch inventory and rationale (companion to docs/dsh-patch.md) |
 
-## 许可
+## License
 
-本项目以 **MIT** 许可证发布，全文见 [LICENSE](LICENSE)。版权与许可条款以 LICENSE 文件为准。
+Released under the **MIT** License — see [LICENSE](LICENSE). The LICENSE file is authoritative for copyright and license terms.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,97 @@
+# dsh-llm-fallbacks
+
+[English](README.md) | [中文](README.zh-CN.md)
+
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![node](https://img.shields.io/badge/node-%3E%3D22-339933.svg)
+![bun](https://img.shields.io/badge/bun-%3E%3D1.2.17-fbf0df.svg)
+![dsh](https://img.shields.io/badge/dsh-DeepSeek%20Harness%20compatible-4B32C3.svg)
+
+dsh（DeepSeek Harness）的自动模型降级插件：当 root agent 或 subagent 的模型请求持续失败（重试耗尽、权限、配额超限、限流 429）时，按角色/模型 fallback 链自动切换 provider/model，当前 step/turn 在目标模型上继续完成——任务不因模型问题中断。
+
+一句话安装：
+
+```sh
+dsh plugin --profile web add https://github.com/dsh-external/dsh-llm-fallbacks.git
+```
+
+## 能力一览
+
+- **root / subagent 自动降级**：任意 agent 在模型故障下按链切换到下一个可用 provider/model，无需手动换模型。
+- **角色链**：subagent 可走独立于 root 的 fallback 链——显式 `agent.options.role`（需 dsh role patch）→ `roles.rules` 顺序匹配 → `roles.default`，首个命中即停。
+- **链 specificity**：exact `provider/model` 键 → `provider/*` 键 → 角色链 → `default` 链；`provider/*` 条目保留失败模型 id 仅换 provider。
+- **冷却与回主**：被切离/失败的模型在冷却期内不再入选；`revertPolicy: cooldown-expiry` 冷却到期后自动回主模型，`never` 会话内不回。
+- **行为可见**：每次切换追加持久化会话事件 `fallbacks/switch`（from/to/role/reason），配合 info 级日志（候选尝试顺序与跳过原因）与 web 设置页只读状态，无静默换模型。
+- **安全阀**：每 step 的 `maxSwitchesPerStep` 超限后停止切换、保持原错误语义，防止链循环放大延迟；`mode: 'always'` 的 provider 另有重试上限（`alwaysModeRetryCap`）。
+- **无配置回归（no-op）**：`enabled` 默认关闭（`false`），空链 / 未命中触发码 / 角色解析失败时插件完全 no-op——行为与未安装时一致，不产生任何事件。
+
+## 与 omp `retry.modelFallback` / `fallbackChains` 语义对照
+
+本插件与 omp 的 `retry.modelFallback` / `retry.fallbackChains` 语义对齐（对照见下），dsh 侧以 `fallbacks` settings 命名空间承载配置。
+
+| dsh-llm-fallbacks | omp | 语义对照 |
+|---|---|---|
+| `fallbacks.enabled` | `retry.modelFallback` | 功能总开关。dsh 默认 `false`（空链即 no-op）；omp 关闭即不触发 |
+| `fallbacks.chains` | `retry.fallbackChains` | 链配置。键/条目 selector 语法与 specificity（exact → `provider/*` → 角色 → default）一致 |
+| `fallbacks.revertPolicy` | `retry.fallbackRevertPolicy` | `cooldown-expiry` / `never` 语义一致：冷却到期回主 / 会话内不回 |
+| `fallbacks.roles`（default / rules / `agent.options.role`） | 子代理模型 pattern 列表（首个可解析 pattern 为主模型、其余为 fallback；无 `agent:<name>` 链键） | 都以「角色/agent」为链分组维度；dsh 的显式 role 与规则匹配更精确，可让 subagent 独立成链 |
+| `fallbacks.triggerCodes` | 无公开对应配置（按失败类型触发） | dsh 将触发失败码集合开放为可配置项，默认 `['AUTH', 'QUOTA', 'RATE_LIMIT']` |
+| `fallbacks.cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap` | 无公开对应配置（冷却为内置行为） | dsh 侧可配置的冷却时长、单步安全阀、always 模式重试上限 |
+
+> omp 侧语义以 omp 自身文档为准；本表仅列出本插件与之对齐/差异的部分，dsh 侧字段定义见 [docs/configuration.md](docs/configuration.md)。
+
+## 安装
+
+### 一句话 URL 安装
+
+```sh
+dsh plugin --profile web add https://github.com/dsh-external/dsh-llm-fallbacks.git
+```
+
+### 本地目录安装（开发/验证推荐）
+
+```sh
+# 1) 在插件仓库目录构建（prepare 自构建需要 bun）
+pnpm install
+# 2) 装入目标 profile（示例为 web）
+dsh plugin --profile web add .
+```
+
+> 不提供 npm registry 安装命令（本迭代未发布 npm 包）。两种安装方式、卸载与 `--dump-config` 验证（含 bundle 层顺序要求）详见 [docs/install.md](docs/install.md)。
+
+## 快速开始
+
+### 最小配置
+
+在 dsh 的设置文档（默认 `$DSH_HOME/settings.yaml`）中添加 `fallbacks:` 分节：
+
+```yaml
+fallbacks:
+  enabled: true          # 功能级开关；默认关闭（false），需显式打开后生效
+  chains:
+    default:             # 角色 default 链：主模型失败后按顺序尝试
+      - anthropic/claude-3-5-sonnet
+      - openai/*
+  roles:
+    default: default
+    rules:
+      - origin: subagent   # 所有 subagent → reviewer 角色（走独立链）
+        role: reviewer
+```
+
+角色是链的分组键：`roles.default` 为兜底角色，`roles.rules` 按 origin/provider/model 顺序匹配到具体角色（首个命中即停）；显式 `agent.options.role`（subagent 经 `agentOptions.role` 传入，需 dsh role patch，见 [docs/dsh-patch.md](docs/dsh-patch.md)）优先级最高——配置了 `reviewer` 链后，归属该角色的 agent 走独立 fallback 链。
+
+保存并重启 web 会话后生效。功能级开关 `fallbacks.enabled` **默认关闭（`false`）**——打开开关后插件才会介入；`triggerCodes` 默认覆盖 `AUTH` / `QUOTA` / `RATE_LIMIT`；**未配置任何链时行为与未安装插件完全一致**。更多示例（角色链、provider 通配键、roles 规则）见 [docs/configuration.md](docs/configuration.md)。
+
+## 文档
+
+| 文档 | 内容 |
+|---|---|
+| [docs/install.md](docs/install.md) | profile 安装 / git 安装 / 卸载 / `--dump-config` 验证 |
+| [docs/configuration.md](docs/configuration.md) | `fallbacks` 命名空间全字段、selector 语法、示例 YAML、设置页使用、行为说明 |
+| [docs/dsh-patch.md](docs/dsh-patch.md) | subagent 显式角色 patch 的动机、应用/回滚/验证、dsh 升级后重跑 |
+| [patches/README.md](patches/README.md) | patch 清单与原理（与 docs/dsh-patch.md 配套） |
+
+## 许可
+
+本项目以 **MIT** 许可证发布，全文见 [LICENSE](LICENSE)。版权与许可条款以 LICENSE 文件为准。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,6 +83,8 @@ fallbacks:
 
 保存并重启 web 会话后生效。功能级开关 `fallbacks.enabled` **默认关闭（`false`）**——打开开关后插件才会介入；`triggerCodes` 默认覆盖 `AUTH` / `QUOTA` / `RATE_LIMIT`；**未配置任何链时行为与未安装插件完全一致**。更多示例（角色链、provider 通配键、roles 规则）见 [docs/configuration.md](docs/configuration.md)。
 
+> **升级提示（行为变更）**：已有 `fallbacks:` 配置若**未显式写 `enabled` 键**，升级后解析为 `false`——请补上 `enabled: true` 以保持插件继续生效。
+
 ## 文档
 
 | 文档 | 内容 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@
 
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
-| `enabled` | boolean | `true` | 总开关。`false` 时插件完全不介入；`true` 但未配置任何链时行为与未安装插件一致（no-op） |
+| `enabled` | boolean | `false` | 功能级总开关。默认关闭（OFF）：`false` 时插件完全不介入、设置页隐藏配置表单主体；`true` 但未配置任何链时行为与未安装插件一致（no-op） |
 | `triggerCodes` | string[] | `['AUTH', 'QUOTA', 'RATE_LIMIT']` | 命中这些失败码时进入链决策。可重试型故障（5xx / `RATE_LIMIT` 等）先由 llm-retry 退避重试，预算耗尽后同样进入决策——**无需为 5xx 额外添加 triggerCodes** |
 | `chains` | Record&lt;string, string[]&gt; | `{}` | 链键 → 有序 fallback 选择器列表。键为 `provider/model`、`provider/*` 或角色名；条目为 `provider/model` 或 `provider/*`（见下文 selector 语法） |
 | `roles.default` | string | `'default'` | 角色解析兜底：无显式 role、无规则命中时使用的角色 |
@@ -16,7 +16,7 @@
 | `maxSwitchesPerStep` | number | `8` | 单步安全阀：每 step 切换次数上限，超限停止切换、保持原错误语义，防止链循环放大延迟 |
 | `alwaysModeRetryCap` | number | `5` | always 模式重试上限：`retryPolicy.mode === 'always'` 的 provider 在同一请求内重试达到该次数后切换；`0` 禁用 |
 
-> 默认值以 spec §4 为准，与 `src/config.ts` 的 schema 默认值一致；设置页对数值字段（`cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）旁显示默认值，其余字段展示当前生效值（未配置时即默认值）。
+> 默认值以本迭代 readme-settings spec §1.2 为准（`enabled` 默认 `false`），与 `src/config.ts` 的 schema 默认值一致；设置页对数值字段（`cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）旁显示默认值，其余字段展示当前生效值（未配置时即默认值）。
 
 ## Selector 语法
 
@@ -88,6 +88,7 @@ fallbacks:
 
 要点：
 
+- 示例显式设置 `enabled: true`——功能级开关默认 `false`，未显式打开时插件不介入、设置页隐藏配置表单主体。
 - 链首条目即主模型之后的第一个降级目标；链内条目即优先级。
 - 切换只改变后续请求的 provider/model 路由，不重置会话上下文与工具状态。
 - 链目标模型需各自已配置密钥与配额（不同 provider 之间成本/额度可能不同）。
@@ -95,10 +96,12 @@ fallbacks:
 ## web 设置页使用说明
 
 - **入口**：web 设置 GUI → Settings → **Fallbacks**（位于 Models 页之后）。
+- **始终可用（骨架恒渲染）**：无论是否已配置 `fallbacks` 命名空间（首次打开、loading、error 等任意描述符状态），页面都渲染骨架——`nav` 标题、介绍、只读状态块、功能级开关 `enabled`、保存/恢复默认动作。命名空间尚未注册时显示默认配置种子，保存动作可用（失败会如实提示，见下）。
+- **功能级开关 `enabled`（默认 OFF）**：开关即用户配置字段 `fallbacks.enabled`，默认关闭。关闭时隐藏配置表单主体（`triggerCodes` / `chains` / `roles` / `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`），显示「功能未开启：打开 `enabled` 开关以显示配置界面」提示——隐藏不丢弃，编辑中的 draft 保留；打开后显示完整配置界面。拨动开关即时显隐（draft 驱动），经保存动作持久化。
 - **可读标签**：枚举型配置项显示可读标签而非原始枚举值——`RATE_LIMIT` →「限流（429）」、`QUOTA` →「配额超限」、`AUTH` →「权限/认证失败」；`cooldown-expiry` →「冷却到期后回主模型」、`never` →「保持备用模型」。数值字段旁显示默认值；其余字段展示当前生效值（未配置时即默认值）。
 - **链/角色行编辑**：`chains` 以「键 + 每行一个选择器的多行输入」编辑；`roles.rules` 以行编辑（origin/provider/model/role），空字段不参与匹配。
-- **恢复默认**：一键把该命名空间的用户配置重置为组合默认值。
-- **冲突重载**：保存携带 `expectedRevision`；配置被其它地方修改时保存被拒，页面显示冲突横幅与「重新加载」按钮，避免静默覆盖并发修改。
+- **恢复默认**：一键把该命名空间的用户配置重置为组合默认值（`enabled` 回 `false`）。
+- **冲突重载**：保存携带 `expectedRevision`；配置被其它地方修改时保存被拒，页面显示冲突横幅与「重新加载」按钮，避免静默覆盖并发修改。命名空间尚未注册时保存省略 `expectedRevision` 尝试写入，host 拒绝则错误横幅如实呈现、骨架与 draft 保留。
 - **只读状态块**：显示当前生效配置摘要（启用状态/默认角色/链数/触发码）；「最近切换摘要」当前为占位，运行期验证后接入会话事件读取面（见实现）。
 
 ## 行为说明

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,8 +39,8 @@ dsh 的 profile 由有序 bundle 层组合而成：`@deepseek-ai/dsh-base`（内
 ## 2. git 安装
 
 ```sh
-dsh plugin --profile web add https://github.com/<owner>/dsh-llm-fallbacks.git
-# 或指定 ref：add https://github.com/<owner>/dsh-llm-fallbacks.git#<branch|tag|commit>
+dsh plugin --profile web add https://github.com/dsh-external/dsh-llm-fallbacks.git
+# 或指定 ref：add https://github.com/dsh-external/dsh-llm-fallbacks.git#<branch|tag|commit>
 ```
 
 git 安装注意：
@@ -68,8 +68,8 @@ dsh --profile web --dump-config
 
 然后**重启 dsh web 会话**（`dsh web` 或重启正在运行的会话），让 host 半与 client 半（设置页）加载：
 
-- web 设置 GUI 的 Settings 中应出现 **Fallbacks** 页（位于 Models 页之后）。
-- 页面可读、可编辑、可保存；未配置任何链时显示默认配置，行为 no-op（详见 [docs/configuration.md](docs/configuration.md)）。
+- web 设置 GUI 的 Settings 中应出现 **Fallbacks** 页（位于 Models 页之后），且**始终可用**——首次打开（尚无 `fallbacks` 配置）也渲染页面骨架。
+- 页面可读、可编辑、可保存；功能级开关 `enabled` **默认 OFF**（关闭时隐藏配置表单主体），打开开关后显示完整配置表单；未配置任何链时行为 no-op（详见 [docs/configuration.md](docs/configuration.md)）。
 
 ## 4. 卸载
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -11,17 +11,17 @@
 
 ## 已验证（本迭代证据，T1–T8）
 
-### 1. 测试矩阵（单元 + 集成，133 → 153 全绿）
+### 1. 测试矩阵（单元 + 集成，153 → 168 全绿）
 
 | 范围 | 文件 | 数量 | 覆盖契约 |
 |---|---|---|---|
 | 单元（T2） | `selectors.spec.ts` / `chains.spec.ts` / `roles.spec.ts` / `cooldown.spec.ts` | 11 / 26 / 10 / 9 | selector 解析与 specificity（exact → `provider/*` → 角色 → default）、`provider/*` 条目保留模型 id 仅换 provider、角色规则顺序匹配、cooldown/revert（惰性过期、never 无限 TTL） |
-| 单元（T3） | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 2 / 30 | 状态机（pendingSwitch 产生→应用→清除、appliedTurnStep 防重放、step 推进重置）、`fallbacks/switch` 事件形状与 JSON 往返、`Config({})` 恒等于默认配置（no-op 基线）、小集成 Step 6 全项 |
-| 集成（T4） | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 16 / 4 / 5 | 端到端重集成、**双插件共存顺序**（normal 先退避、预算耗尽后切换；不可重试码直切）、**always 先委托下游 + cap 在 request 边界**（ADR-2）、冷却/revert 集成、**安全阀**超限后原错误语义、组合顺序互不干扰 |
-| client（T5） | `fallbacks-store.spec.ts` | 20 | 设置页描述符读/写（redactSecrets 面、expectedRevision 冲突保护、settings-conflict 状态）、chain/rule 行编辑往返、controller 生命周期 |
+| 单元（T3） | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 2 / 37 | 状态机（pendingSwitch 产生→应用→清除、appliedTurnStep 防重放、step 推进重置）、`fallbacks/switch` 事件形状与 JSON 往返、`Config({})` 恒等于默认配置（no-op 基线）、小集成 Step 6 全项 |
+| 集成（T4） | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 17 / 4 / 5 | 端到端重集成、**双插件共存顺序**（normal 先退避、预算耗尽后切换；不可重试码直切）、**always 先委托下游 + cap 在 request 边界**（ADR-2）、冷却/revert 集成、**安全阀**超限后原错误语义、组合顺序互不干扰 |
+| client（T5） | `fallbacks-store.spec.ts` | 27 | 设置页描述符读/写（redactSecrets 面、expectedRevision 冲突保护、settings-conflict 状态）、chain/rule 行编辑往返、controller 生命周期 |
 | 回归 | `skeleton.spec.ts` | 3 | bundle 契约（row id、空 schema 接受、host+client apply 入口） |
 
-结果：**13 files / 153 tests 全绿**（`pnpm test`，vitest run）；`pnpm build`（bun build host →
+结果：**13 files / 168 tests 全绿**（`pnpm test`，vitest run）；`pnpm build`（bun build host →
 `bunx tsc` → bun build client）全绿。no-op 回归不变量（空链 / 未命中 / 链耗尽 / 安全阀
 超限 → 透传、不产生 `fallbacks/switch` 事件）由 T3/T4 测试持久断言。
 
@@ -151,7 +151,7 @@ dsh 升级（`$DSH_HOME/source/current` 指向新 staging）会重置本体改�
 
 | 面 | 未覆盖原因 | 验证归属 |
 |---|---|---|
-| web 设置 GUI 交互（页面出现、编辑保存、冲突重载） | 沙箱无法操作真实 web 会话 | 用户待执行 §2（client 半逻辑已由 T5 20 例测试覆盖） |
+| web 设置 GUI 交互（页面出现、编辑保存、冲突重载） | 沙箱无法操作真实 web 会话 | 用户待执行 §2（client 半逻辑已由 T5 27 例测试覆盖） |
 | 真实模型调用与失败注入（AUTH/QUOTA/RATE_LIMIT 触发、切换继续） | 沙箱无真实模型凭据与运行中会话 | 用户待执行 §3（决策逻辑已由 T3/T4 集成测试覆盖） |
 | 跨进程观察（日志、`fallbacks/switch` 会话事件在真实会话中的落地） | 沙箱无法运行真实 dsh 会话 | 用户待执行 §3/§4 |
 | 真实安装上的 patch apply → build | 对运行中 `$DSH_HOME` 的写操作被沙箱拒绝 | 用户待执行 §4（可应用性已只读 `git apply --check` + 沙箱全流程验证） |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -95,11 +95,17 @@ dsh --profile web --dump-config   # 组合树末尾应出现 # == dsh-llm-fallba
 ### 2. web 设置页验证
 
 1. 打开 web 设置 GUI → Settings，确认出现 **Fallbacks** 页（位于 Models 页之后）。
-2. 编辑任一字段（如把 `cooldownMs` 改为 `600000`）并保存。
-3. **预期**：保存成功、无冲突横幅；`$DSH_HOME/settings.yaml`（或该 profile 的 settings
-   路径）写入新值；再次进入页面显示已保存的值，revision 正常（并发修改时出现冲突横幅
-   +「重新加载」按钮，不静默覆盖）。
-4. 一键「恢复默认」后确认配置回组合默认值。
+2. **首次打开（尚无 `fallbacks` 配置）**：页面显示骨架（`nav` 标题 / 介绍 / 只读状态块 /
+   功能级开关 / 保存 / 恢复默认），功能级开关 `enabled` **默认 OFF**，配置表单主体隐藏、
+   显示「功能未开启」提示——页面始终可用，不因命名空间缺失而空白。
+3. 打开 `enabled` 开关 → 配置表单主体出现（`triggerCodes` / `chains` / `roles` /
+   `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）。
+4. 编辑任一字段（如把 `cooldownMs` 改为 `600000`）并保存。
+5. **预期**：保存成功、无冲突横幅；`$DSH_HOME/settings.yaml`（或该 profile 的 settings
+   路径）写入新值（含 `enabled: true`）；再次进入页面显示已保存的值、开关保持 ON，
+   revision 正常（并发修改时出现冲突横幅 +「重新加载」按钮，不静默覆盖）。
+6. 关闭 `enabled` 开关 → 表单主体再次隐藏（编辑中的 draft 保留，重新打开仍在）；
+   一键「恢复默认」后确认配置回组合默认值（`enabled` 回 `false`）。
 
 ### 3. 运行期 fallback 验证（模拟失败）
 

--- a/src/client/FallbacksSection.module.css
+++ b/src/client/FallbacksSection.module.css
@@ -26,11 +26,29 @@
   color: var(--dsw-alias-label-tertiary);
 }
 
-.notice {
-  margin: 0;
-  font-size: 14px;
-  line-height: 22px;
-  color: var(--dsw-alias-label-tertiary);
+/* Enabled OFF notice (readme-settings spec §1.2): neutral guidance shown in
+ * place of the hidden form body — informational, not an error. */
+.offNotice {
+  padding: 8px 12px;
+  border: 1px solid var(--dsw-alias-border-l2);
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--dsw-alias-label-secondary);
+  background: var(--dsw-alias-bg-layer-1);
+}
+
+/* Namespace-not-registered info banner (spec §1.4-3): informational, not a
+ * dead-end notice — the page shows the default-config seed and saves are
+ * attempted. Uses the business (info) state tokens. */
+.infoBanner {
+  padding: 8px 12px;
+  border: 1px solid var(--dsw-alias-state-business-primary);
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--dsw-alias-state-business-primary);
+  background: var(--dsw-alias-state-business-tertiary);
 }
 
 .field {

--- a/src/client/FallbacksSection.tsx
+++ b/src/client/FallbacksSection.tsx
@@ -121,10 +121,14 @@ export function FallbacksSection({ controller, t }: FallbacksSectionProps): Reac
   // Editors seed from `defaultFallbacksConfig` on mount (readme-settings spec
   // §1.4-1): the skeleton is always visible — even before any descriptor
   // arrives (idle/loading) or when the namespace is missing (unavailable).
-  // `seededRevision` stays null until the first ready descriptor, which then
-  // re-seeds with server truth. Because controls stay disabled until
-  // `writable` turns true (only a ready descriptor sets it), the mount seed
-  // can never be overwritten while the user is editing.
+  // The mount seed is only a placeholder: `seededRevision` stays null until
+  // the first ready descriptor, and every later ready (a refresh re-load)
+  // re-seeds with server truth. Controls are not gated on `ready` — a missing
+  // namespace with `writable: true` leaves the switch/form body editable
+  // pre-ready (§1.4-4) — so a mid-edit push (host registers the namespace →
+  // settings/changed → refresh → load → ready) overwrites the draft with
+  // server truth on the next ready: unsaved drafts are not preserved across
+  // the unavailable→ready upgrade.
   const [scalars, setScalars] = useState<FallbacksScalars>(() => scalarsOf(defaultFallbacksConfig))
   const [chainRows, setChainRows] = useState<ChainRow[]>(() => chainsToRows(defaultFallbacksConfig.chains))
   const [ruleRows, setRuleRows] = useState<RoleRuleRow[]>(() => rulesToRows(defaultFallbacksConfig.roles.rules))

--- a/src/client/FallbacksSection.tsx
+++ b/src/client/FallbacksSection.tsx
@@ -22,6 +22,7 @@ import type { ReactNode } from 'react'
 import { useSyncExternalStore } from 'react'
 import type { PropsLocale, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
 import type { FallbacksConfig, RevertPolicy } from '../config.ts'
+import { defaultFallbacksConfig } from '../config.ts'
 import {
   FallbacksSettingsController,
   chainsToRows,
@@ -117,11 +118,16 @@ export function FallbacksSection({ controller, t }: FallbacksSectionProps): Reac
     }
   }, [controller])
 
-  // Editors seed from the descriptor once per revision; a save or a reload
-  // bumps the revision and re-seeds with server truth.
-  const [scalars, setScalars] = useState<FallbacksScalars | null>(null)
-  const [chainRows, setChainRows] = useState<ChainRow[]>([])
-  const [ruleRows, setRuleRows] = useState<RoleRuleRow[]>([])
+  // Editors seed from `defaultFallbacksConfig` on mount (readme-settings spec
+  // §1.4-1): the skeleton is always visible — even before any descriptor
+  // arrives (idle/loading) or when the namespace is missing (unavailable).
+  // `seededRevision` stays null until the first ready descriptor, which then
+  // re-seeds with server truth. Because controls stay disabled until
+  // `writable` turns true (only a ready descriptor sets it), the mount seed
+  // can never be overwritten while the user is editing.
+  const [scalars, setScalars] = useState<FallbacksScalars>(() => scalarsOf(defaultFallbacksConfig))
+  const [chainRows, setChainRows] = useState<ChainRow[]>(() => chainsToRows(defaultFallbacksConfig.chains))
+  const [ruleRows, setRuleRows] = useState<RoleRuleRow[]>(() => rulesToRows(defaultFallbacksConfig.roles.rules))
   const seededRevision = useRef<number | null>(null)
 
   useEffect(() => {
@@ -133,27 +139,16 @@ export function FallbacksSection({ controller, t }: FallbacksSectionProps): Reac
     setRuleRows(rulesToRows(state.config.roles.rules))
   }, [state.status, state.revision, state.config])
 
-  // Statuses that keep the form mounted: ready, saving, and error-with-
-  // conflict (the stale draft stays visible next to the conflict banner so a
-  // reload can re-seed instead of silently discarding the user's edits).
-  const formMounted = scalars !== null && (
-    state.status === 'ready'
-    || state.status === 'saving'
-    || (state.status === 'error' && state.conflict !== null)
-  )
-  if (!formMounted) {
-    if (state.status === 'unavailable') {
-      return <div className={css.notice}>{t('unavailable')}</div>
-    }
-    if (state.status === 'error') {
-      return <div className={css.notice} role="alert">{t('error.generic', { message: state.error ?? '' })}</div>
-    }
-    return <div className={css.notice}>{t('loading')}</div>
-  }
+  // The skeleton always renders (readme-settings spec §1.2): title, intro,
+  // banners, the read-only status block, the `enabled` switch, and the
+  // save/reset actions are visible in every store state (idle / loading /
+  // ready / saving / unavailable / error). The form body below is gated on
+  // the draft's `enabled` flag. Controls are disabled while `writable` is
+  // false (initial load, loading, or a read-only describe response), so an
+  // empty skeleton never invites edits the host would refuse.
 
   const updateScalars = (mutator: (draft: FallbacksScalars) => void): void => {
     setScalars(prev => {
-      if (prev === null) return prev
       const next: FallbacksScalars = { ...prev, triggerCodes: [...prev.triggerCodes] }
       mutator(next)
       return next
@@ -205,6 +200,12 @@ export function FallbacksSection({ controller, t }: FallbacksSectionProps): Reac
       {state.error !== null && state.conflict === null && (
         <div className={css.banner} role="alert">{t('error.generic', { message: state.error })}</div>
       )}
+      {state.status === 'unavailable' && (
+        // Namespace not registered (readme-settings spec §1.4-3): an
+        // informational banner — the page shows the default-config seed and
+        // saves are attempted; failures land in the error banner above.
+        <div className={css.infoBanner}>{t('unavailable')}</div>
+      )}
 
       {/* AC-7 read-only status: effective config summary; the recent-switch
        * summary is a placeholder until T8 wires a session-event reading face
@@ -232,6 +233,15 @@ export function FallbacksSection({ controller, t }: FallbacksSectionProps): Reac
         <span className={css.hint}>{t('enabled.hint')}</span>
       </label>
 
+      {/* Enabled OFF (readme-settings spec §1.2): the form body is hidden but
+       * never discarded — the draft stays in state and comes right back when
+       * the switch is toggled on. */}
+      {!scalars.enabled && (
+        <div className={css.offNotice}>{t('enabled.off')}</div>
+      )}
+
+      {scalars.enabled && (
+      <>
       <fieldset className={css.field} disabled={!writable}>
         <legend className={css.fieldLabel}>{t('triggerCodes.label')}</legend>
         <span className={css.hint}>{t('triggerCodes.hint')}</span>
@@ -416,6 +426,8 @@ export function FallbacksSection({ controller, t }: FallbacksSectionProps): Reac
           {t('roles.addRule')}
         </button>
       </fieldset>
+      </>
+      )}
 
       <div className={css.actions}>
         <button

--- a/src/client/fallbacks-store.ts
+++ b/src/client/fallbacks-store.ts
@@ -17,6 +17,11 @@
  * surfaces it as `state.conflict` so the form can prompt a reload instead of
  * silently overwriting a concurrent change (the `SettingsConflictError`
  * presentation contract).
+ *
+ * Namespace-missing writes (readme-settings spec §1.4-2): when no view has
+ * ever been accepted the store still attempts `update`/`replace` with
+ * `expectedRevision` omitted (no precondition) — acceptance is the host's
+ * call; a refusal lands in `error` with the banner surfacing it honestly.
  */
 
 import type {
@@ -243,10 +248,16 @@ export class FallbacksSettingsController {
       if (!response.result.ok) throw response.result.error
       const view = response.result.value.namespaces.find(entry => entry.ns === FALLBACKS_SETTINGS_NS)
       if (view === undefined) {
+        // Namespace not registered (readme-settings spec §1.4-3): keep the
+        // 'unavailable' status — there is no server truth (no view/revision)
+        // — but seed the spec defaults and follow the describe response's
+        // writable flag instead of forcing `false`, so the page stays a
+        // usable skeleton and a first config can be attempted.
         this.view = undefined
+        const writable = response.result.value.writable
         this.store.update((state) => {
           state.status = 'unavailable'
-          state.writable = false
+          state.writable = writable
           state.config = defaultFallbacksConfig
           state.revision = 0
           state.error = null
@@ -262,14 +273,17 @@ export class FallbacksSettingsController {
 
   /**
    * Persist the full edited configuration via `settings.update` (merge
-   * semantics), carrying the descriptor revision so a stale editor is
-   * refused rather than silently overwriting a concurrent change.
+   * semantics). With a descriptor view the write carries `view.revision` so a
+   * stale editor is refused rather than silently overwriting a concurrent
+   * change; without a view (namespace never registered) `expectedRevision` is
+   * omitted — a precondition-less write whose acceptance is the host's call
+   * (readme-settings spec §1.4-2).
    * @param next - the complete edited configuration.
    */
   async save(next: FallbacksConfig): Promise<void> {
     const view = this.view
     const state = this.store.getSnapshot()
-    if (view === undefined || !state.writable || state.status === 'saving') return
+    if (!state.writable || state.status === 'saving') return
     const generation = ++this.generation
     this.store.update((draft) => {
       draft.status = 'saving'
@@ -280,7 +294,7 @@ export class FallbacksSettingsController {
       const response = await this.api.settings.update({
         ns: FALLBACKS_SETTINGS_NS,
         patch: next as unknown as object,
-        expectedRevision: view.revision,
+        ...(view === undefined ? {} : { expectedRevision: view.revision }),
       })
       if (generation !== this.generation) return
       if (!response.result.ok) throw response.result.error
@@ -294,12 +308,13 @@ export class FallbacksSettingsController {
   /**
    * Reset the namespace's user section wholesale via `settings.replace`
    * (`section: {}` resets to composition defaults — the removal path a merge
-   * cannot express).
+   * cannot express). `expectedRevision` rides along when a view exists and is
+   * omitted otherwise, mirroring {@link save}'s namespace-missing policy.
    */
   async resetToDefaults(): Promise<void> {
     const view = this.view
     const state = this.store.getSnapshot()
-    if (view === undefined || !state.writable || state.status === 'saving') return
+    if (!state.writable || state.status === 'saving') return
     const generation = ++this.generation
     this.store.update((draft) => {
       draft.status = 'saving'
@@ -310,7 +325,7 @@ export class FallbacksSettingsController {
       const response = await this.api.settings.replace({
         ns: FALLBACKS_SETTINGS_NS,
         section: {},
-        expectedRevision: view.revision,
+        ...(view === undefined ? {} : { expectedRevision: view.revision }),
       })
       if (generation !== this.generation) return
       if (!response.result.ok) throw response.result.error

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -16,6 +16,7 @@ export const zh = {
   'nav.description': '模型故障自动降级',
   'enabled.label': '启用故障降级',
   'enabled.hint': '关闭后插件完全不介入；开启但未配置任何链时行为与未安装插件一致。',
+  'enabled.off': '功能未开启：打开 enabled 开关以显示配置界面。',
   'triggerCodes.label': '触发失败码',
   'triggerCodes.hint': '命中这些失败码时进入降级链决策；可重试型故障（如 5xx）由 llm-retry 先行退避，预算耗尽后同样进入决策。',
   'triggerCodes.RATE_LIMIT': '限流（429）',
@@ -66,7 +67,7 @@ export const zh = {
   'reset': '恢复默认',
   'reset.confirm': '确定要把 fallbacks 配置恢复为默认值吗？',
   'loading': '加载中…',
-  'unavailable': '无法读取 fallbacks 设置（未注册或只读环境）。',
+  'unavailable': 'fallbacks 命名空间尚未注册：以下显示默认配置，可尝试保存；保存失败会在此处如实提示。',
   'error.generic': '出错：{message}',
 } satisfies Record<string, string>
 
@@ -79,6 +80,7 @@ export const en = {
   'nav.description': 'Automatic fallback on model failures',
   'enabled.label': 'Enable failure fallback',
   'enabled.hint': 'When off the plugin never intervenes; when on with no chains configured behavior is identical to an uninstalled plugin.',
+  'enabled.off': 'Feature disabled: turn on the enabled switch to show the configuration interface.',
   'triggerCodes.label': 'Trigger failure codes',
   'triggerCodes.hint': 'Failures with these codes enter chain decision; retryable failures (e.g. 5xx) back off via llm-retry first and reach the decision only when its budget is exhausted.',
   'triggerCodes.RATE_LIMIT': 'Rate limit (429)',
@@ -129,7 +131,7 @@ export const en = {
   'reset': 'Reset to defaults',
   'reset.confirm': 'Reset the fallbacks configuration to defaults?',
   'loading': 'Loading…',
-  'unavailable': 'Cannot read fallbacks settings (namespace not registered or read-only environment).',
+  'unavailable': 'The fallbacks namespace is not registered yet: showing the default configuration. You can try to save; failures will be reported here.',
   'error.generic': 'Error: {message}',
 } satisfies Record<FallbacksKey, string>
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,9 +47,15 @@ export interface FallbacksConfig {
   alwaysModeRetryCap: number
 }
 
-/** Spec §4 defaults — `Config({})` must equal this (no-op install). */
+/**
+ * Spec §4 defaults — `Config({})` must equal this (no-op install).
+ * `enabled` defaults to `false` (readme-settings spec §1.2): the feature
+ * switch is off until the user turns it on in the settings page; an
+ * unconfigured install (`enabled: false`, empty chains) behaves exactly like
+ * an uninstalled plugin (AC-3).
+ */
 export const defaultFallbacksConfig: FallbacksConfig = {
-  enabled: true,
+  enabled: false,
   triggerCodes: ['AUTH', 'QUOTA', 'RATE_LIMIT'],
   chains: {},
   roles: { default: 'default', rules: [] },
@@ -65,7 +71,7 @@ export const defaultFallbacksConfig: FallbacksConfig = {
  * the spec defaults, `.required()` keeps `rules[].role` mandatory.
  */
 export const Config = z.object({
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().default(false),
   triggerCodes: z.array(z.string()).default(['AUTH', 'QUOTA', 'RATE_LIMIT']),
   chains: z.dict(z.array(z.string())).default({}),
   roles: z

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -20,7 +20,9 @@ describe('fallbacks Config schema', () => {
     } as unknown as FallbacksConfig)
     expect(resolved.cooldownMs).toBe(1_000)
     expect(resolved.chains).toEqual({ default: ['other/gpt-4o'] })
-    expect(resolved.enabled).toBe(true)
+    // The feature switch defaults OFF (readme-settings spec §1.2); a partial
+    // input inherits the new default.
+    expect(resolved.enabled).toBe(false)
     expect(resolved.triggerCodes).toEqual(['AUTH', 'QUOTA', 'RATE_LIMIT'])
   })
 })

--- a/tests/fallbacks-store.spec.ts
+++ b/tests/fallbacks-store.spec.ts
@@ -307,6 +307,26 @@ describe('FallbacksSettingsController', () => {
     expect(state.revision).toBe(1)
   })
 
+  it('resets via settings.replace with no expectedRevision when the namespace is missing but writable (spec §1.4-2)', async () => {
+    // resetToDefaults mirrors save()'s precondition-less policy: no view →
+    // expectedRevision is omitted (no precondition); the host's acceptance
+    // lands the store in ready with a real view/revision.
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [] }))
+    api.settings.replace.mockResolvedValue(ok(viewOf({ value: defaultFallbacksConfig, revision: 1 })))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.resetToDefaults()
+    expect(api.settings.replace).toHaveBeenCalledTimes(1)
+    const write = api.settings.replace.mock.calls[0]![0] as Record<string, unknown>
+    expect(write.ns).toBe('fallbacks')
+    expect(write.section).toEqual({})
+    expect(write).not.toHaveProperty('expectedRevision')
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('ready')
+    expect(state.revision).toBe(1)
+  })
+
   it('surfaces a host refusal of a precondition-less write as an error (spec §1.4-2)', async () => {
     // The host says no (unregistered namespace / read refusal): the error
     // state + banner render honestly — the skeleton and draft survive.

--- a/tests/fallbacks-store.spec.ts
+++ b/tests/fallbacks-store.spec.ts
@@ -178,14 +178,33 @@ describe('FallbacksSettingsController', () => {
     expect(api.settings.describe).toHaveBeenCalledWith({})
   })
 
-  it('reports unavailable when the namespace is missing from the descriptor', async () => {
+  it('seeds defaults and follows writable when the namespace is missing (unavailable, not a dead end)', async () => {
+    // readme-settings spec §1.4-3: the 'unavailable' status is kept — there is
+    // no server truth (no view/revision) — but the page must stay a usable
+    // skeleton: spec-default seed + writable following the describe response.
     const api = makeApi()
     api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [] }))
     const controller = new FallbacksSettingsController(api)
     await controller.load()
     const state = controller.store.getSnapshot()
     expect(state.status).toBe('unavailable')
+    expect(state.writable).toBe(true)
+    expect(state.config).toEqual(defaultFallbacksConfig)
+    expect(state.revision).toBe(0)
+    expect(state.error).toBeNull()
+  })
+
+  it('keeps a read-only environment honest: missing namespace + writable:false stays disabled', async () => {
+    // §1.4-4: only a real read-only describe response disables the controls —
+    // the always-visible skeleton must not weaken honest read-only rendering.
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: false, hasDocument: false, namespaces: [] }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('unavailable')
     expect(state.writable).toBe(false)
+    expect(state.config).toEqual(defaultFallbacksConfig)
   })
 
   it('surfaces a failed describe as an error state', async () => {
@@ -258,7 +277,7 @@ describe('FallbacksSettingsController', () => {
     expect(controller.store.getSnapshot().revision).toBe(3)
   })
 
-  it('refuses writes when the namespace is missing or not writable', async () => {
+  it('refuses writes when the provider is not writable', async () => {
     const api = makeApi()
     api.settings.describe.mockResolvedValue(ok({ writable: false, hasDocument: false, namespaces: [viewOf()] }))
     const controller = new FallbacksSettingsController(api)
@@ -267,6 +286,40 @@ describe('FallbacksSettingsController', () => {
     await controller.resetToDefaults()
     expect(api.settings.update).not.toHaveBeenCalled()
     expect(api.settings.replace).not.toHaveBeenCalled()
+  })
+
+  it('attempts a precondition-less write when the namespace is missing but writable (spec §1.4-2)', async () => {
+    // No view → expectedRevision is omitted (no precondition); the host's
+    // acceptance lands the store in ready with a real view/revision.
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [] }))
+    api.settings.update.mockResolvedValue(ok(viewOf({ value: defaultFallbacksConfig, revision: 1 })))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.save(defaultFallbacksConfig)
+    expect(api.settings.update).toHaveBeenCalledTimes(1)
+    const write = api.settings.update.mock.calls[0]![0] as Record<string, unknown>
+    expect(write.ns).toBe('fallbacks')
+    expect(write.patch).toEqual(defaultFallbacksConfig)
+    expect(write).not.toHaveProperty('expectedRevision')
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('ready')
+    expect(state.revision).toBe(1)
+  })
+
+  it('surfaces a host refusal of a precondition-less write as an error (spec §1.4-2)', async () => {
+    // The host says no (unregistered namespace / read refusal): the error
+    // state + banner render honestly — the skeleton and draft survive.
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [] }))
+    api.settings.update.mockResolvedValue(error('settings-rejected', 'namespace not registered', { ns: 'fallbacks' }))
+    const controller = new FallbacksSettingsController(api)
+    await controller.load()
+    await controller.save(defaultFallbacksConfig)
+    const state = controller.store.getSnapshot()
+    expect(state.status).toBe('error')
+    expect(state.error).toBe('namespace not registered')
+    expect(state.conflict).toBeNull()
   })
 
   it('drops in-flight responses after dispose (generation guard)', async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -25,6 +25,7 @@ import { Context, type Logger } from 'cordis'
 import type { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { apply, countRetryEvents, normalizeChains, stateStore } from '../src/index.ts'
+import { defaultFallbacksConfig } from '../src/config.ts'
 import { registrations, resetSettingsStub } from './support/settings-stub.ts'
 import {
   cfg,
@@ -101,6 +102,27 @@ describe('request-error → request switch closed loop', () => {
     const action = await dispatchRequestError(ctx, agent)
     expect(action).toBeUndefined()
     expect(switchEvents(agent)).toHaveLength(0)
+  })
+})
+
+describe('default-config no-op (AC-3: enabled default OFF flips nothing at runtime)', () => {
+  it('passes trigger-code failures and requests through with zero events on the default config', async () => {
+    const { agent } = makeAgent('agent-ac3', { provider: 'mock', model: 'gpt-4o' })
+    // The true spec default — `enabled: false`, empty chains — must behave
+    // exactly like an uninstalled plugin (readme-settings spec §1.3: the
+    // default-value flip does not change the runtime gating).
+    apply(ctx, defaultFallbacksConfig)
+
+    // request-error: the trigger code would enter the decision path if the
+    // switch were on; with the default config it passes through untouched.
+    const action = await dispatchRequestError(ctx, agent, { failure: { message: 'denied', code: 'AUTH' } })
+    expect(action).toBeUndefined()
+    expect(switchEvents(agent)).toHaveLength(0)
+
+    // request: passthrough, and no state entry was ever grown (zero-cost).
+    const config = await dispatchRequest(ctx, agent, { provider: 'mock', model: 'gpt-4o' })
+    expect(config).toEqual({ provider: 'mock', model: 'gpt-4o' })
+    expect(stateStore(ctx)?.size).toBe(0)
   })
 })
 

--- a/tests/support/harness.ts
+++ b/tests/support/harness.ts
@@ -22,9 +22,16 @@ import type { LlmCallConfig, LlmFailure, ReasoningEffortId, ResolvedRetryPolicy 
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { defaultFallbacksConfig, type FallbacksConfig } from '../../src/config.ts'
 
-/** Config helper: spec defaults + overrides (the plugin re-resolves through the schema). */
+/**
+ * Config helper: spec defaults + overrides (the plugin re-resolves through
+ * the schema). The `enabled` baseline is explicit `true` — the default value
+ * flipped to `false` in this iteration (readme-settings spec §1.2), and the
+ * runtime tests exercise the *active* plugin, so every cfg() call inherits
+ * `enabled: true` unless a case overrides it (AC-3 default no-op is pinned
+ * by its own explicit test).
+ */
 export function cfg(overrides: Partial<FallbacksConfig> = {}): FallbacksConfig {
-  return { ...defaultFallbacksConfig, ...overrides }
+  return { ...defaultFallbacksConfig, enabled: true, ...overrides }
 }
 
 /** Fake agent + session; `setRoute` simulates the loop logging a new request header after a switch. */


### PR DESCRIPTION
## Summary

Iteration **iter-20260810-readme-settings** — two user-requested changes:

1. **README 中英双语**：`README.md` (en) + `README.zh-CN.md` (zh) 双文件互链、shields.io badges、一句话 URL 安装命令（第一段介绍后）；docs 同步（install/configuration/verification）。
2. **Fallbacks 设置页始终可用 + `enabled` 默认 OFF**：设置页在任意配置状态下渲染可操作骨架（含首开无配置场景）；功能级开关 `fallbacks.enabled`（用户配置字段）默认 `false`，OFF 隐藏表单主体、ON 显示完整配置界面；命名空间缺失时以默认值种子展示 + 保存可尝试（无 view 省略 expectedRevision，失败如实呈现）。

## Changes

- `src/config.ts`: `enabled` default `true → false`（单点）
- `src/client/fallbacks-store.ts`: unavailable 语义改写（默认种子 + writable 跟随 + 可保存）
- `src/client/FallbacksSection.tsx`: 骨架恒渲染、挂载即播种、enabled 显隐表单主体
- `src/client/locales.ts` + `FallbacksSection.module.css`: 文案定稿 ①② + 样式
- `README.md` / `README.zh-CN.md` / `docs/install.md` / `docs/configuration.md` / `docs/verification.md`
- 测试：`tests/`（cfg() 基准修正、store 用例拆分、AC-3 no-op 专项；**13 files / 168 tests green**）

## Gates

- SDD: T1/T2 每 task 独立 review Approve
- Plan QC tri: qc1/qc2/qc3 Approve ×2 轮（fix 波次 5 项 Suggestion + targeted re-review）
- QA gate: mandatory — **Accept**（zero-residual；AC-1..AC-5 全映射；C-3/C-4 视觉项转人工验收指引）
- Phase 3 iteration-close: compound（knowledge 更新 1 篇，validate PASS）+ roadmap + compass completed