### PR TITLE
ci: add GitHub Actions verify pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,19 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11
+          version: 11.21.0
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.23.2
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test
+
+      - run: pnpm build


### PR DESCRIPTION
## Summary

User request (2026-08-14): add CI configuration. New `.github/workflows/ci.yml` — verify pipeline for PRs + main pushes:

- Triggers: `pull_request`, `push: main`, `workflow_dispatch`
- Concurrency group per workflow+ref (stale runs cancelled)
- Job `build-and-test` (ubuntu-latest, `permissions: contents: read`, `timeout-minutes: 20`):
  `checkout@v4` → `pnpm/action-setup@v4` (11.21.0) → `setup-node@v4` (22.23.2, cache pnpm) → `pnpm install --frozen-lockfile` → `pnpm test` → `pnpm build` (tsc + tsdown + build-client + verify-dist)

Zero-publish, zero secrets (verified: `@deepseek-ai/*` peers resolve from the public registry, no `.npmrc`).

## Verification

- actionlint clean + YAML parse (implementer evidence)
- QC tri 3× Approve (0 Critical/Warning) → fix wave e239eff → targeted re-review 3× Approve
- QA (mandatory): real PR run green (this run)
- Open residual R-001 (defer, low): double-build idempotent redundancy (prepare during install + explicit build) — tracked with Durable Roadmap in `status.json`