### PR TITLE
docs: English-only docs/ + root AGENTS.md (dev conventions + .changes rules)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# AGENTS.md — dsh-llm-fallbacks
+
+Project-level rules for coding agents in this repository. This file is the
+**project layer**; the Morning Star harness lives under `.mstar/` (see
+[Process artifacts](#process-artifacts)).
+
+## Source priority
+
+1. The current user instruction
+2. This file (project rules)
+3. `.mstar/` harness rules (`mstar-*` skills)
+4. Role references (`mstar-roles`)
+
+## Repository
+
+`dsh-llm-fallbacks` is a TypeScript plugin for dsh (DeepSeek Harness): it
+builds automatic provider/model fallback chains so agent steps keep running
+when LLM requests fail (retry exhausted, auth, quota, rate limit). It mounts
+into dsh as a **pure mount** — see [Code constraints](#code-constraints).
+
+- Runtime: Node >= 22, pnpm >= 10 (project stack: pnpm 11.21+).
+- Package manager: pnpm; CI installs with `pnpm install --frozen-lockfile`.
+- License: MIT (`LICENSE` is authoritative).
+
+## Build & test interface
+
+- `pnpm test` — vitest run (full suite; includes the release-script
+  contract tests in `tests/release-scripts.spec.ts`).
+- `pnpm build` — full build: `tsc -p tsconfig.build.json` → `tsdown` →
+  `build-client` → `tsc` → `verify-dist`.
+- `pnpm release:prepare [-- <version> | -- --patch]` — release prep
+  (see [Release flow](#release-flow)).
+- `pnpm release:validate -- v<version>` — version/tag consistency check.
+- Local workflow lint (not in CI): `actionlint .github/workflows/*.yml`
+  (ci + release-prep + release).
+- CI (`.github/workflows/ci.yml`): `pnpm test` + `pnpm build` on
+  PR / push to main / manual.
+
+## Changelog fragments (`.changes/`)
+
+Every **user-visible change** MUST ship with a fragment in
+`.changes/unreleased/` — fragments are what the changelog is made of.
+`pnpm release:prepare` assembles them into `CHANGELOG.md` and archives them
+to `.changes/archive/<version>/`. **A release with zero fragments fails at
+publish time**: the changelog section is empty, and the Release workflow
+refuses to create an empty GitHub Release.
+
+Rules:
+
+- **One file per change**: filename is any slug ending in `.md`
+  (e.g. `add-foo.md`). `.changes/unreleased/README.md` and `.gitkeep` are
+  ignored by the assembler.
+- **Frontmatter**: optional `category:` key — one file carries ONE category
+  (`Added`, `Changed`, `Fixed`, ...). It groups the fragment's bullets under
+  a `### <category>` heading in the changelog. Default: `Changed`.
+- **Body**: one or more **English bullet lines** (`- ` prefix). The changelog
+  is single-language (English) and the body is rendered **verbatim** into
+  `CHANGELOG.md`. Non-bullet lines (e.g. `<!-- CN -->`) are rendered verbatim
+  too and garble the changelog — never put them in a fragment.
+
+```markdown
+---
+category: Added
+---
+- Describe the change in one concise English bullet.
+- A second bullet if needed.
+```
+
+- Keep each fragment focused on a single user-visible change.
+
+## Documentation language
+
+- **English only** for docs and user-facing text (decision 2026-08-14).
+  `README.md` is the English main file; `README.zh-CN.md` is the Chinese
+  translation. All `docs/*.md` are English.
+- Never add Chinese prose to `README.md`, `docs/`, `CHANGELOG.md`, or
+  fragments.
+
+## Release flow
+
+PR-driven, two steps — merging the release PR is the ONLY publish path
+(no `push:tags` auto-publish):
+
+1. **Release prep** (manual: Actions → Release prep → Run workflow): assembles
+   fragments, bumps `package.json`, builds, and opens/updates a
+   `release vX.Y.Z` PR (base `main`, label `release`). Pass an explicit
+   version (the first release is `0.1.0-alpha.2`) or leave the input empty
+   for an auto `--patch` bump.
+2. **Merge the PR** → `release.yml` runs on the merge commit: validate →
+   build → `npm publish --provenance --access public --tag latest` →
+   tag `vX.Y.Z` → GitHub Release (prerelease when the version contains `-`).
+
+Secrets: **zero long-term secrets**. npm auth is Trusted Publishing (OIDC,
+tokenless) once the package exists; the one-time `NODE_AUTH_TOKEN` bootstrap
+secret is only for the first publish and is deleted afterwards. Workflows use
+only the built-in `GITHUB_TOKEN`. Release workflows run Node 24.19.0 /
+pnpm 11.21.0.
+
+Full SOP, npm auth setup, and rollback → `docs/release.md`.
+
+## Code constraints
+
+- **Mount-only**: the plugin never modifies the dsh source tree (bundle
+  insert + client inject + own gateway; no patches, no postinstall step).
+  Keep it that way.
+- **Peers from the public registry**: all `@deepseek-ai/*` packages are
+  `peerDependencies` ONLY — resolved from the npm registry at dev time
+  (`autoInstallPeers` + user-level `~/.npmrc` token), never added to
+  `dependencies`/`devDependencies`, never linked locally.
+  `tests/peer-deps.test.ts` enforces this contract.
+- **English commit messages**, conventional style (`feat:`, `fix:`,
+  `docs:`, `chore:`, ...).
+- **Feature branch → PR → main** for all changes; never commit directly to
+  `main`.
+- Match existing patterns and keep diffs surgical.
+
+## Process artifacts
+
+`.mstar/` is the Morning Star harness's local process SSOT: process artifacts
+(`plans/`, `sdd/`, `status.json`, `iterations/`, ...) are **gitignored**;
+tracked results are `.mstar/knowledge/` and `.mstar/specs/`. Harness rules
+live in the `mstar-*` skills. This file intentionally carries no dynamic
+state, current progress, or review details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,107 +1,107 @@
-# 配置指南（`fallbacks` 命名空间）
+# Configuration Guide (`fallbacks` Namespace)
 
-插件配置集中在 `fallbacks` settings 命名空间，可在 dsh 设置文档（默认 `$DSH_HOME/settings.yaml`）中编辑，也可在 web 设置 GUI 的 **插件配置 → Fallbacks 卡片**中编辑——两者读写同一命名空间。卡片的读写走**插件自有 gateway 通道**（`/api/fallbacks/get` / `/api/fallbacks/set` / `/api/fallbacks/reset`），不依赖 dsh 本体的任何设置暴露机制；`fallbacks` 命名空间不出现在宿主 describe 暴露集合属预期设计。插件对 dsh 源码树**零本地修改**（纯挂载：bundle 行插入 + client inject + 自有 gateway），dsh 升级无需重打补丁。
+Plugin configuration lives in the `fallbacks` settings namespace. It can be edited in the dsh settings document (default `$DSH_HOME/settings.yaml`) or in the web settings GUI via **插件配置 (Plugin Settings) → Fallbacks card** — both read and write the same namespace. The card's reads/writes go through the **plugin's own gateway channel** (`/api/fallbacks/get` / `/api/fallbacks/set` / `/api/fallbacks/reset`) and do not depend on any settings-exposure mechanism of the dsh host; the `fallbacks` namespace not appearing in the host's describe exposure is by design. The plugin makes **zero local modifications** to the dsh source tree (pure mount: bundle row insert + client inject + its own gateway), so dsh upgrades never require re-patching.
 
-## 两块制模型
+## Two-block model
 
-配置自 iter-20260813 起为**两块制**，用户只需记住两块：
+Since iter-20260813 the configuration follows a **two-block model** — you only need to remember two blocks:
 
-| 块 | 一句话 | 配置落点 |
+| Block | In one sentence | Config location |
 |----|--------|----------|
-| 块 1 | root 主代理失败只走这一条链；空 = 不降级 | `rootChain` |
-| 块 2 | 先声明角色，再让规则引用；没命中则继承 root | `roles.list` + `roles.rules` |
+| Block 1 | The root agent's failures follow this one chain only; empty = no fallback | `rootChain` |
+| Block 2 | Declare roles first, then let rules reference them; no match inherits root | `roles.list` + `roles.rules` |
 
-**不要混用：**
+**Do not mix them up:**
 
-- `'inherit'` = 内置**角色 id**（规则目标 / 未命中缺省；**禁止**写入 `roles.list[].id`）；
-- `'inherit-root'` = 角色实体上的**链拼接策略**（默认；角色链走完再**追加** `rootChain`）；
-- 旧「角色解析兜底字段」**已删除**，不再是有效配置（改写依据见下文迁移映射表）。
+- `'inherit'` = the built-in **role id** (rule target / no-match default; **forbidden** in `roles.list[].id`);
+- `'inherit-root'` = the **chain-append policy** on a role entity (default; runs the role chain, then **appends** `rootChain`);
+- the old "role-resolution fallback field" **has been removed** and is no longer valid configuration (see the migration mapping table below for how to rewrite it).
 
-## 字段总览
+## Field overview
 
-| 字段 | 类型 | 默认值 | 说明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | boolean | `false` | 功能级总开关。默认关闭（OFF）：`false` 时插件完全不介入、卡片隐藏配置表单主体；`true` 但未配置任何链时行为与未安装插件一致（no-op） |
-| `triggerCodes` | string[] | `['AUTH', 'QUOTA', 'RATE_LIMIT']` | 命中这些失败码时进入链决策。可重试型故障（5xx / `RATE_LIMIT` 等）先由 llm-retry 退避重试，预算耗尽后同样进入决策——**无需为 5xx 额外添加 triggerCodes** |
-| `rootChain` | string[] | `[]` | **块 1**。root 主代理的有序降级链；条目为 `provider/model` 或 `provider/*`（见下文条目语法）。空 = root 不降级（no-op 透传） |
-| `roles.list` | Array | `[]` | **块 2**。声明式角色实体集合（id/label/description + 可选 chain/fallback，条目字段见下表）。id 须匹配 `/^[a-z0-9-]{1,32}$/` 且集合内唯一；`'inherit'` 为保留字，**禁止**用作 id |
-| `roles.rules` | Array | `[]` | **块 2**。角色规则：按 `origin`（`root`/`subagent`）、`provider`、`model` 模式顺序匹配到角色（字段省略即不约束，首个命中即停）；`role` 只能引用 `roles.list[].id` 或内置 `'inherit'` |
-| `cooldownMs` | number | `300000` | 冷却时长（毫秒）。被切离/失败的模型在冷却期内不再入选 |
-| `revertPolicy` | `'cooldown-expiry'` \| `'never'` | `'cooldown-expiry'` | 冷却到期后的回主策略：到期回主模型 / 会话内保持备用模型 |
-| `maxSwitchesPerStep` | number | `8` | 单步安全阀：每 step 切换次数上限，超限停止切换、保持原错误语义，防止链循环放大延迟 |
-| `alwaysModeRetryCap` | number | `5` | always 模式重试上限：`retryPolicy.mode === 'always'` 的 provider 在同一请求内重试达到该次数后切换；`0` 禁用 |
+| `enabled` | boolean | `false` | Feature-level master switch. Defaults to off (`false`): when `false` the plugin never intervenes and the card hides the configuration form body; when `true` but with no chains configured, the behavior is identical to an uninstalled plugin (no-op) |
+| `triggerCodes` | string[] | `['AUTH', 'QUOTA', 'RATE_LIMIT']` | Failures with these codes enter chain decision. Retryable failures (5xx / `RATE_LIMIT` etc.) are first retried with backoff by llm-retry and enter the decision the same way once its budget is exhausted — **no extra `triggerCodes` entries are needed for 5xx** |
+| `rootChain` | string[] | `[]` | **Block 1**. The root agent's ordered fallback chain; entries are `provider/model` or `provider/*` (see entry syntax below). Empty = root does not fall back (no-op pass-through) |
+| `roles.list` | Array | `[]` | **Block 2**. Declarative role-entity collection (id/label/description + optional chain/fallback; entry fields in the table below). The id must match `/^[a-z0-9-]{1,32}$/` and be unique within the collection; `'inherit'` is a reserved word and **must not** be used as an id |
+| `roles.rules` | Array | `[]` | **Block 2**. Role rules: match to a role in order by `origin` (`root`/`subagent`), `provider`, `model` patterns (omitted fields are unconstrained; first match wins); `role` may only reference `roles.list[].id` or the built-in `'inherit'` |
+| `cooldownMs` | number | `300000` | Cooldown duration (milliseconds). Switched-away / failed models are not re-selected during the cooldown period |
+| `revertPolicy` | `'cooldown-expiry'` \| `'never'` | `'cooldown-expiry'` | Primary-return policy after cooldown expiry: return to the primary model on expiry / keep the fallback model for the session |
+| `maxSwitchesPerStep` | number | `8` | Per-step safety valve: the switch-count cap per step; beyond it switching stops and the original error semantics are kept, preventing chain loops from amplifying latency |
+| `alwaysModeRetryCap` | number | `5` | Always-mode retry cap: providers with `retryPolicy.mode === 'always'` switch after this many retries within the same request; `0` disables |
 
-> 默认值以 `src/config.ts` 的 `defaultFallbacksConfig` 为准；卡片对数值字段（`cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）旁显示默认值，其余字段展示当前生效值（未配置时即默认值）。
+> The defaults are defined by `defaultFallbacksConfig` in `src/config.ts`; the card shows the default value next to numeric fields (`cooldownMs` / `maxSwitchesPerStep` / `alwaysModeRetryCap`) and the currently effective value for all other fields (which equals the default when unset).
 
-### `roles.list` 条目字段
+### `roles.list` entry fields
 
-| 字段 | 类型 | 必填 | 说明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| `id` | string | 是 | 角色 id：`/^[a-z0-9-]{1,32}$/`、集合内唯一；`'inherit'` 为保留字，禁止使用 |
-| `label` | string | 推荐填写 | 角色名称（自由文本，不校验）；schema 默认空字符串，缺失不拦截保存 |
-| `description` | string | 推荐填写 | 角色描述（自由文本，不校验）；schema 默认空字符串，缺失不拦截保存 |
-| `chain` | string[] | 否（设置卡保存强制） | 角色自身的有序降级链（条目语法同 `rootChain`）。**必填语义**：角色无 model 配置无意义——设置卡保存强制至少一条（空 chain 拦截保存 + 行内提示）；手写 YAML 缺省/空 chain 启动时告警（不崩溃）；运行时缺省仍按防御语义回退 `rootChain` |
-| `fallback` | `'inherit-root'` \| `'none'` | 否（默认 `'inherit-root'`） | 链拼接策略：`inherit-root` = 角色链走完再追加 `rootChain`；`none` = 仅用角色自身链 |
-| `prompt` / `permissions` | string / object | 否 | **预留字段**（见下节） |
+| `id` | string | Yes | Role id: `/^[a-z0-9-]{1,32}$/`, unique within the collection; `'inherit'` is reserved and forbidden |
+| `label` | string | Recommended | Role name (free text, not validated); schema default is the empty string, absence does not block saving |
+| `description` | string | Recommended | Role description (free text, not validated); schema default is the empty string, absence does not block saving |
+| `chain` | string[] | No (enforced by the settings card on save) | The role's own ordered fallback chain (entry syntax same as `rootChain`). **Required semantics**: a role without model config is meaningless — the settings card enforces at least one entry on save (an empty chain blocks the save + inline hint); a hand-written YAML with a missing/empty chain warns at startup (no crash); at runtime a missing chain still falls back to `rootChain` defensively |
+| `fallback` | `'inherit-root'` \| `'none'` | No (default `'inherit-root'`) | Chain-append policy: `inherit-root` = append `rootChain` after the role chain; `none` = the role's own chain only |
+| `prompt` / `permissions` | string / object | No | **Reserved fields** (see next section) |
 
-### `roles.rules` 条目字段
+### `roles.rules` entry fields
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 |---|---|---|
-| `origin` | `'root'` \| `'subagent'` | 来源约束；省略 = 不约束 |
-| `provider` | string | provider 约束；省略 = 不约束 |
-| `model` | string | model 约束；省略 = 不约束 |
-| `role` | string | 规则目标：**必须**引用 `roles.list[].id` 或内置 `'inherit'`；未声明引用 → 告警 + `legacyKeys`，该条不生效 |
+| `origin` | `'root'` \| `'subagent'` | Origin constraint; omitted = unconstrained |
+| `provider` | string | Provider constraint; omitted = unconstrained |
+| `model` | string | Model constraint; omitted = unconstrained |
+| `role` | string | Rule target: **must** reference `roles.list[].id` or the built-in `'inherit'`; an undeclared reference → warning + `legacyKeys`, the entry does not take effect |
 
-### `prompt` / `permissions`（预留字段）
+### `prompt` / `permissions` (reserved fields)
 
-`roles.list` 条目上的 `prompt` 与 `permissions`（`allow` / `deny`）为 **schema 预留字段**：
+`prompt` and `permissions` (`allow` / `deny`) on `roles.list` entries are **schema-reserved fields**:
 
-- **YAML 写入不改变本轮降级行为**——本轮无运行时消费方；
-- **UI 本轮不展示**——Fallbacks 卡片不渲染这两个字段；
-- **next iteration 由插件 subagent 工具消费**——落地为 persona 注入与 tool 过滤（规划中的 `fallbacks-explicit-role-tool`）。
+- **Writing them in YAML does not change this round's fallback behavior** — there is no runtime consumer this round;
+- **The UI does not show them this round** — the Fallbacks card does not render these two fields;
+- **next iteration: consumed by the plugin's subagent tool** — landing as persona injection and tool filtering (the planned `fallbacks-explicit-role-tool`).
 
-## 条目语法
+## Entry syntax
 
-**链条目**（`rootChain` / `roles.list[].chain` 的值，有序）：
+**Chain entries** (the values of `rootChain` / `roles.list[].chain`, ordered):
 
-- `provider/model` —— 精确切换：切换到指定模型；
-- `provider/*` —— 保留失败模型 id，仅切换 provider；目标 provider 无此模型 id 时跳过该候选（近匹配模糊解析不在本迭代范围）。
+- `provider/model` — exact switch: switch to the specified model;
+- `provider/*` — keep the failed model id and switch the provider only; when the target provider lacks this model id the candidate is skipped (fuzzy near-match resolution is out of scope for this iteration).
 
-> **链键命名空间已删除**：旧 `chains` 键的三种键语义（`provider/model` exact、`provider/*` 通配、角色名作键）不再存在——失败模型特异路由改由 `roles.rules`（按 provider/model 模式匹配到角色）近似，角色归属由声明实体表达。条目侧 `provider/*` 通配保留。
+> **The chain-key namespace is removed**: the three key semantics of the old `chains` key (`provider/model` exact, `provider/*` wildcard, role-name keys) no longer exist — model-specific routing on failure is now approximated by `roles.rules` (matching to a role by provider/model pattern), and role membership is expressed by declared entities. The entry-side `provider/*` wildcard is kept.
 
-空白填充边界：selector 的空白填充（如 `other/ gpt-4o`）在保存时**原样保留**（GUI 不重写用户输入），运行时解析归一化（`parseSelector` 容忍空白），语义与未填充时一致。
+Whitespace padding: whitespace padding in a selector (e.g. `other/ gpt-4o`) is **preserved as-is** on save (the GUI does not rewrite user input); runtime parsing normalizes it (`parseSelector` tolerates whitespace), so the semantics are identical to the unpadded form.
 
-非法/未知条目（缺分隔符、空段、多余分隔符等）在保存校验时告警并**拦截保存**（卡片）或启动告警（校验函数），不崩溃、不生效；在 dsh 运行环境（存在模型目录服务）下，`*/*` 永不匹配——目标 provider 无 `*` 模型目录，存在性探针会跳过该候选。
+Invalid/unknown entries (missing separator, empty segment, extra separator, etc.) warn at save validation and **block the save** (card) or warn at startup (validation function); they never crash and never take effect. In a running dsh environment (with a model-catalog service) `*/*` never matches — the target provider has no `*` model catalog, so the existence probe skips that candidate.
 
-## 角色解析与链拼接
+## Role resolution and chain composition
 
-**角色解析**（所有 agent，root 与 subagent 同构；顺序匹配、首个命中即停）：
+**Role resolution** (uniform for all agents, root and subagent alike; ordered matching, first match wins):
 
-1. `roles.rules` 按 `origin` / `provider` / `model` 模式匹配（字段省略即不约束）→ 命中的规则目标角色；
-2. 未命中任何规则 → 内置 `'inherit'` 角色（无自身链 → `rootChain`）。
+1. `roles.rules` matches by `origin` / `provider` / `model` pattern (omitted fields are unconstrained) → the target role of the matched rule;
+2. no rule matches → the built-in `'inherit'` role (no own chain → `rootChain`).
 
-`inherit` 是**保留角色 id**：它只作规则目标 / 未命中缺省，**禁止**写入 `roles.list[].id`。命中规则但目标角色未在 `roles.list` 声明 → 防御性回退 `'inherit'` 并告警。
+`inherit` is a **reserved role id**: it serves only as a rule target / no-match default and **must not** be written to `roles.list[].id`. A matched rule whose target role is not declared in `roles.list` → defensive fallback to `'inherit'` with a warning.
 
-**链拼接**（append-not-replace）：命中角色的实际候选链为
+**Chain composition** (append-not-replace): the actual candidate chain for a matched role is
 
 ```text
 [...role.chain, ...(role.fallback === 'none' ? [] : rootChain)]
 ```
 
-- `fallback: inherit-root`（默认）：角色自身链在前，`rootChain` 兜底在后；
-- `fallback: none`：仅角色自身链；自身链为空且 `none` → no-op 透传；
-- 未命中规则（`inherit`）或角色未声明：候选链 = `rootChain`。
+- `fallback: inherit-root` (default): the role's own chain first, `rootChain` as the trailing fallback;
+- `fallback: none`: the role's own chain only; an empty own chain with `none` → no-op pass-through;
+- no rule matched (`inherit`) or role undeclared: candidate chain = `rootChain`.
 
-候选过滤（命中即跳过）：与当前模型相同、处于冷却期、本 step 已失败、`provider/*` 条目目标 provider 无此模型 id。
+Candidate filtering (skipped on hit): same as the current model, in cooldown, already failed this step, or the `provider/*` entry's target provider lacks this model id.
 
-> **角色必填 model 配置**：声明角色无 model 配置无意义——要么为角色配置至少一条 `chain`，要么让规则直接引用内置 `inherit`。设置卡保存强制（空 chain 拦截保存 + 行内提示）；手写 YAML 缺省/空 chain 启动时 `logger.warn` 告警（不崩溃）；运行时缺省仍按防御语义回退 `rootChain`（不改变既有「缺省 → rootChain」行为）。
+> **Roles require model config**: a declared role without model config is meaningless — either give the role at least one `chain` entry or have rules reference the built-in `inherit` directly. The settings card enforces this on save (an empty chain blocks the save + inline hint); a hand-written YAML with a missing/empty chain triggers a `logger.warn` at startup (no crash); at runtime a missing chain still falls back to `rootChain` defensively (the existing "no chain → rootChain" behavior is unchanged).
 
-> **运行时落地说明**：上述角色解析 / 链拼接的新语义已由运行时（`src/roles.ts` / `src/chains.ts` / `src/index.ts`，fallbacks-role-runtime Plan 2）消费；旧形状字段（`chains` / `roles.default` / 未声明角色引用）启动时经 `detectLegacyKeys` 告警提示迁移（见下方迁移映射表），决策行为按新模型工作。
+> **Runtime landing note**: the new role-resolution / chain-composition semantics above are consumed by the runtime (`src/roles.ts` / `src/chains.ts` / `src/index.ts`, fallbacks-role-runtime Plan 2); old-shape fields (`chains` / `roles.default` / undeclared role references) are flagged for migration at startup via `detectLegacyKeys` (see the migration mapping table below), and decision behavior follows the new model.
 
-## 示例 YAML
+## Example YAML
 
-以下配置演示两块制完整形态——root 链、角色实体（含 `fallback` 策略）与引用声明角色 / 内置 `inherit` 的规则（写入 `$DSH_HOME/settings.yaml`）：
+The following configuration demonstrates the full two-block shape — a root chain, role entities (including their `fallback` policy), and rules referencing declared roles / the built-in `inherit` (write it into `$DSH_HOME/settings.yaml`):
 
 ```yaml
 fallbacks:
@@ -141,82 +141,82 @@ fallbacks:
   alwaysModeRetryCap: 5
 ```
 
-要点：
+Key points:
 
-- 示例显式设置 `enabled: true`——功能级开关默认 `false`，未显式打开时插件不介入、卡片隐藏配置表单主体。
-- 链首条目即主模型之后的第一个降级目标；链内条目即优先级。
-- 只声明角色不写规则 = 该角色**永不命中**（未命中走 `inherit` → `rootChain`）；想让角色被命中必须同时写一条引用它的 `roles.rules`。
-- `role: inherit` 是合法规则目标：显式把某类请求指向内置 inherit（root 链）。
-- 切换只改变后续请求的 provider/model 路由，不重置会话上下文与工具状态。
-- 链目标模型需各自已配置密钥与配额（不同 provider 之间成本/额度可能不同）。
+- The example sets `enabled: true` explicitly — the feature switch defaults to `false`; without an explicit opt-in the plugin never intervenes and the card hides the configuration form body.
+- The first chain entry is the first fallback target after the primary model; entries in the chain are ordered by priority.
+- Declaring a role without any rule = that role is **never hit** (a no-match goes to `inherit` → `rootChain`); to have a role hit you must also write a `roles.rules` entry referencing it.
+- `role: inherit` is a valid rule target: it explicitly points a class of requests at the built-in inherit (the root chain).
+- Switching only changes the provider/model routing of subsequent requests; it does not reset session context or tool state.
+- Each chain-target model needs its own credentials and quota configured (costs/quotas can differ between providers).
 
-## 迁移映射表（旧格式 → 新格式）
+## Migration mapping table (old format → new format)
 
-旧格式（iter-20260812 及以前）配置**不会自动迁移**：插件检测到后经三通道提示（见下节），由用户按下表手工改写。
+Legacy-format (iter-20260812 and earlier) configuration is **not migrated automatically**: once detected, the plugin flags it through three channels (see the next section) and the user rewrites it manually per the table below.
 
-| 旧（iter-20260812 及以前） | 新 |
+| Old (iter-20260812 and earlier) | New |
 |----------------------------|-----|
 | `chains: { default: [...] }` | `rootChain: [...]` |
-| `chains: { reviewer: [...] }` | `roles.list: [{ id: reviewer, chain: [...] }]`（另写一条 `roles.rules` 才能命中该角色；只声明不引用 = 永不命中，未命中走 `inherit`） |
-| `chains: { deepseek/*: [...] }` | `roles.rules: [{ provider: deepseek, role: <已声明 id> }]`（须先有对应 `roles.list` 项，旧链条目写入该 `roles.list[].chain`；或删除该键） |
-| `chains: { deepseek/deepseek-chat: [...] }` | `roles.rules: [{ provider: deepseek, model: deepseek-chat, role: <已声明 id> }]`（旧链条目写入对应 `roles.list[].chain`） |
-| `roles.rules[].role` 任意字符串 | 引用 `roles.list[].id` 或内置 `'inherit'`（enum）；未声明引用 → `legacyKeys` + 告警，该条不生效 |
-| `roles.default: 'default'`（或任意字符串） | **删除该字段**；无规则命中 → 内置 `'inherit'`（→ `rootChain`）。「所有子代理默认走某链」改写为一条 `{ origin: subagent, role: <id> }` |
-| 角色链无兜底 | `fallback: inherit-root`（默认）→ `[...role.chain, ...rootChain]`；`fallback: none` → 仅 `role.chain` |
-| （无对应旧字段）`prompt` / `permissions` | schema **预留**；本轮无 UI、无运行时消费；YAML 写入不改变本轮降级行为 |
-| （无对应旧字段）角色 id = `inherit` | **禁止**写入 `roles.list`；`inherit` 只作规则目标 / 未命中缺省 |
+| `chains: { reviewer: [...] }` | `roles.list: [{ id: reviewer, chain: [...] }]` (also write a `roles.rules` entry for the role to be hit; declaring without referencing = never hit, no-match goes to `inherit`) |
+| `chains: { deepseek/*: [...] }` | `roles.rules: [{ provider: deepseek, role: <已声明 id> }]` (requires a corresponding `roles.list` entry first; move the old chain entries into that `roles.list[].chain`; or delete the key) |
+| `chains: { deepseek/deepseek-chat: [...] }` | `roles.rules: [{ provider: deepseek, model: deepseek-chat, role: <已声明 id> }]` (move the old chain entries into the corresponding `roles.list[].chain`) |
+| `roles.rules[].role` any string | Reference `roles.list[].id` or the built-in `'inherit'` (enum); an undeclared reference → `legacyKeys` + warning, the entry does not take effect |
+| `roles.default: 'default'` (or any string) | **Delete this field**; no rule match → the built-in `'inherit'` (→ `rootChain`). Rewrite "all subagents default to some chain" as one `{ origin: subagent, role: <id> }` entry |
+| Role chain without a fallback | `fallback: inherit-root` (default) → `[...role.chain, ...rootChain]`; `fallback: none` → `role.chain` only |
+| (no old counterpart) `prompt` / `permissions` | schema **reserved**; no UI and no runtime consumption this round; writing them in YAML does not change this round's fallback behavior |
+| (no old counterpart) role id = `inherit` | **forbidden** in `roles.list`; `inherit` serves only as a rule target / no-match default |
 
-## 三通道 legacy 提示
+## Three-channel legacy notice
 
-旧格式配置升级后经**三通道**提示，不静默丢失、**不自动改文件**：
+After an upgrade, legacy-format configuration is flagged through **three channels** — nothing is silently dropped and **no file is rewritten automatically**:
 
-1. **UI 横幅**（本轮已生效）：Fallbacks 卡片主体顶部渲染迁移提示（`get` / `set` / `reset` 响应 `legacyKeys` 非空时）——「检测到旧格式配置字段（…）：已按新模型展示，请按 docs/configuration.md 迁移表手工改写；插件不会自动改写配置。」不阻断编辑、不改磁盘；**保存不删除旧格式键**（`set` 为合并语义，旧 `chains` / `roles.default` 会保留在 user layer）——清理请手动编辑 YAML，或用「恢复默认」重置该命名空间。
-2. **启动 warn**（已落地）：插件启动/配置读取时以 `logger.warn` 提示检测到的 legacy 字段——`apply()` 经 `detectLegacyKeys` 检测，`legacyKeys` 管道同步报告；三通道已闭合。
-3. **本文档迁移表**：上节「迁移映射表」为手工改写依据。
+1. **UI banner** (live this round): the Fallbacks card renders a migration banner at the top of its body (when the `get` / `set` / `reset` response carries a non-empty `legacyKeys`) — "Legacy config fields detected (...): now shown in the new model — rewrite them manually following the migration table in docs/configuration.md (the plugin will not rewrite them automatically)." It does not block editing or touch disk; **saving does not delete the old-format keys** (`set` is merge-semantics, so old `chains` / `roles.default` stay in the user layer) — clean them up by editing YAML manually or by resetting the namespace with "Reset to defaults".
+2. **Startup warn** (shipped): on plugin startup / config read, detected legacy fields are reported via `logger.warn` — `apply()` detects them through `detectLegacyKeys`, and the `legacyKeys` pipeline reports synchronously; the three channels are closed.
+3. **This document's migration table**: the "Migration mapping table" section above is the reference for manual rewriting.
 
-## web 插件配置卡使用说明
+## Web plugin-config card usage
 
-- **入口**：web 设置 GUI → Settings → **插件配置** 页 → **Fallbacks 卡片**（与 bash / agent-loop / web-search / advisor 卡同列表，order 30；卡片取代了旧的独立 Settings 导航页）。
-- **始终可用（骨架恒渲染）**：无论首次打开、loading、error 等任意状态，卡片都渲染骨架——卡片头（名称/描述）、只读状态块、功能级开关 `enabled`、保存/恢复默认动作。配置来自 gateway 通道 `get`（成功则 `present`）；`get` 失败/通道不可达时显示可操作骨架而非死卡，保存动作可用（失败会如实提示，见下）。
-- **legacy 横幅**：`get` 响应含 `legacyKeys`（非空）→ 卡片主体顶部渲染迁移提示横幅（zh/en），指向本文档迁移表；不阻断编辑、不改磁盘。
-- **功能级开关 `enabled`（默认 OFF）**：开关即用户配置字段 `fallbacks.enabled`，默认关闭。关闭时隐藏配置表单主体（`triggerCodes` / `rootChain` / `roles` / `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`），显示「功能未开启：打开 `enabled` 开关以显示配置界面」提示——隐藏不丢弃，编辑中的 draft 保留；打开后显示完整配置界面。拨动开关即时显隐（draft 驱动），经保存动作持久化。
-- **可读标签**：枚举型配置项显示可读标签而非原始枚举值——`RATE_LIMIT` →「限流（429）」、`QUOTA` →「配额超限」、`AUTH` →「权限/认证失败」；`cooldown-expiry` →「冷却到期后回主模型」、`never` →「保持备用模型」；`inherit-root` →「继承 root（角色链后追加 rootChain）」、`none` →「仅角色链（不追加 rootChain）」。数值字段旁显示默认值；其余字段展示当前生效值（未配置时即默认值）。
-- **rootChain 区**：标题「root 主代理降级链」+ 提示「未配置 = root 不降级」；选择器行复用目录下拉（provider/model 级联 + `provider/*` 通配 + 目录外合成选项），**无键输入**。
-- **roles.list 区**：每角色一张实体卡——id（文本，格式校验：`/^[a-z0-9-]{1,32}$/`、唯一、`inherit` 保留字非法）、label（文本，**推荐填写**）、description（文本，**推荐填写**）、chain 选择器行（可折叠/追加）、fallback 下拉（`inherit-root` / `none`）、删除按钮；「添加角色」按钮。**本轮不渲染** `prompt` / `permissions`。
-- **roles.rules 区**：行编辑 origin（root/subagent/任意）+ provider（目录下拉/任意）+ model（级联下拉/任意）+ role（**下拉**：`inherit` + 已声明角色 ids，同页联动——角色增删即时反映）；「添加规则」按钮。空字段不参与匹配。
-- **保存前校验（拦截 save）**：id 格式/唯一/保留字、rule role 引用、selector 非法、角色 chain 为空（未配置模型）→ 行内标注（红边/提示）+ 错误横幅；**校验失败拦截 `save()`**——点保存不写入、看到错误；校验通过才经 gateway `set` 写 user layer。
-- **model-selection 协调（AC-2，文档化降级）**：存在活跃 model-selection（用户在设置页 / `settings.yaml` 选择了 provider/model）时，触发码故障后的切换**仍然决策并记录**（`fallbacks/switch` 事件、冷却；当步实际路由可能被活跃 selection 覆写，最终 provider/model 以重新套用的选择为准）——这是去掉本地 patch 标记协调后的**宿主原生行为**（T2 结论，见 [docs/verification.md](docs/verification.md) §4.3）。request-error 触发链不受影响；无活跃 selection 时路由到链目标。卡片含一行降级说明（`status.selectionNote`，zh/en）。
-- **恢复默认**：一键把该命名空间的用户配置重置为组合默认值（`enabled` 回 `false`）——经 gateway `reset`（清空 user layer，组合默认值生效）。
-- **保存与错误呈现**：保存经 gateway `set`（merge 语义）写 user layer，无 revision guard——并发/写失败时错误横幅如实呈现保存结果，骨架与 draft 保留（不静默覆盖）。
-- **只读状态块**：显示**当前生效模型**（由配置 + 最近切换**推导**的展示值——无切换时取 `rootChain` 首项；未启用或 `rootChain` 未配置时显示「fallbacks 未启用（或 rootChain 未配置）」；非实时路由探测，附非实时说明文案）+ **最近切换摘要**（来自当前会话原始 `fallbacks/switch` 事件面，最新在前，每条含 from/to/role/reason/时间）。摘要随 `settings/document-updated`（fallbacks 命名空间）/ `llm/adapters-updated`（仅目录）/ 会话切换 / 连接重置推送刷新（无轮询）——页面打开期间发生的切换，在下一次推送或重载页面后呈现；状态块只读、不可编辑。会话内的同款诊断也可用 `/fallbacks` 命令查看（见 README；显示**角色自身链条目**，rootChain 兜底时以「（inherit-root）」标注、不逐条渲染 rootChain 条目；角色无自身链时才完整显示 rootChain 条目，与运行时拼接顺序一致）。**Legacy 注意**：仅配旧格式 `chains`（未迁移、无 `rootChain`）的用户，状态块按新形状推导会显示「未启用（或 rootChain 未配置）」——运行时**不再读取**旧 `chains` 键（决策只按新形状工作，仅配旧字段时表现为 no-op 透传），迁移信号以启动 warn 与卡片顶部**迁移横幅**为准（见「三通道 legacy 提示」）。
+- **Entry**: web settings GUI → Settings → **Plugin Settings** page → **Fallbacks card** (same list as the bash / agent-loop / web-search / advisor cards, order 30; the card replaces the old standalone Settings navigation page).
+- **Always available (skeleton always renders)**: in any state — first open, loading, error — the card renders its skeleton: card header (name/description), read-only status block, feature switch `enabled`, and the save / reset-to-defaults actions. The config comes from the gateway channel `get` (`present` when it succeeds); when `get` fails / the channel is unreachable, an actionable skeleton is shown instead of a dead card, and saving stays available (failures are reported truthfully, see below).
+- **Legacy banner**: a non-empty `legacyKeys` in the `get` response → a migration banner (zh/en) renders at the top of the card body, pointing at this document's migration table; it does not block editing or touch disk.
+- **Feature switch `enabled` (default OFF)**: the switch is the user-config field `fallbacks.enabled`, off by default. When off, the configuration form body is hidden (`triggerCodes` / `rootChain` / `roles` / `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`) and the hint "Feature disabled: turn on the enabled switch to show the configuration interface." is shown — hiding does not discard anything; an in-progress draft is kept. Turning the switch on reveals the full configuration interface. Toggling shows/hides immediately (draft-driven) and persists via the save action.
+- **Readable labels**: enumerable config items show readable labels instead of raw enum values — `RATE_LIMIT` → "Rate limit (429)", `QUOTA` → "Quota exceeded", `AUTH` → "Auth / permission failure"; `cooldown-expiry` → "Return to the primary model", `never` → "Keep the fallback model (until session end)"; `inherit-root` → "Inherit root (append rootChain after the role chain)", `none` → "Role chain only (no rootChain)". Numeric fields show the default value beside them; other fields show the currently effective value (the default when unset).
+- **rootChain area**: title "Root agent fallback chain" + hint "Unset = root does not fall back"; selector rows reuse the catalog dropdown (provider/model cascade + `provider/*` wildcard + synthetic options for values outside the catalog), **no key input**.
+- **roles.list area**: one entity card per role — id (text, format-validated: `/^[a-z0-9-]{1,32}$/`, unique, the `inherit` reserved word is invalid), label (text, **recommended**), description (text, **recommended**), chain selector rows (collapsible / appendable), fallback dropdown (`inherit-root` / `none`), and a delete button; an "Add role" button. `prompt` / `permissions` are **not rendered this round**.
+- **roles.rules area**: per-row editing of origin (root/subagent/any) + provider (catalog dropdown/any) + model (cascade dropdown/any) + role (**dropdown**: `inherit` + declared role ids, linked within the page — role add/remove reflects immediately); an "Add rule" button. Empty fields do not participate in matching.
+- **Pre-save validation (blocks save)**: id format/uniqueness/reserved word, rule role references, invalid selectors, empty role chain (no model config) → inline annotation (red border/hint) + error banner; **a failed validation blocks `save()`** — clicking save writes nothing and shows the error; only a passing validation writes the user layer via the gateway `set`.
+- **model-selection coordination (AC-2, documented degradation)**: with an active model-selection (the user picked a provider/model in the settings page or `settings.yaml`), a switch after a trigger-code failure is **still decided and recorded** (`fallbacks/switch` event, cooldown; the step's actual routing may be overridden by the active selection, with the final provider/model following the re-applied selection) — this is **host-native behavior** after removing the local patch-marker coordination (T2 conclusion, see [docs/verification.md](docs/verification.md) §4.3). request-error-triggered chains are unaffected; without an active selection the request routes to the chain target. The card carries a one-line degradation note (`status.selectionNote`, zh/en).
+- **Reset to defaults**: one click resets this namespace's user configuration to the composed defaults (`enabled` back to `false`) — via the gateway `reset` (clears the user layer; the composed defaults take effect).
+- **Saving and error presentation**: saving writes the user layer via the gateway `set` (merge semantics) with no revision guard — on concurrent/write failure an error banner truthfully presents the save result, and the skeleton and draft are kept (no silent overwrite).
+- **Read-only status block**: shows the **current effective model** (a value **derived** from configuration + recent switches — with no switches it takes the first `rootChain` entry; when disabled or with `rootChain` unconfigured it shows "Fallbacks disabled (or rootChain not configured)"; it is not real-time route probing and carries a non-real-time note) + a **recent-switches summary** (from the current session's raw `fallbacks/switch` event surface, newest first, each entry with from/to/role/reason/time). The summary refreshes via push (no polling) on `settings/document-updated` (fallbacks namespace) / `llm/adapters-updated` (catalog only) / session switch / connection reset — switches that happen while the page is open appear after the next push or a page reload. The status block is read-only and not editable. The same in-session diagnostics are available via the `/fallbacks` command (see README; it shows the **role's own chain entries**, annotated `(inherit-root)` when `rootChain` is the fallback, without rendering `rootChain` entries one by one; `rootChain` entries render in full only when the role has no own chain — matching the runtime composition order). **Legacy note**: for users with only old-format `chains` configured (not migrated, no `rootChain`), the status block derives per the new shape and shows "not enabled (or rootChain not configured)" — the runtime **no longer reads** the old `chains` key (decisions work only on the new shape; old-only fields behave as a no-op pass-through), and the migration signal is the startup warn plus the card-top **migration banner** (see "Three-channel legacy notice").
 
-## 行为说明
+## Behavior notes
 
-### 触发条件
+### Trigger conditions
 
-`enabled` 为 true、存在匹配的候选链、且失败码 ∈ `triggerCodes`（默认 `AUTH`/`QUOTA`/`RATE_LIMIT`）时进入链决策：
+Chain decision is entered when `enabled` is true, a matching candidate chain exists, and the failure code ∈ `triggerCodes` (default `AUTH`/`QUOTA`/`RATE_LIMIT`):
 
-- `AUTH` / `QUOTA` 为不可重试码，不经退避直达本插件；
-- `RATE_LIMIT` 及 5xx 等可重试码先由 llm-retry 退避重试，预算耗尽后委托到本插件；
-- 未命中 triggerCodes 的失败（含 always 模式下的非 triggerCode 失败）一律透传，走 llm-retry 或原错误路径。
+- `AUTH` / `QUOTA` are non-retryable codes and reach this plugin directly without backoff;
+- retryable codes such as `RATE_LIMIT` and 5xx are first retried with backoff by llm-retry and are delegated to this plugin only when its budget is exhausted;
+- failures that do not hit `triggerCodes` (including non-triggerCode failures under always mode) always pass through, taking the llm-retry or original-error path.
 
-### 切换后继续
+### Continuing after a switch
 
-命中候选 → 记录待应用切换 + 把当前模型压入冷却 + 记账 + 追加 `fallbacks/switch` 事件 → 返回重试 → 下一轮请求在目标模型上构建，当前 step/turn 继续完成，任务不中断。
+A candidate hit → record a pending switch + push the current model into cooldown + bookkeeping + append the `fallbacks/switch` event → return a retry → the next request builds on the target model, and the current step/turn continues to completion without interrupting the task.
 
-### 冷却与回主
+### Cooldown and returning to the primary
 
-被切离/失败的模型在 `cooldownMs` 内不再入选（冷却与「本 step 已失败」双重抑制）；`cooldown-expiry` 冷却到期后该模型可重新入选（回主）；`never` 会话内不回（无限冷却）。
+A switched-away / failed model is not re-selected within `cooldownMs` (cooldown and "already failed this step" double suppression); with `cooldown-expiry` the model can be re-selected after the cooldown expires (return to primary); `never` does not return within the session (infinite cooldown).
 
-### 安全阀与 always 模式
+### Safety valve and always mode
 
-- **安全阀**：每 step 记录失败模型集合与切换计数，`maxSwitchesPerStep` 超限后不再决策，step 以原错误语义结束（原始错误码与 message 原样保留）；step 推进时重置。
-- **always 模式 cap**：`retryPolicy.mode === 'always'` 的 provider 在请求构建边界按 turn/step/provider 统计已持久化的 `llm/retry` 事件数，≥ `alwaysModeRetryCap`（0 禁用）时触发切换（`reason: always-cap`）。llm-retry 的 always 模式先委托下游再退避，cap 之前本插件不抢占（见 spec ADR-2）。
+- **Safety valve**: per step the failed-model set and switch count are recorded; beyond `maxSwitchesPerStep` no more decisions are made and the step ends with the original error semantics (the original error code and message are preserved verbatim); the counters reset when the step advances.
+- **always-mode cap**: for providers with `retryPolicy.mode === 'always'`, persisted `llm/retry` events are counted per turn/step/provider at the request-building boundary; at ≥ `alwaysModeRetryCap` (0 disables) a switch is triggered (`reason: always-cap`). llm-retry's always mode delegates downstream before backing off; before the cap this plugin never preempts (see spec ADR-2).
 
-### no-op 不变量
+### No-op invariant
 
-未配置 `rootChain` 且无命中角色链 / `enabled: false` / 未命中 triggerCodes / 角色解析失败 / 链耗尽 / 安全阀超限：插件一律透传，请求与会话事件流与未安装插件时完全一致，不产生任何 `fallbacks/switch` 事件。
+With no `rootChain` configured and no role chain hit / `enabled: false` / no `triggerCodes` hit / role-resolution failure / chain exhausted / safety-valve cap exceeded: the plugin always passes through, the request and session event stream are identical to an uninstalled plugin, and no `fallbacks/switch` events are produced.
 
-### 与 llm-retry 的关系
+### Relationship with llm-retry
 
-本插件**不修改** llm-retry 与 provider 的 `retryPolicy`：fallback 只在 llm-retry 委托/耗尽后介入（bundle 层序保证，见 [docs/install.md](docs/install.md)）；`llm/retry` 事件仅用于 always 模式 cap 计数。插件卸载（HMR/dispose）时监听随 fiber 卸载、每-agent 状态整体清空，无残留状态。
+This plugin **does not modify** llm-retry's or providers' `retryPolicy`: fallback only intervenes after llm-retry delegates/exhausts its budget (guaranteed by bundle layer order, see [docs/install.md](docs/install.md)); `llm/retry` events are used only for always-mode cap counting. On plugin unload (HMR/dispose) the listeners unload with the fiber and all per-agent state is cleared entirely — no residual state.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,30 +110,30 @@ fallbacks:
     - AUTH
     - QUOTA
     - RATE_LIMIT
-  rootChain:                     # 块 1：root 主代理降级链；空 = root 不降级
+  rootChain:                     # Block 1: the root agent's fallback chain; empty = root does not fall back
     - anthropic/claude-3-5-sonnet
     - openai/*
-  roles:                         # 块 2：先声明角色，再让规则引用
+  roles:                         # Block 2: declare roles first, then let rules reference them
     list:
-      - id: reviewer             # 角色实体：id 唯一、/^[a-z0-9-]{1,32}$/；inherit 为保留字
-        label: 审查者
-        description: 代码审查子代理
-        chain:                   # 角色自身链
+      - id: reviewer             # Role entity: unique id matching /^[a-z0-9-]{1,32}$/; 'inherit' is reserved
+        label: Reviewer
+        description: Code review subagent
+        chain:                   # The role's own chain
           - openai/gpt-4o-mini
-        fallback: inherit-root   # 默认：角色链走完再追加 rootChain
+        fallback: inherit-root   # Default: append rootChain after the role's own chain
       - id: cheap
-        label: 廉价模型
-        description: 成本优先
+        label: Cheap model
+        description: Cost first
         chain:
           - deepseek/deepseek-chat
-        fallback: none           # 仅角色链，不追加 rootChain
-    rules:                       # 顺序匹配 origin/provider/model，首个命中即停；具体规则须写在宽泛规则之前
-      - provider: deepseek       # 最具体的先列：精确 provider/model → 显式指向内置 inherit（root 链）
+        fallback: none           # Role's own chain only; no rootChain appended
+    rules:                       # Match origin/provider/model in order, first hit wins; specific rules before broad ones
+      - provider: deepseek       # Most specific first: exact provider/model → explicitly targets the built-in inherit (root chain)
         model: deepseek-reasoner
         role: inherit
-      - origin: subagent         # 所有 subagent → reviewer 角色
+      - origin: subagent         # All subagents → reviewer role
         role: reviewer
-      - provider: deepseek       # 宽泛规则放后面：其它 deepseek provider 的 agent → cheap 角色
+      - provider: deepseek       # Broad rules last: other deepseek providers' agents → cheap role
         role: cheap
   cooldownMs: 300000
   revertPolicy: cooldown-expiry
@@ -158,8 +158,8 @@ Legacy-format (iter-20260812 and earlier) configuration is **not migrated automa
 |----------------------------|-----|
 | `chains: { default: [...] }` | `rootChain: [...]` |
 | `chains: { reviewer: [...] }` | `roles.list: [{ id: reviewer, chain: [...] }]` (also write a `roles.rules` entry for the role to be hit; declaring without referencing = never hit, no-match goes to `inherit`) |
-| `chains: { deepseek/*: [...] }` | `roles.rules: [{ provider: deepseek, role: <已声明 id> }]` (requires a corresponding `roles.list` entry first; move the old chain entries into that `roles.list[].chain`; or delete the key) |
-| `chains: { deepseek/deepseek-chat: [...] }` | `roles.rules: [{ provider: deepseek, model: deepseek-chat, role: <已声明 id> }]` (move the old chain entries into the corresponding `roles.list[].chain`) |
+| `chains: { deepseek/*: [...] }` | `roles.rules: [{ provider: deepseek, role: <declared id> }]` (requires a corresponding `roles.list` entry first; move the old chain entries into that `roles.list[].chain`; or delete the key) |
+| `chains: { deepseek/deepseek-chat: [...] }` | `roles.rules: [{ provider: deepseek, model: deepseek-chat, role: <declared id> }]` (move the old chain entries into the corresponding `roles.list[].chain`) |
 | `roles.rules[].role` any string | Reference `roles.list[].id` or the built-in `'inherit'` (enum); an undeclared reference → `legacyKeys` + warning, the entry does not take effect |
 | `roles.default: 'default'` (or any string) | **Delete this field**; no rule match → the built-in `'inherit'` (→ `rootChain`). Rewrite "all subagents default to some chain" as one `{ origin: subagent, role: <id> }` entry |
 | Role chain without a fallback | `fallback: inherit-root` (default) → `[...role.chain, ...rootChain]`; `fallback: none` → `role.chain` only |

--- a/docs/consumer-api.md
+++ b/docs/consumer-api.md
@@ -1,74 +1,74 @@
-# 消费契约（Consumer API）
+# Consumer Contract (Consumer API)
 
-本文档定义 `dsh-llm-fallbacks` 对外暴露的**消费面**：① 包根库 API（`import { … } from 'dsh-llm-fallbacks'`）；② 具名 cordis service（`ctx.get('llm-fallbacks')`）。两个入口共享同一函数实现（单点真相，无复制逻辑）。安装方式见 [docs/install.md](install.md)；发布流程见 [docs/release.md](release.md)。
+This document defines the **consumer surface** `dsh-llm-fallbacks` exposes: (1) the package-root library API (`import { … } from 'dsh-llm-fallbacks'`); (2) the named cordis service (`ctx.get('llm-fallbacks')`). Both entry points share the same function implementations (single point of truth, no copied logic). Installation → [docs/install.md](install.md); release process → [docs/release.md](release.md).
 
-> **契约边界**：本文档描述的是**本包**的导出面与生命周期。**本包契约成立 ≠ 隔壁仓库已接上**——集成是否完成需以目标仓库的实际接线为准。
+> **Contract boundary**: this document describes **this package's** export surface and lifecycle. **A valid package contract ≠ an integrated downstream repository** — whether integration is complete must be judged by the actual wiring in the target repository.
 
-## 库 API（包根 re-export）
+## Library API (package-root re-export)
 
-`src/index.ts` 从包根统一 re-export 运行时函数、值常量与类型，消费方直接 `import { … } from 'dsh-llm-fallbacks'`，无需深入子模块路径。
+`src/index.ts` re-exports the runtime functions, value constants, and types uniformly from the package root, so consumers `import { … } from 'dsh-llm-fallbacks'` directly without reaching into submodule paths.
 
-### 最小示例
+### Minimal example
 
 ```ts
 import { resolveRole, resolveChain, validateFallbacksConfig } from 'dsh-llm-fallbacks'
 
-// resolveRole：按 origin/provider/model 顺序匹配 roles.rules → 角色 id（未命中 → 'inherit'）
+// resolveRole: matches roles.rules in origin/provider/model order → role id (no match → 'inherit')
 const role = resolveRole(agent, config.roles.rules, roleIds)
 
-// resolveChain：角色链 + rootChain 拼接后返回存活候选（决策路径同款）
+// resolveChain: concatenates the role chain + rootChain and returns surviving candidates (same as the decision path)
 const candidates = resolveChain(config.roles.list, config.rootChain, role, provider, model)
 
-// validateFallbacksConfig：校验配置，问题经 logger.warn 告警（不抛错）
+// validateFallbacksConfig: validates the config; problems are warned via logger.warn (never throws)
 validateFallbacksConfig(config, logger)
 ```
 
-### 函数导出清单
+### Function exports
 
-| 导出 | 说明 |
+| Export | Description |
 |---|---|
-| `resolveRole(agent, rules, roleIds, warn?)` | 按 `origin`/`provider`/`model` 顺序匹配 `roles.rules`，返回命中的角色 id；无规则命中或引用未声明角色时返回内置 `'inherit'`。 |
-| `resolveCandidate(entry, failing, modelExists?)` | 把单个链条目解析为候选；`provider/*` 通配展开为失败模型；条目非法或存在性探测失败返回 `null`。 |
-| `resolveChainViews(roles, rootChain, role, provider, model, warn?)` | 单趟解析角色的拼接链，返回未过滤候选视图 `{ all, wildcard }`（`wildcard[i]` 标记候选 `all[i]` 是否来自通配条目）。 |
-| `selectCandidates(all, wildcard, filter?, modelExists?)` | 对候选视图应用过滤与存在性探测，返回存活候选列表。 |
-| `resolveChain(roles, rootChain, role, provider, model, filter?, modelExists?, warn?)` | 完整链解析（决策路径同款）：拼接角色链 + `rootChain`（`fallback: 'none'` 不追加），返回存活候选。 |
-| `hasWildcardEntry(roles, rootChain, role)` | 探测该角色的拼接链是否含 `provider/*` 通配条目——调用方据此决定是否需要 catalog 存在性探测（与解析同源，无过近似）。 |
-| `createCandidateFilter(options)` | 构造候选过滤器：跳过当前模型、冷却中、本 step 已失败与缺失模型 id 的候选。 |
-| `annotateCandidates(candidates, surviving, options)` | 为每个候选标注跳过原因（`skip` 未定义 = 存活），用于可见性 / 日志。 |
-| `validateFallbacksConfig(config, logger)` | 校验配置合法性（未声明角色引用、非法链等），问题经 `logger.warn` 告警（不抛错）。 |
-| `detectLegacyKeys(source)` | 检测配置中的已删除旧键（如 `chains`），返回命中的键名列表。 |
-| `parseSelector(input)` | 解析 `provider/model` 或 `provider/*` 选择器；输入非法时抛 `SelectorError`。 |
+| `resolveRole(agent, rules, roleIds, warn?)` | Matches `roles.rules` in `origin`/`provider`/`model` order and returns the matched role id; returns the built-in `'inherit'` when no rule matches or a referenced role is undeclared. |
+| `resolveCandidate(entry, failing, modelExists?)` | Resolves a single chain entry into a candidate; `provider/*` wildcards expand to the failing models; returns `null` for invalid entries or failed existence probes. |
+| `resolveChainViews(roles, rootChain, role, provider, model, warn?)` | Single-pass resolution of a role's concatenated chain, returning the unfiltered candidate views `{ all, wildcard }` (`wildcard[i]` marks whether candidate `all[i]` came from a wildcard entry). |
+| `selectCandidates(all, wildcard, filter?, modelExists?)` | Applies the filter and existence probes to the candidate views, returning the list of surviving candidates. |
+| `resolveChain(roles, rootChain, role, provider, model, filter?, modelExists?, warn?)` | Full chain resolution (same as the decision path): concatenates the role chain + `rootChain` (`fallback: 'none'` appends nothing), returning the surviving candidates. |
+| `hasWildcardEntry(roles, rootChain, role)` | Detects whether a role's concatenated chain contains `provider/*` wildcard entries — callers use it to decide whether catalog existence probes are needed (same source as resolution, no over-approximation). |
+| `createCandidateFilter(options)` | Builds a candidate filter: skips the current model, models in cooldown, models already failed in this step, and missing model ids. |
+| `annotateCandidates(candidates, surviving, options)` | Annotates each candidate with its skip reason (`skip` undefined = surviving), for visibility / logging. |
+| `validateFallbacksConfig(config, logger)` | Validates config legality (undeclared role references, illegal chains, etc.); problems are warned via `logger.warn` (never throws). |
+| `detectLegacyKeys(source)` | Detects removed legacy keys (e.g. `chains`) in the config, returning the list of keys hit. |
+| `parseSelector(input)` | Parses a `provider/model` or `provider/*` selector; throws `SelectorError` on invalid input. |
 
-### 值导出
+### Value exports
 
-| 导出 | 说明 |
+| Export | Description |
 |---|---|
-| `INHERIT_ROLE_ID` | 内置保留角色 id `'inherit'`（无规则命中时的回退目标）。 |
-| `ROLE_ID_PATTERN` | 角色 id 格式正则 `/^[a-z0-9-]{1,32}$/`。 |
-| `defaultFallbacksConfig` | 默认配置对象（`enabled: false`、默认 `triggerCodes`、空链）。 |
-| `provide` | 声明性服务元数据 `['llm-fallbacks'] as const`（loader/工具识别用；实际注册在 `apply()` 内——见下节具名 service）。 |
-| `SelectorError` | `parseSelector` 抛出的可捕获错误类——catch 侧类型安全依赖它。 |
+| `INHERIT_ROLE_ID` | Built-in reserved role id `'inherit'` (fallback target when no rule matches). |
+| `ROLE_ID_PATTERN` | Role id format regex `/^[a-z0-9-]{1,32}$/`. |
+| `defaultFallbacksConfig` | Default config object (`enabled: false`, default `triggerCodes`, empty chains). |
+| `provide` | Declarative service metadata `['llm-fallbacks'] as const` (for loader/tool recognition; actual registration happens inside `apply()` — see the named service section below). |
+| `SelectorError` | The catchable error class thrown by `parseSelector` — catch-side type safety depends on it. |
 
-### 类型导出
+### Type exports
 
-`FallbacksConfig` / `FallbacksRole` / `FallbacksRoles` / `FallbacksRoleRule` / `FallbackStrategy` / `RevertPolicy` / `Origin` / `AgentLike` / `Selector` / `FailingModel` / `AnnotatedCandidate` / `CandidateSkipReason` / `CandidateFilterOptions` / `FallbacksConfigLogger` / `FallbacksService`——均为 `export type`，仅编译期存在。
+`FallbacksConfig` / `FallbacksRole` / `FallbacksRoles` / `FallbacksRoleRule` / `FallbackStrategy` / `RevertPolicy` / `Origin` / `AgentLike` / `Selector` / `FailingModel` / `AnnotatedCandidate` / `CandidateSkipReason` / `CandidateFilterOptions` / `FallbacksConfigLogger` / `FallbacksService` — all `export type`, compile-time only.
 
-### 插件既有导出（保持不变）
+### Existing plugin exports (unchanged)
 
-`name` / `Config`（schemastery schema）/ `stateStore` / `countRetryEvents` / `apply` 及事件与状态类型（`FallbackSwitchReason` / `FallbacksSwitchEventData` / `AgentFallbackState` / `FallbackStateStore` / `PendingSwitch` / `StepFailures`）继续从包根导出，零回归。
+`name` / `Config` (schemastery schema) / `stateStore` / `countRetryEvents` / `apply` and the event and state types (`FallbackSwitchReason` / `FallbacksSwitchEventData` / `AgentFallbackState` / `FallbackStateStore` / `PendingSwitch` / `StepFailures`) continue to be exported from the package root, zero regression.
 
-> **机械守卫（S-3）**：上方运行时导出清单（函数 / 值 / 插件既有导出）的 SSOT 是 `tests/export-surface.spec.ts` 中的 `LIBRARY_EXPORT_KEYS` —— 本清单新增或删除任何运行时键，都必须同步该数组（及同文件的 `valueExports` 类型映射），否则 CI 失败。类型导出清单由同文件 `expectTypeOf` 块 pin（dev-time 类型 pin，本地 tsc 校验）。
+> **Mechanical guard (S-3)**: the SSOT for the runtime export inventory above (functions / values / existing plugin exports) is `LIBRARY_EXPORT_KEYS` in `tests/export-surface.spec.ts` — adding or removing any runtime key in this inventory requires syncing that array (and the `valueExports` type mapping in the same file), or CI fails. The type export inventory is pinned by the `expectTypeOf` block in the same file (dev-time type pin, checked by local tsc).
 
-## 具名 service（`ctx.get('llm-fallbacks')`）
+## Named service (`ctx.get('llm-fallbacks')`)
 
-插件 `apply()` 后在 cordis `Context` 上以名称 `'llm-fallbacks'` 注册服务。**它是与库 API 共享同一函数实现的纯函数小面，不是第二套库 API**：运行态（冷却、最近切换等）不属于契约——跨插件读状态请监听 `fallbacks/switch` 事件，不要读服务对象内部。
+After the plugin's `apply()`, a service is registered on the cordis `Context` under the name `'llm-fallbacks'`. **It is a small pure-function face sharing the same function implementations as the library API — not a second library API**: runtime state (cooldown, recent switches, etc.) is not part of the contract — cross-plugin state reads should listen to `fallbacks/switch` events instead of reading service object internals.
 
-### 形状
+### Shape
 
 ```ts
 {
-  name: 'llm-fallbacks'          // 与插件 name 一致
-  version: string                // package.json version（模块加载时快照）
+  name: 'llm-fallbacks'          // matches the plugin name
+  version: string                // package.json version (snapshot taken at module load)
   resolveRole: typeof resolveRole
   resolveChain: typeof resolveChain
   validateFallbacksConfig: typeof validateFallbacksConfig
@@ -76,11 +76,11 @@ validateFallbacksConfig(config, logger)
 }
 ```
 
-服务面**刻意不包含**运行态（无 `stateStore` / 事件发射器）与过滤 helper——那些只走库 import。静态导出 `provide = ['llm-fallbacks'] as const` 是声明性元数据（loader/工具识别用），实际注册发生在 `apply()` 内。
+The service surface **deliberately excludes** runtime state (no `stateStore` / event emitter) and the filtering helpers — those go through library imports only. The static export `provide = ['llm-fallbacks'] as const` is declarative metadata (for loader/tool recognition); the actual registration happens inside `apply()`.
 
-### 探测示例
+### Probe example
 
-与 mstar loader-probe 用法一致：先用 `!== undefined` 探测可用性，再调用。
+Same usage as the mstar loader-probe: probe availability with `!== undefined` first, then call.
 
 ```ts
 const fb = ctx.get('llm-fallbacks')
@@ -89,15 +89,15 @@ if (fb !== undefined) {
 }
 ```
 
-### 生命周期
+### Lifecycle
 
-- **apply 后可用**：插件 apply 期间 `ctx.get('llm-fallbacks')` 返回服务对象，四函数与库 re-export 为同一函数引用，`version` 等于 package.json 版本。
-- **dispose 后撤销**：注册随插件 fiber unload 自动注销（cordis 4 fiber-scoped），插件 dispose 后 `ctx.get('llm-fallbacks')` 为 `undefined`——strict `get` 对缺失实现返回 `undefined`，不抛错。
+- **Available after `apply`**: during plugin apply, `ctx.get('llm-fallbacks')` returns the service object; the four functions are the same function references as the library re-exports, and `version` equals the package.json version.
+- **Withdrawn after `dispose`**: the registration is automatically unregistered when the plugin fiber unloads (cordis 4 fiber-scoped); after plugin dispose, `ctx.get('llm-fallbacks')` is `undefined` — the strict `get` returns `undefined` for a missing implementation, never throwing.
 
-### 类型合并
+### Type merging
 
-import 本包即自动合并 `Context` 类型（`declare module '@deepseek-ai/cordis'` 增补 `'llm-fallbacks'?: FallbacksService`），消费方**无需自行 declare**；`FallbacksService` 类型亦从包根导出。未 import 本包类型时，`ctx.get('llm-fallbacks')` 退化到 untyped 重载。
+Importing this package automatically merges the `Context` type (`declare module '@deepseek-ai/cordis'` augments `'llm-fallbacks'?: FallbacksService`), so consumers **do not need to declare it themselves**; the `FallbacksService` type is also exported from the package root. Without importing this package's types, `ctx.get('llm-fallbacks')` degrades to the untyped overload.
 
-## 版本元信息
+## Version metadata
 
-`version` 是发布时 package.json 的版本字符串（模块加载时经 `createRequire` 读取一次的快照），随发布更新；消费方可据此做版本门控，但它**不是运行态**，不代表任何实时状态。
+`version` is the package.json version string at publish time (a snapshot read once at module load via `createRequire`), updated with each release; consumers can use it for version gating, but it is **not runtime state** and does not represent any live status.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,76 +1,76 @@
-# 安装指南
+# Installation Guide
 
-本文介绍如何把 `dsh-llm-fallbacks` 装入 dsh profile、验证安装与卸载。
+This document explains how to load `dsh-llm-fallbacks` into a dsh profile, verify the installation, and uninstall it.
 
-## 前置条件
+## Prerequisites
 
-- 可用的 dsh 运行环境（`$DSH_HOME`，默认 `~/.dsh`）；开发期类型检查与测试从 npm registry 解析 `@deepseek-ai/*@0.1.0-rc.6` peer 依赖（registry 认证令牌，见下文"认证（pnpm 11）"）。
-- 构建需要 **node**（`>= 22`）与 **pnpm**（`>= 10`）——仅**本地目录安装**（开发）需要：插件的 `prepare` 脚本自构建（`pnpm run build`，tsdown + tsc，pnpm 栈无 bun）；registry 安装装的是已构建产物，目标机无需构建。
-- 目标 profile（如 `web`）可读写，安装后需要重启 dsh 会话。
+- A working dsh runtime environment (`$DSH_HOME`, defaults to `~/.dsh`); development-time type checking and tests resolve the `@deepseek-ai/*@0.1.0-rc.6` peer dependencies from the npm registry (registry auth token — see "Authentication (pnpm 11)" below).
+- Building requires **node** (`>= 22`) and **pnpm** (`>= 10`) — needed **only for local directory installs** (development): the plugin's `prepare` script self-builds (`pnpm run build`, tsdown + tsc, pnpm stack without bun); registry installs deliver built artifacts, so the target machine does not build anything.
+- The target profile (e.g. `web`) is readable/writable, and a dsh session restart is required after installation.
 
-## 开发期 `@deepseek-ai/*` peer 解析（npm registry）
+## Development-time `@deepseek-ai/*` peer resolution (npm registry)
 
-`@deepseek-ai/*` 是私有包，运行时由宿主 dsh 盒内 bundle 提供（`peerDependencies` 契约，tsdown 构建期外部化 `@deepseek-ai/*`）。开发期从 npm registry 解析真实包（`0.1.0-rc.6`）：`pnpm-workspace.yaml` 的 `autoInstallPeers: true` + 用户级 `~/.npmrc` 的认证令牌，`pnpm install` 时自动装齐 peer 依赖——类型检查、测试与跳转全部走真实代码（无本地 link farm）。
+`@deepseek-ai/*` is a private package family: at runtime it is provided by the host dsh box as a bundle (`peerDependencies` contract; `@deepseek-ai/*` is externalized at tsdown build time). During development the real packages (`0.1.0-rc.6`) are resolved from the npm registry: `autoInstallPeers: true` in `pnpm-workspace.yaml` + an auth token in the user-level `~/.npmrc` — `pnpm install` pulls in the peer dependencies automatically, so type checking, tests, and navigation all run against the real code (no local link farm).
 
-- **认证（pnpm 11）**：pnpm 11 起项目级 `.npmrc` 的凭据**不再展开环境变量**（`${NPM_TOKEN}` 失效并告警）。令牌须放**用户级** `~/.npmrc`：`@deepseek-ai:registry=https://registry.npmjs.org/` + `//registry.npmjs.org/:_authToken=<token>`（或 `pnpm config set "//registry.npmjs.org/:_authToken" <token>`）；`NPM_TOKEN` 仍为受限 scope 的只读令牌来源。
-- **版本**：`peerDependencies` 钉 `^0.1.0-rc.6`（与 dlx 宿主 rc.6 对齐）；dsh 升级后同步 bump peer 版本。
-- **pnpm 版本**：pnpm 11.21+（本项目栈）。11.21 起默认启用 minimum-release-age 供应链门禁，`pnpm-workspace.yaml` 的 `minimumReleaseAgeExclude` 是 **pnpm 自动维护**的豁免表——rc.6 整线（及 cordis 4.0.1）发布于当日，自动列入；**不要手动删除该块**：已解析锁文件在无豁免时会硬失败（`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`，需 `pnpm clean --lockfile` 重新解析）。
-- **客户端运行时缝**：registry 包的 `dsh-client-runtime` `./client` 入口是浏览器 loader artifact（非 node 可导入），测试用本地 node-safe 双（`tests/support/snapshot-store.ts`，vitest alias）。
+- **Authentication (pnpm 11)**: as of pnpm 11, credentials in a project-level `.npmrc` **no longer expand environment variables** (`${NPM_TOKEN}` is invalid and warns). The token must live in the **user-level** `~/.npmrc`: `@deepseek-ai:registry=https://registry.npmjs.org/` + `//registry.npmjs.org/:_authToken=<token>` (or `pnpm config set "//registry.npmjs.org/:_authToken" <token>`); `NPM_TOKEN` remains the read-only token source for the restricted scope.
+- **Version**: `peerDependencies` is pinned to `^0.1.0-rc.6` (aligned with the dlx host's rc.6); bump the peer version in sync after a dsh upgrade.
+- **pnpm version**: pnpm 11.21+ (this project's stack). Since 11.21 the minimum-release-age supply-chain gate is enabled by default; the `minimumReleaseAgeExclude` table in `pnpm-workspace.yaml` is a **pnpm-maintained** exemption table — the whole rc.6 line (and cordis 4.0.1) was published on the same day and is auto-listed; **do not delete the block manually**: a resolved lockfile hard-fails without the exemptions (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`; re-resolve with `pnpm clean --lockfile`).
+- **Client runtime seam**: the `dsh-client-runtime` `./client` entry of the registry package is a browser loader artifact (not node-importable); tests use a local node-safe double (`tests/support/snapshot-store.ts`, vitest alias).
 
-## 1. 本地目录安装（推荐）
+## 1. Local directory install (recommended)
 
 ```sh
-# 1) 在插件仓库目录构建（prepare 自构建，产出 dist/）
-pnpm install        # 或显式 pnpm build
-# 2) 装入目标 profile
+# 1) Build in the plugin repo directory (prepare self-build, produces dist/)
+pnpm install        # or explicit: pnpm build
+# 2) Load into the target profile
 dsh plugin --profile web add .
 ```
 
-`dsh plugin` 会把参数转发给该 profile 目录下的 pnpm（`add`、`remove`、`why` 等均可用），并将 `dsh-llm-fallbacks` 追加到 profile 的 bundle 层列表（`dsh.profile.bundles`）。插件为**纯挂载**：安装 = bundle 行插入 + client inject（`dsh.client.inject`），**对 dsh 源码树零修改、无任何补丁步骤**；dsh 升级无需重打补丁。
+`dsh plugin` forwards its arguments to the pnpm in the profile directory (`add`, `remove`, `why`, etc. all work) and appends `dsh-llm-fallbacks` to the profile's bundle layer list (`dsh.profile.bundles`). The plugin is **mount-only**: installation = bundle row insert + client inject (`dsh.client.inject`), **zero modification of the dsh source tree, no patch steps**; dsh upgrades never require re-patching.
 
-### bundle 层顺序（硬性要求）
+### Bundle layer order (hard requirement)
 
-dsh 的 profile 由有序 bundle 层组合而成：`@deepseek-ai/dsh-base`（内含 llm-retry 插件）→ `@deepseek-ai/dsh-web-app` → `@mstar-harness/dsh` →（`add` 追加的）`dsh-llm-fallbacks`。
+A dsh profile is composed of ordered bundle layers: `@deepseek-ai/dsh-base` (contains the llm-retry plugin) → `@deepseek-ai/dsh-web-app` → `@mstar-harness/dsh` → `dsh-llm-fallbacks` (appended by `add`).
 
-**`dsh-llm-fallbacks` 必须排在 llm-retry（`@deepseek-ai/dsh-base` 层内）之后**：插件的 `agent/request-error` 监听需在 llm-retry 之后组合，才能在重试预算耗尽（normal 模式）或 llm-retry 先委托下游（always 模式）后介入；顺序颠倒会让可重试失败先到达本插件、抢占 llm-retry 的退避。
+**`dsh-llm-fallbacks` must be ordered after llm-retry (inside the `@deepseek-ai/dsh-base` layer)**: the plugin's `agent/request-error` listener must compose after llm-retry so it only steps in after the retry budget is exhausted (normal mode) or after llm-retry has delegated downstream first (always mode); a reversed order would let retryable failures reach this plugin first and preempt llm-retry's backoff.
 
-`add` 默认追加到列表末尾即满足该顺序，无需手工改动；若手动编辑 `$DSH_HOME/profiles/web/package.json` 的 `dsh.profile.bundles`，请保持 `@deepseek-ai/dsh-base` 在本插件之前。
+`add` appends to the end of the list by default, which satisfies this order — no manual change needed; if you edit the `dsh.profile.bundles` of `$DSH_HOME/profiles/web/package.json` by hand, keep `@deepseek-ai/dsh-base` before this plugin.
 
-## 2. registry 安装
+## 2. Registry install
 
 ```sh
-dsh plugin --profile web add dsh-llm-fallbacks   # 钉精确版本：加 @<version>
+dsh plugin --profile web add dsh-llm-fallbacks   # pin an exact version: add @<version>
 ```
 
-registry 安装注意：
+Registry install notes:
 
-- **构建产物，无需自建**：registry 包即已构建产物（`dist/`），目标机**不需要** node / pnpm，不存在 `prepare` 自构建。
-- **无 pnpm ≥ 10 构建放行**：构建拦截（`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`）只针对 git 依赖；registry 包无构建脚本执行，无需 `onlyBuiltDependencies` / `approve-builds`。
-- **版本**：跟随 npm dist-tag（默认 `latest`）；钉精确版本 `dsh-llm-fallbacks@<version>` 可防止后续发布悄悄改变实际运行的代码。
-- **纯挂载，无补丁步骤**：registry 安装即完成——插件对 dsh 源码树零修改（bundle 行插入 + client inject + 自有 gateway），无需任何 apply/revert 脚本，dsh 升级后无需重打。
+- **Built artifacts, no self-build**: the registry package ships built artifacts (`dist/`) — the target machine needs **no node / pnpm** and there is no `prepare` self-build.
+- **No pnpm ≥ 10 build approval**: the build interception (`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`) applies to git dependencies only; registry packages run no build scripts, so `onlyBuiltDependencies` / `approve-builds` are not needed.
+- **Version**: follows the npm dist-tag (default `latest`); pinning an exact version `dsh-llm-fallbacks@<version>` prevents a later publish from silently changing the code that actually runs.
+- **Mount-only, no patch steps**: a registry install is complete as-is — the plugin makes zero modifications to the dsh source tree (bundle row insert + client inject + its own gateway), no apply/revert scripts, and nothing to re-patch after a dsh upgrade.
 
-> **发布状态**：`dsh-llm-fallbacks` **尚未发布到 npm registry**——首个版本 `0.1.0-alpha.2` 待发布（发布流水线已就绪；首次发布用一次性 `NODE_AUTH_TOKEN`，Trusted Publishing 在首次发布后配置）。本节 registry 命令在首个 release PR merge 前为**预告**；当前可用的是 [git 安装](#4-git-安装当前可用)。发布流程见 [docs/release.md](docs/release.md)。
+> **Release status**: `dsh-llm-fallbacks` is **not published to the npm registry yet** — the first version `0.1.0-alpha.2` is pending (the release pipeline is in place; the first publish uses a one-time `NODE_AUTH_TOKEN`, with Trusted Publishing configured after the first release). The registry commands in this section are a **preview** until the first release PR is merged; what works today is the [git install](#4-git-install-currently-available). Release process → [docs/release.md](docs/release.md).
 
-## 3. npm / pnpm 包安装（预告）
+## 3. npm / pnpm package install (preview)
 
 ```sh
-npm install dsh-llm-fallbacks   # 或：pnpm add dsh-llm-fallbacks
+npm install dsh-llm-fallbacks   # or: pnpm add dsh-llm-fallbacks
 ```
 
-> **预告**：`dsh-llm-fallbacks@0.1.0-alpha.2` 发布后生效。包为已构建产物（`dist/`），消费面（库函数导入、具名 service）文档见 [docs/consumer-api.md](docs/consumer-api.md)。
+> **Preview**: effective after `dsh-llm-fallbacks@0.1.0-alpha.2` is published. The package ships built artifacts (`dist/`); the consumer surface (library function imports, named service) is documented in [docs/consumer-api.md](docs/consumer-api.md).
 
-## 4. git 安装（当前可用）
+## 4. Git install (currently available)
 
 ```sh
-dsh plugin --profile web add github:omdsh-dev/dsh-llm-fallbacks   # 钉 commit：加 #<sha>
-# 等价完整 URL 形式（或加 #<branch|tag|commit> 指定 ref）：
+dsh plugin --profile web add github:omdsh-dev/dsh-llm-fallbacks   # pin a commit: add #<sha>
+# Equivalent full-URL form (or add #<branch|tag|commit> to pin a ref):
 # dsh plugin --profile web add https://github.com/omdsh-dev/dsh-llm-fallbacks.git
 ```
 
-git 安装注意：
+Git install notes:
 
-- **prepare 自建**：pnpm 在安装 git 依赖时会执行包的 `prepare` 脚本（`pnpm run build`）自构建，安装机需要 node 与 pnpm；构建失败会导致装入未构建的包。
-- **pnpm ≥ 10 构建放行（第一次 add 必遇）**：pnpm ≥ 10 默认不执行 git 依赖的构建脚本（含 `prepare`/`postinstall`）。第一次 `add` 会失败并打印 `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`，同时给出精确的包 key（`dsh-llm-fallbacks`）。把该 key 加进此 profile 的 `pnpm-workspace.yaml`：
+- **prepare self-build**: when installing a git dependency, pnpm runs the package's `prepare` script (`pnpm run build`) to self-build, so the installing machine needs node and pnpm; a failed build installs an unbuilt package.
+- **pnpm ≥ 10 build approval (every first `add` hits it)**: pnpm ≥ 10 does not run a git dependency's build scripts (including `prepare`/`postinstall`) by default. The first `add` fails and prints `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` together with the exact package key (`dsh-llm-fallbacks`). Add that key to this profile's `pnpm-workspace.yaml`:
 
   ```yaml
   # $DSH_HOME/profiles/web/pnpm-workspace.yaml
@@ -78,16 +78,16 @@ git 安装注意：
     - dsh-llm-fallbacks
   ```
 
-  然后重跑 `add`；也可交互式 `dsh plugin --profile web approve-builds` 选择放行。该放行 = 允许该包代码在安装期于你的机器上执行——建议钉 commit（`github:omdsh-dev/dsh-llm-fallbacks#<sha>`），防止后续 push 悄悄改变实际运行的代码。确切行为以你所用 pnpm 版本的策略为准。
-- **纯挂载，无补丁步骤**：git 安装执行 `prepare`（构建）即完成——插件对 dsh 源码树零修改（bundle 行插入 + client inject + 自有 gateway），无需任何 apply/revert 脚本，dsh 升级后无需重打。
+  Then re-run `add`; alternatively allow it interactively with `dsh plugin --profile web approve-builds`. The approval means that package's code is allowed to execute on your machine at install time — pinning a commit (`github:omdsh-dev/dsh-llm-fallbacks#<sha>`) is recommended to prevent a later push from silently changing the code that actually runs. Exact behavior follows the policy of the pnpm version you use.
+- **Mount-only, no patch steps**: a git install executes `prepare` (build) and is done — the plugin makes zero modifications to the dsh source tree (bundle row insert + client inject + its own gateway), no apply/revert scripts, and nothing to re-patch after a dsh upgrade.
 
-## 5. 验证安装
+## 5. Verify the installation
 
 ```sh
 dsh --profile web --dump-config
 ```
 
-组合配置树末尾应出现本插件的独立层：
+The plugin's own layer should appear at the end of the merged configuration tree:
 
 ```yaml
 # == dsh-llm-fallbacks
@@ -96,19 +96,19 @@ dsh --profile web --dump-config
   config: {}
 ```
 
-且其**之前**的层包含 llm-retry（来自 `@deepseek-ai/dsh-base`）——层序即 waterfall 注册顺序（见上文 bundle 层顺序）。
+And the layer **before** it includes llm-retry (from `@deepseek-ai/dsh-base`) — the layer order is the waterfall registration order (see the bundle layer order above).
 
-然后**重启 dsh web 会话**（`dsh web` 或重启正在运行的会话），让 host 半与 client 半（插件配置卡）加载：
+Then **restart the dsh web session** (`dsh web`, or restart the running session) so that both the host half and the client half (the plugin config card) load:
 
-- web 设置 GUI 的 Settings → **插件配置** 页中应出现 **Fallbacks 卡片**，且**始终可用**——首次打开（尚无 `fallbacks` 配置）也渲染卡片骨架。
-- 卡片可读、可编辑、可保存；功能级开关 `enabled` **默认 OFF**（关闭时隐藏配置表单主体），打开开关后显示完整配置表单；未配置任何链时行为 no-op（详见 [docs/configuration.md](docs/configuration.md)）。
-- 会话内可直接键入 `/fallbacks` 查看当前会话的诊断（角色 → 链 → 最近切换 → 冷却），详见 README 的 `/fallbacks` 一节。
+- The web settings GUI's Settings → **插件配置** page should show the **Fallbacks card**, **always available** — the card skeleton also renders on first open (before any `fallbacks` config exists).
+- The card is readable, editable, and saveable; the feature switch `enabled` **defaults to OFF** (hiding the config form body while off) — turning the switch on reveals the full config form; with no chains configured the behavior is a no-op (see [docs/configuration.md](docs/configuration.md)).
+- In-session, type `/fallbacks` directly to inspect the current session's diagnostics (role → chain → recent switches → cooldown); see the README's `/fallbacks` section.
 
-## 6. 卸载
+## 6. Uninstall
 
 ```sh
 dsh plugin --profile web remove dsh-llm-fallbacks
-dsh --profile web --dump-config   # 确认 llm-fallbacks 层已消失
+dsh --profile web --dump-config   # confirm the llm-fallbacks layer is gone
 ```
 
-重启 dsh web 会话使卸载生效。卸载后插件不再介入任何请求/错误路径，已持久化的 `fallbacks/switch` 会话事件为历史记录，不受卸载影响。
+Restart the dsh web session for the uninstall to take effect. After uninstalling, the plugin no longer participates in any request/error path; already-persisted `fallbacks/switch` session events remain as history and are unaffected by the uninstall.

--- a/docs/release.md
+++ b/docs/release.md
@@ -125,7 +125,7 @@ Each fragment focuses on one user-visible change.
 
 ## Release checklist
 
-- [ ] `pnpm test` all green (409 test baseline, vitest run)
+- [ ] `pnpm test` all green (460 test baseline across 23 files, vitest run)
 - [ ] `pnpm build` all green (tsc + tsdown + build-client + verify-dist)
 - [ ] `actionlint .github/workflows/*.yml` clean (ci + release-prep + release)
 - [ ] `pnpm release:validate -- v<version>` passes (local preview before releasing)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,117 +1,117 @@
-# 发布指南（Release Guide）
+# Release Guide
 
-本文档说明 `dsh-llm-fallbacks` 的发布流程：npm 认证（首次发布 bootstrap token → 后续 Trusted Publishing）、发布 SOP（触发 → 审查 → merge）、changelog fragment 格式、发布检查清单与回滚/重跑说明。
+This document describes the `dsh-llm-fallbacks` release process: npm authentication (first-release bootstrap token → Trusted Publishing afterwards), the release SOP (trigger → review → merge), changelog fragment format, the release checklist, and rollback / re-run instructions.
 
-## 发布模型（PR-driven）
+## Release model (PR-driven)
 
-发布是**两步制**，不是黑盒一键：
+Releases are **two-step**, not a one-click black box:
 
-1. **Release prep**（手动触发）→ 生成可审查的 `release vX.Y.Z` PR（版本 bump + 英文 changelog + fragment 归档）。
-2. **merge 该 PR 才发布** → `Release` workflow 自动 publish + tag + GitHub Release。
+1. **Release prep** (manual trigger) → generates a reviewable `release vX.Y.Z` PR (version bump + English changelog + fragment archive).
+2. **Merging that PR is what publishes** → the `Release` workflow automatically publishes + tags + creates the GitHub Release.
 
-仓库**不声明 `NPM_TOKEN`**：常规发布 npm 认证走 Trusted Publishing（OIDC `id-token` + `npm publish --provenance`，tokenless）；**首次发布例外**——npm TP 只能对已存在的包配置，首个版本用一次性 `NODE_AUTH_TOKEN` secret 发布（见「npm 认证」节）。GitHub 侧只用内置 `GITHUB_TOKEN`。**没有 `push:tags` 自动发布路径**——手动 `git tag && git push --tags` 不会发布，发布唯一入口是 merge `release vX.Y.Z` PR。
+The repository **does not declare `NPM_TOKEN`**: routine publishing authenticates to npm via Trusted Publishing (OIDC `id-token` + `npm publish --provenance`, tokenless); **the first release is the exception** — npm TP can only be configured for an existing package, so the first version is published with a one-time `NODE_AUTH_TOKEN` secret (see the "npm authentication" section). On the GitHub side only the built-in `GITHUB_TOKEN` is used. **There is no `push:tags` auto-publish path** — a manual `git tag && git push --tags` does not publish; the only publishing entry point is merging a `release vX.Y.Z` PR.
 
-相关工作流：
+Related workflows:
 
-| Workflow | 文件 | 触发 |
+| Workflow | File | Trigger |
 |---|---|---|
-| CI | `.github/workflows/ci.yml` | PR / push main / 手动 |
-| Release prep | `.github/workflows/release-prep.yml` | 手动（Actions → Release prep → Run workflow） |
-| Release | `.github/workflows/release.yml` | merge 标题为 `release v*` 的 PR |
+| CI | `.github/workflows/ci.yml` | PR / push to main / manual |
+| Release prep | `.github/workflows/release-prep.yml` | manual (Actions → Release prep → Run workflow) |
+| Release | `.github/workflows/release.yml` | merging a PR titled `release v*` |
 
-## npm 认证：首次发布 bootstrap token → 后续 Trusted Publishing（用户操作）
+## npm authentication: first-release bootstrap token → Trusted Publishing (user action)
 
-npm 的 Trusted Publishing（OIDC）只能对**已存在的包**配置——没有预注册路径，`dsh-llm-fallbacks` 尚未发布，首次发布无法走 TP（会 ENEEDAUTH/404）。因此认证分两段：
+npm Trusted Publishing (OIDC) can only be configured for an **existing package** — there is no pre-registration path, and since `dsh-llm-fallbacks` is not published yet, the first release cannot use TP (it would hit ENEEDAUTH/404). Authentication is therefore split into two phases:
 
-- **首次发布（bootstrap）**：一次性 Granular Access Token 存入 `NODE_AUTH_TOKEN` secret，发布 `0.1.0-alpha.2`。
-- **后续发布**：首次发布成功后，在 npm 包设置配置 Trusted Publisher 绑定 `release.yml`，此后发布**零 secrets**（OIDC 自动认证，token 可删除）。
+- **First release (bootstrap)**: a one-time Granular Access Token is stored in the `NODE_AUTH_TOKEN` secret to publish `0.1.0-alpha.2`.
+- **Subsequent releases**: once the first release has succeeded, configure a Trusted Publisher bound to `release.yml` in the npm package settings; afterwards publishing is **zero-secrets** (OIDC auto-authentication; the token can be deleted).
 
-> **bootstrap token 是一次性机制，不是长期方案**：TP 配置完成后应从 GitHub 删除 `NODE_AUTH_TOKEN` secret（npm 官方也建议配置 TP 后限制传统 token 的发布权限）。
+> **The bootstrap token is a one-time mechanism, not a long-term solution**: once TP is configured, delete the `NODE_AUTH_TOKEN` secret from GitHub (npm also recommends restricting traditional tokens' publish permission after configuring TP).
 >
-> 两步都只能由 npm 账号所有者（维护者）在 npm 网站上完成——仓库内无法自动配置，也不是本仓库代码能代做的。
+> Both steps can only be performed by the npm account owner (maintainer) on the npm website — they cannot be automated from the repository, and repository code cannot do them on your behalf.
 
-### 首次发布：一次性 Granular Access Token（用户操作）
+### First release: one-time Granular Access Token (user action)
 
-1. 登录 [npmjs.com](https://www.npmjs.com) → 右上角头像 → **Access Tokens** → **Generate New Token** → 类型选择 **Granular Access Token**。
-2. 填写名称（如 `dsh-llm-fallbacks-bootstrap`）；Package 选择 `dsh-llm-fallbacks`；权限选择 **Read and write**。
-   - 若包尚未发布、npm 的 package picker 列表里还没有 `dsh-llm-fallbacks`：改用 **org 级 publish scope**（如 `omdsh-dev` 下选择该包/全部包），或走「手动 token 路径」——创建 **Granular Access Token** 后**不限制 package**（或选择 Any package），发布时依赖该 token 的发布权限。
-3. 复制 token，到 GitHub 仓库 **Settings → Secrets and variables → Actions** 新建 repository secret，名称 **`NODE_AUTH_TOKEN`**，值粘贴该 token。
-4. `release.yml` 的 publish 步骤通过 `env: NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}` 自动读取（`setup-node` 的 `registry-url` 会把该值写入 `.npmrc`，npm 自动使用）；secret 不存在时该 env 为空 → 走 OIDC/provenance 路径。
+1. Sign in to [npmjs.com](https://www.npmjs.com) → avatar (top right) → **Access Tokens** → **Generate New Token** → choose **Granular Access Token** as the type.
+2. Fill in a name (e.g. `dsh-llm-fallbacks-bootstrap`); select `dsh-llm-fallbacks` as the Package; select **Read and write** as the permission.
+   - If the package is not yet published and `dsh-llm-fallbacks` is not yet in npm's package picker list: use an **org-level publish scope** instead (select that package / all packages under e.g. `omdsh-dev`), or take the "manual token path" — create a **Granular Access Token** **without restricting the package** (or select Any package) and rely on that token's publish permission at publish time.
+3. Copy the token and create a repository secret in GitHub at **Settings → Secrets and variables → Actions** named **`NODE_AUTH_TOKEN`**, pasting the token as its value.
+4. The publish step of `release.yml` reads it automatically via `env: NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}` (`setup-node`'s `registry-url` writes the value into `.npmrc`, which npm uses automatically); when the secret is absent the env is empty → the OIDC/provenance path is used.
 
-### 后续发布：在 npm 包设置配置 Trusted Publisher（用户操作，tokenless）
+### Subsequent releases: configure a Trusted Publisher in the npm package settings (user action, tokenless)
 
-首次发布成功后，包在 npm 上才有 Settings 页：
+The package only gets a Settings page on npm after the first release succeeds:
 
-1. 登录 [npmjs.com](https://www.npmjs.com) → **Packages** → `dsh-llm-fallbacks` → **Settings** → **Trusted publishing**。
-2. **Select your publisher** → 选择 **GitHub Actions**。
-3. 填写字段：
-   - **Organization or user**（必填）：`omdsh-dev`（GitHub 组织/用户名）；
-   - **Repository**（必填）：`dsh-llm-fallbacks`；
-   - **Workflow filename**（必填）：`release.yml` —— **只填文件名**，不含路径，须含 `.yml`/`.yaml` 扩展名；workflow 须存在于仓库 `.github/workflows/` 下；
-   - **Environment name**（可选）：仅当发布 job 使用 GitHub environment 保护时填写；
-   - **Allowed actions**（必填）：勾选 **`npm publish`**（本仓库直接 `npm publish --provenance`，不走 staged publish）。
-4. 保存。该配置**不创建任何 token**——npm 接受来自该 workflow 的 OIDC 发布（tokenless by design）。
+1. Sign in to [npmjs.com](https://www.npmjs.com) → **Packages** → `dsh-llm-fallbacks` → **Settings** → **Trusted publishing**.
+2. **Select your publisher** → choose **GitHub Actions**.
+3. Fill in the fields:
+   - **Organization or user** (required): `omdsh-dev` (GitHub org/user);
+   - **Repository** (required): `dsh-llm-fallbacks`;
+   - **Workflow filename** (required): `release.yml` — **the filename only**, no path, and it must include the `.yml`/`.yaml` extension; the workflow must exist under the repository's `.github/workflows/`;
+   - **Environment name** (optional): fill in only if the publish job uses GitHub environment protection;
+   - **Allowed actions** (required): check **`npm publish`** (this repository publishes directly with `npm publish --provenance`, no staged publish).
+4. Save. This configuration **creates no token** — npm accepts OIDC publishing from that workflow (tokenless by design).
 
-> 每个包同一时间只能有一个 trusted publisher 配置；可随时编辑/删除（删除后回到 token 认证）。
+> A package can only have one trusted publisher configuration at a time; it can be edited/deleted at any time (deleting returns to token authentication).
 
-### 注意事项
+### Notes
 
-- npm **provenance** 要求包为公开包（工作流中发布命令已是 `--access public`）。
-- GitHub 侧**无需额外配置**：OIDC token（`permissions: id-token: write`）由 Actions 自动签发；`contents: write` / `pull-requests: write` 已在 workflow 内声明。
-- TP 就绪后删除 `NODE_AUTH_TOKEN` secret：npm CLI 在 OIDC 环境中优先走 OIDC，token 只是 bootstrap 期的回退路径。
-- 首次发布走**显式** `0.1.0-alpha.2`（见下方 SOP）；`--patch` auto 留给后续。
+- npm **provenance** requires the package to be public (the publish command in the workflow already uses `--access public`).
+- **No extra configuration on the GitHub side**: the OIDC token (`permissions: id-token: write`) is issued by Actions automatically; `contents: write` / `pull-requests: write` are already declared in the workflow.
+- Delete the `NODE_AUTH_TOKEN` secret once TP is ready: the npm CLI prefers OIDC in an OIDC environment; the token is only the fallback path during the bootstrap period.
+- The first release uses **explicit** `0.1.0-alpha.2` (see the SOP below); `--patch` auto is left for later releases.
 
-## 发布 SOP
+## Release SOP
 
-### 1. 写 changelog fragment
+### 1. Write a changelog fragment
 
-对每个**用户可见变更**，在 `.changes/unreleased/` 下新增一个 fragment（格式见下节；**一个文件一个 category**，纯英文 bullets——`<!-- CN -->` 等非 bullet 行会被原样渲染进 CHANGELOG）。
+For every **user-visible change**, add a fragment under `.changes/unreleased/` (format in the next section; **one file, one category**, English bullets — non-bullet lines such as `<!-- CN -->` are rendered into the CHANGELOG verbatim).
 
-**必须至少有一个 fragment**：`release.yml` 在 changelog 提取为空时直接 fail（发布中止）——空版本节无法发布。首次发布前尤其检查 `.changes/unreleased/` 非空（本仓库首次发布的 fragment 已随功能提交）。
+**At least one fragment is mandatory**: `release.yml` fails outright when the changelog extraction is empty (an empty version section cannot be published). Before the first release in particular, verify that `.changes/unreleased/` is non-empty (this repository's first-release fragments were committed together with the features).
 
-### 2. 触发 Release prep
+### 2. Trigger Release prep
 
-仓库 → **Actions** → 左侧 **Release prep** → **Run workflow**：
+Repository → **Actions** → **Release prep** in the sidebar → **Run workflow**:
 
-- **版本输入**：
-  - **首次发布**：显式填 `0.1.0-alpha.2`（先验证流水线，正式版留给下一迭代）。
-  - **后续**：留空 = auto bump（`--patch`）——当前版本为 prerelease 且尾段为数字（`X.Y.Z-pre.N`）时只递增 N（`0.1.0-alpha.1` → `0.1.0-alpha.2`，**保持 prerelease 线**）；无 prerelease 时 patch+1（`0.1.0` → `0.1.1`）；prerelease 尾段非数字时报错，改用显式版本。
+- **Version input**:
+  - **First release**: fill in `0.1.0-alpha.2` explicitly (validate the pipeline first; the stable version is left for the next iteration).
+  - **Later**: leave blank = auto bump (`--patch`) — when the current version is a prerelease with a numeric tail (`X.Y.Z-pre.N`), only N is incremented (`0.1.0-alpha.1` → `0.1.0-alpha.2`, **staying on the prerelease line**); without a prerelease, patch+1 (`0.1.0` → `0.1.1`); a non-numeric prerelease tail errors out — use an explicit version instead.
 
-工作流会依次：
+The workflow then runs, in order:
 
-1. **拒绝已发布版本**：显式版本且 git tag `v<v>` 已存在 → 报错退出（已发布版本无法重跑 prep）。
-2. `pnpm release:prepare`：bump `package.json` version、把 `.changes/unreleased/` fragments 组装成 `## [<version>] - <date>` 节插入 `CHANGELOG.md`（`## [Unreleased]` 之下）、归档 fragments 到 `.changes/archive/<version>/`。
-   - **日期为 UTC**：脚本用 `new Date().toISOString().slice(0, 10)`，节日期固定为 UTC 当天；正时区深夜本地 prep 可能显示「昨天」——以 UTC 为准即可。
-3. `pnpm release:validate -- v<v>`：package.json 版本与 tag 一致 + tag 未已存在（双保险）。
-4. `pnpm build` 冒烟。
-5. 提交 `chore(release): prepare v<v>` 到 `release/v<v>` 分支并 push（force-with-lease）。
-6. 开 PR `release v<v>`（base `main`，label `release`）；**open PR 已存在则更新它**，**closed PR 已存在则先 reopen 再更新**，都没有才新建。
+1. **Rejects already-released versions**: with an explicit version and an existing git tag `v<v>` → errors and exits (a released version cannot re-run prep).
+2. `pnpm release:prepare`: bumps the `package.json` version, assembles the `.changes/unreleased/` fragments into a `## [<version>] - <date>` section inserted into `CHANGELOG.md` (below `## [Unreleased]`), and archives the fragments to `.changes/archive/<version>/`.
+   - **The date is UTC**: the script uses `new Date().toISOString().slice(0, 10)`, so the section date is fixed to the UTC day; a local prep late at night in a positive timezone may display "yesterday" — UTC is authoritative.
+3. `pnpm release:validate -- v<v>`: package.json version matches the tag + the tag does not already exist (belt and suspenders).
+4. `pnpm build` smoke test.
+5. Commits `chore(release): prepare v<v>` to the `release/v<v>` branch and pushes (force-with-lease).
+6. Opens the PR `release v<v>` (base `main`, label `release`); **updates it if an open PR already exists**, **reopens then updates a closed PR if one exists**, and only creates a new PR when neither exists.
 
-### 3. 审查 release PR
+### 3. Review the release PR
 
-merge 前核对：
+Before merging, verify:
 
-- [ ] `package.json` 的 `version` 是预期版本；
-- [ ] `CHANGELOG.md` 在 `## [Unreleased]` 下出现 `## [<version>] - <date>` 节，fragment bullet 正确、英文；
-- [ ] `.changes/unreleased/` 的 fragment 已归档到 `.changes/archive/<version>/`；
-- [ ] diff 只含版本 / changelog / 归档（外加分支上任何直接提交，如无应为三块）。
+- [ ] `package.json` `version` is the expected version;
+- [ ] `CHANGELOG.md` has a `## [<version>] - <date>` section under `## [Unreleased]` with correct, English fragment bullets;
+- [ ] the `.changes/unreleased/` fragments are archived to `.changes/archive/<version>/`;
+- [ ] the diff contains only version / changelog / archive changes (plus any direct commits on the branch; with none it should be those three blocks).
 
-### 4. Merge → 自动发布
+### 4. Merge → automatic publish
 
-merge 后 `release.yml` 触发（`pull_request: closed` + `merged == true` + 标题 `release v` 前缀）：
+After the merge, `release.yml` triggers (`pull_request: closed` + `merged == true` + title with the `release v` prefix):
 
-1. 检出 merge commit → `release:validate` → `pnpm build`；
-2. `npm publish --provenance --access public --tag latest` —— **显式 `--tag latest`**：npm ≥ 11（Node 24 自带）发布 prerelease 必须显式 `--tag`，否则 hard-throw；首个版本（`0.1.0-alpha.2`）落默认 `latest` dist-tag（`npm i dsh-llm-fallbacks` 可解析），后续稳定版 `0.1.0` 自然接棒 `latest`。npm 认证自动选择：TP 已配置 → OIDC；bootstrap 期 → `NODE_AUTH_TOKEN`（见「npm 认证」节）；
-3. 打 tag `v<v>` 并 push（已存在则跳过）；
-4. 用 changelog 节创建 GitHub Release（版本含 `-` 时 `prerelease: true`）。
+1. Checks out the merge commit → `release:validate` → `pnpm build`;
+2. `npm publish --provenance --access public --tag latest` — **explicit `--tag latest`**: npm ≥ 11 (bundled with Node 24) requires an explicit `--tag` when publishing a prerelease, otherwise it hard-throws; the first version (`0.1.0-alpha.2`) lands on the default `latest` dist-tag (`npm i dsh-llm-fallbacks` resolves), and the later stable `0.1.0` naturally takes over `latest`. npm authentication is selected automatically: TP configured → OIDC; bootstrap period → `NODE_AUTH_TOKEN` (see the "npm authentication" section);
+3. Tags `v<v>` and pushes (skipped if it exists);
+4. Creates the GitHub Release from the changelog section (`prerelease: true` when the version contains `-`).
 
-## Changelog fragment 格式
+## Changelog fragment format
 
-`.changes/unreleased/` 下每个文件是一条 fragment（`.changes/unreleased/README.md` 是说明文件，`.gitkeep` 是占位，二者都会被忽略）：
+Each file under `.changes/unreleased/` is one fragment (`.changes/unreleased/README.md` is the explainer file and `.gitkeep` is a placeholder — both are ignored):
 
-- **文件名**：任意以 `.md` 结尾的 slug（如 `add-foo.md`）。
-- **Frontmatter（可选）**：`category:` 键把该 fragment 的 bullets 归入 changelog 中的 `### <category>` 小标题（默认 `Changed`）。
-- **正文**：一行或多行英文 bullet（`- ` 前缀），原样渲染。
+- **Filename**: any slug ending in `.md` (e.g. `add-foo.md`).
+- **Frontmatter (optional)**: the `category:` key groups the fragment's bullets under a `### <category>` subheading in the changelog (default `Changed`).
+- **Body**: one or more English bullet lines (`- ` prefix), rendered verbatim.
 
 ```markdown
 ---
@@ -121,34 +121,34 @@ category: Added
 - A second bullet if needed.
 ```
 
-每条 fragment 聚焦一个用户可见变更。
+Each fragment focuses on one user-visible change.
 
-## 发布检查清单
+## Release checklist
 
-- [ ] `pnpm test` 全绿（409 测试基线，vitest run）
-- [ ] `pnpm build` 全绿（tsc + tsdown + build-client + verify-dist）
-- [ ] `actionlint .github/workflows/*.yml` 干净（ci + release-prep + release）
-- [ ] `pnpm release:validate -- v<version>` 通过（发布前本地预览）
-- [ ] 版本号与 CHANGELOG 节一致；fragments 已归档
-- [ ] npm 认证就绪：首次发布 = `NODE_AUTH_TOKEN` secret 已配置；后续发布 = Trusted Publisher 已绑定 `release.yml`（见「npm 认证」节）
+- [ ] `pnpm test` all green (409 test baseline, vitest run)
+- [ ] `pnpm build` all green (tsc + tsdown + build-client + verify-dist)
+- [ ] `actionlint .github/workflows/*.yml` clean (ci + release-prep + release)
+- [ ] `pnpm release:validate -- v<version>` passes (local preview before releasing)
+- [ ] version matches the CHANGELOG section; fragments archived
+- [ ] npm authentication ready: first release = `NODE_AUTH_TOKEN` secret configured; later releases = Trusted Publisher bound to `release.yml` (see the "npm authentication" section)
 
-## 回滚 / 重跑
+## Rollback / re-run
 
-- **PR 阶段（未 merge）**：版本或内容不对 → 直接**关闭 PR**，或**重跑 Release prep**。重跑是幂等式的：同版本重跑会重新生成 `release/v<v>` 分支（force-with-lease push）并处理 PR——**有 open PR 则更新它**；**有 closed PR 则先 `gh pr reopen` 再更新正文**；两者都没有才新建。**永远不会原地编辑一个 closed PR**（那会让发布静默卡死）。
-- **merge 后、发布中途失败**：若 `npm publish` 已成功但 tag / GitHub Release 步骤失败——**不要直接重跑 Release workflow**：`npm publish` 会因版本已存在于 registry 而失败。修复方式：
-  - 手动补 tag 与 Release：`git tag -a -m "release v<v>" v<v> && git push origin v<v>`，再用 changelog 节手动创建 GitHub Release；或
-  - fix-forward：直接走下一版本（见下）。
-- **已发布但内容错误**：npm **不允许重发同版本**；`npm unpublish` 仅限发布后 72 小时内且无依赖方（有政策限制）。**推荐 fix-forward**：修正后 bump 下一版本（prerelease 线如 `0.1.0-alpha.3`）重新走 SOP。GitHub Release 可随时编辑/删除；tag 在确认无人依赖后可删除（`git push origin :refs/tags/v<v>`）。
-- **语义**：两步制（prep PR + merge）本身就是回滚闸门——发现不对，不 merge 即可，什么都没发生。
+- **PR stage (not merged)**: wrong version or content → simply **close the PR**, or **re-run Release prep**. Re-running is idempotent: re-running with the same version regenerates the `release/v<v>` branch (force-with-lease push) and handles the PR — **updates it if an open PR exists**; **reopens the PR with `gh pr reopen` and updates the body if a closed PR exists**; creates a new one only when neither exists. **A closed PR is never edited in place** (that would silently stall the release).
+- **Failed mid-publish after merge**: if `npm publish` succeeded but the tag / GitHub Release steps failed — **do not re-run the Release workflow directly**: `npm publish` would fail because the version already exists on the registry. Fixes:
+  - manually add the tag and Release: `git tag -a -m "release v<v>" v<v> && git push origin v<v>`, then create the GitHub Release manually from the changelog section; or
+  - fix-forward: go straight to the next version (see below).
+- **Published but wrong content**: npm **does not allow re-publishing the same version**; `npm unpublish` is only possible within 72 hours of publishing and without dependents (policy-limited). **fix-forward is recommended**: fix the content, bump to the next version (on the prerelease line, e.g. `0.1.0-alpha.3`), and re-run the SOP. The GitHub Release can be edited/deleted at any time; the tag can be deleted once you confirm no one depends on it (`git push origin :refs/tags/v<v>`).
+- **Semantics**: the two-step model (prep PR + merge) is itself the rollback gate — if something is wrong, just don't merge and nothing happens.
 
-## 相关文件
+## Related files
 
-| 文件 | 作用 |
+| File | Purpose |
 |---|---|
-| `.github/workflows/release-prep.yml` | 手动入口：bump + changelog + 开/更新 release PR |
-| `.github/workflows/release.yml` | merge 后自动 publish + tag + GitHub Release |
-| `scripts/prepare-release.ts` | 版本解析（显式 / `--patch` auto）、fragment 组装、bump、归档 |
-| `scripts/validate-release-version.ts` | 版本一致性 + tag 未存在校验 |
-| `CHANGELOG.md` | 英文 changelog（`## [Unreleased]` + 版本节） |
-| `.changes/unreleased/` | 待发布 fragments |
-| `.changes/archive/<version>/` | 已消费 fragments 归档 |
+| `.github/workflows/release-prep.yml` | manual entry: bump + changelog + open/update the release PR |
+| `.github/workflows/release.yml` | automatic publish + tag + GitHub Release after merge |
+| `scripts/prepare-release.ts` | version resolution (explicit / `--patch` auto), fragment assembly, bump, archive |
+| `scripts/validate-release-version.ts` | version consistency + tag-not-exists validation |
+| `CHANGELOG.md` | English changelog (`## [Unreleased]` + version sections) |
+| `.changes/unreleased/` | pending fragments |
+| `.changes/archive/<version>/` | consumed fragment archive |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -26,15 +26,15 @@ invariants (empty chains / no match / chain exhausted / safety-valve cap exceede
 
 ### 2. Bundle layer order (proven via scratch profile `--dump-config`)
 
-On a **scratch profile inside the workspace** (`DSH_HOME=<插件仓库>/.dsh-verify`, deleted after verification):
+On a **scratch profile inside the workspace** (`DSH_HOME=<plugin-repo>/.dsh-verify`, deleted after verification):
 
 ```
-$ dsh plugin --profile verify add <插件仓库>
-  → profile 初始化；`dsh.profile.bundles` = ["@deepseek-ai/dsh-base", "dsh-llm-fallbacks"]
-    （reconcile 追加到列表末尾，符合「add 默认追加」语义）
+$ dsh plugin --profile verify add <plugin-repo>
+  → profile initialized; `dsh.profile.bundles` = ["@deepseek-ai/dsh-base", "dsh-llm-fallbacks"]
+    (reconcile appends to the end of the list, matching the "add appends by default" semantics)
 $ dsh --profile verify --dump-config
   # == @deepseek-ai/dsh-base
-  - id: llm-retry            ← llm-retry 位于 dsh-base 层内
+  - id: llm-retry            ← llm-retry lives in the dsh-base layer
   ...
   # == dsh-llm-fallbacks
   - id: llm-fallbacks
@@ -75,10 +75,10 @@ order section of [docs/install.md](docs/install.md); the real web profile's laye
 ### 1. Loading a real profile
 
 ```sh
-cd <插件仓库目录>
-pnpm install          # prepare 自构建（pnpm 工具链）
+cd <plugin-repo>
+pnpm install          # self-build via prepare (pnpm toolchain)
 dsh plugin --profile web add .
-dsh --profile web --dump-config   # 组合树末尾应出现 # == dsh-llm-fallbacks 层
+dsh --profile web --dump-config   # the composed tree should end with a # == dsh-llm-fallbacks layer
 ```
 
 **Expected**: `dsh-llm-fallbacks` is appended to the end of `dsh.profile.bundles` (after `@deepseek-ai/dsh-base`);
@@ -127,7 +127,7 @@ Then restart the dsh web session so the host half and the client half load.
 
 1. **Preflight check**: record `dsh --version` (snapshot); the plugin-side peer dependencies resolve from the npm registry
    (`@deepseek-ai/*@0.1.0-rc.6`, no source tree needed).
-2. **Plugin build**: `cd <插件仓库目录> && pnpm build` (host bundle + client bundle + tsc
+2. **Plugin build**: `cd <plugin-repo> && pnpm build` (host bundle + client bundle + tsc
    declarations) green — pure-mount semantics: no dsh source-tree modification, no patch step; settings read/write go through the plugin
    gateway channel (`/api/fallbacks/get|set|reset`), usable right after installation.
 3. **Restart `dsh web` (web profile)**: stop the old host process → start `dsh web` with the web profile

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -6,7 +6,7 @@ This document records the installation / runtime-contract verification already c
 
 ## Verified (evidence summary for this iteration)
 
-### 1. Test matrix (unit + integration + client + host gateway + command; 20 files / 409 tests all green)
+### 1. Test matrix (unit + integration + client + host gateway + command + release/consumer tooling; 23 files / 460 tests all green)
 
 | Scope | Files | Count | Contract covered |
 |---|---|---|---|
@@ -16,9 +16,10 @@ This document records the installation / runtime-contract verification already c
 | integration (T4) | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 19 / 4 / 5 | end-to-end re-integration (including the registration-order dependency of the model-selection combination, T2), **two-plugin coexistence order** (normal backs off first, switches after the budget is exhausted; non-retryable codes switch directly), **always delegates downstream first + cap at the request boundary** (ADR-2), cooldown/revert integration, **safety-valve** original error semantics after the cap, combination order without mutual interference |
 | client (T5) | `fallbacks-store.spec.ts` / `fallbacks-card.spec.tsx` / `general-row.spec.tsx` / `conversation-switch.spec.tsx` | 88 / 29 / 9 / 15 | card read/write via the **gateway channel** (rpc mock of `/api/fallbacks/get|set|reset`: `load` fetches config from `get`, `save` goes through `set`, `resetToDefaults` goes through `reset`), `present` flag and unreachable-channel skeleton, describe only reads writable + other namespaces (the fallbacks namespace no longer appears in describe), KD-G3 new error path (errors surface truthfully after the revision guard was removed), draft seeded only from a real `get` result (I-1 invariant), chain/rule row-edit round trips, status-block recent-switch extraction (sessions.history event surface), card chrome (plugin-config page listing, collapse/expand, dirty/save/discard), controller lifecycle; General page status row (`settings.general.item` registration shape id `fallbacks` order 100, enabled badge + recent-switch summary, KD-G5 unreachable does not masquerade as disabled, lazy first read and no re-read once read); conversation switch row (`conversation.chat.node` keyed registration key `fallbacks-switch`, D1-defined state machine match/start/update/buildViewNode, renders `from → to (role · reason)` with unknown reasons passed through verbatim, role=status, malformed payloads degrade to the title row without throwing, zh rendering parity smoke) |
 | command (AC-5) | `command.spec.ts` | 30 | `/fallbacks` registration shape (name/description/empty hint/handler, disposer passthrough), conditional `commands` child injection (registers only when a registry exists; silent without a service), snapshot building (role/chain resolution with the default fallback, recent switches newest-first capped, cooldown read-only snapshot), output states (configured chain / no chain / switches present + absent / cooldown present + absent / `never` does not revert), zh/en rendering smoke, real runtime-state integration (switch events + cooldown read from real state; read-only, never adds state) |
+| release/consumer tooling | `service.spec.ts` / `export-surface.spec.ts` / `release-scripts.spec.ts` | 7 / 27 / 17 | the named cordis service surface (static provide metadata, `ctx.get` availability while applied, unregister on dispose, multi-fiber dedupe, same functions as the package-root re-exports); the package export surface (runtime values + callable smokes + type exports matching the docs-inventory keys); release-script gates (autoBumpPatch / insertSection / parseArgs / validateReleaseVersion / tagExists) |
 | regression | `skeleton.spec.ts` / `host-native.spec.ts` / `peer-deps.test.ts` | 3 / 3 / 5 | bundle contract (row id, empty schema accepted, host+client apply entry points); host-native behavior baseline (real `@deepseek-ai/dsh-agent` module: trigger-code switches route to the chain target, always-cap second return point, no-op invariant); registry peer contract (`@deepseek-ai/*` as peerDependencies only, dsh-* pinned to `^0.1.0-rc.6`, autoInstallPeers, no link farm) |
 
-Result: **20 files / 409 tests all green** (`pnpm test`, vitest run); `pnpm build` (`tsc -p tsconfig.build.json` emits JS first (standard decorator downgrade `__esDecorate`) → tsdown host bundle →
+Result: **23 files / 460 tests all green** (`pnpm test`, vitest run); `pnpm build` (`tsc -p tsconfig.build.json` emits JS first (standard decorator downgrade `__esDecorate`) → tsdown host bundle →
 `pnpm run build-client` → `tsc` declarations → `node scripts/verify-dist.mjs` artifact-parsing guard) all green — `tsc` is
 driven by the real host type surface (registry peer `@deepseek-ai/*@0.1.0-rc.6`, no in-repo type shims). The no-op regression
 invariants (empty chains / no match / chain exhausted / safety-valve cap exceeded → pass through without producing
@@ -91,19 +92,19 @@ Then restart the dsh web session so the host half and the client half load.
 2. **First open (no `fallbacks` config yet)**: the card shows its skeleton (card header / intro / read-only status block /
    feature switch / save / reset to defaults), the feature switch `enabled` is **OFF by default**, the configuration form body is hidden
    and the "Feature disabled" hint shows — the card is always usable and never blank just because the namespace is missing.
-3. Turn on the `enabled` switch → the configuration form body appears (`triggerCodes` / `chains` / `roles` /
+3. Turn on the `enabled` switch → the configuration form body appears (`triggerCodes` / `rootChain` / `roles` /
    `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`).
 4. Edit any field (e.g. change `cooldownMs` to `600000`) and save.
 5. **Expected**: the save succeeds with no conflict banner; `$DSH_HOME/settings.yaml` (or that profile's settings
    path) gets the new value written (including `enabled: true`); re-entering the page shows the saved value with the switch
-   still ON, and revision behaves normally (a concurrent modification shows a conflict banner + a "Reload" button instead
-   of a silent overwrite).
+   still ON, and a concurrent modification from another session surfaces as a truthful error banner on save — the gateway
+   `set` has no revision guard, so there is no "Reload" prompt and no silent overwrite (KD-G3).
 6. Turn off the `enabled` switch → the form body hides again (an in-progress draft is kept and still there when reopened);
    after one-click "Reset to defaults" confirm the config is back to the composed defaults (`enabled` back to `false`).
 
 ### 3. Runtime fallback verification (simulated failures)
 
-1. Configure a demo chain in the `fallbacks` namespace: point `chains.default` at a **fallback model**
+1. Configure a demo fallback chain in the `fallbacks` namespace: point `rootChain` at a **fallback model**
    (e.g. `openai/gpt-4o-mini`), misconfigure the primary model's (e.g. `deepseek/deepseek-chat`) credentials or
    point the chain at a non-existent provider, and construct a **non-retryable failure code** (`AUTH` / `QUOTA` path,
    reaching the plugin directly without backoff).
@@ -144,12 +145,12 @@ Then restart the dsh web session so the host half and the client half load.
    (`/api/fallbacks/get|set|reset`), independent of any settings-exposure mechanism of the dsh host (the `fallbacks`
    namespace not appearing in the describe exposure set is by design); a successful `get` sets `present`,
    and an unreachable channel shows an actionable skeleton rather than a dead page.
-3. Turn on the `enabled` switch → the configuration form body appears (`triggerCodes` / `chains` / `roles` /
+3. Turn on the `enabled` switch → the configuration form body appears (`triggerCodes` / `rootChain` / `roles` /
    `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`).
-4. **Add a chain via catalog selection**: in the `chains` row editor pick a target in the provider/model **dropdown
-   (model catalog)** to add a chain entry (e.g. a `default` chain → a fallback `provider/model` that exists in the
-   catalog); same for `roles.rules` row editing (optional). New rows only offer in-catalog options; out-of-catalog
-   values are kept, annotated as synthetic options.
+4. **Add a chain via catalog selection**: in the `rootChain` selector row pick a target in the provider/model **dropdown
+   (model catalog)** to add a chain entry (e.g. the root chain → a fallback `provider/model` that exists in the
+   catalog); same for `roles.list` role-chain rows and `roles.rules` row editing (optional). New rows only offer
+   in-catalog options; out-of-catalog values are kept, annotated as synthetic options.
 5. **Save** → UI saving → ready (`save` writes the user layer via `fallbacks/set`; `set` is
    merge-semantics with no revision guard — concurrent modifications no longer show a conflict banner; errors always
    surface truthfully in a banner).
@@ -172,7 +173,7 @@ Then restart the dsh web session so the host half and the client half load.
 
 #### 4.3 Switch routing + status block (AC-2 / AC-7)
 
-1. **Failure injection**: configure a demo chain (`chains.default` pointing at a fallback model); misconfigure the primary
+1. **Failure injection**: configure a demo fallback chain (`rootChain` pointing at a fallback model); misconfigure the primary
    model's credentials or point the chain at a non-existent provider to construct a **non-retryable failure code**
    (`AUTH` / `QUOTA`, reaching the plugin directly without backoff);
    on the retryable-code path (`RATE_LIMIT` / 5xx) observe llm-retry backing off first and the chain decision

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,37 +1,32 @@
-# 验证记录（profile 安装与插件配置卡运行期验证）
+# Verification Record (Profile Installation and Plugin-Config Card Runtime Verification)
 
-本文记录 `dsh-llm-fallbacks` 在**本仓库验证环境（沙箱兼容的 scratch 环境）**下已完成
-的安装/运行契约验证，以及**需要在用户真实 dsh 环境执行**的验证步骤与预期结果。
+This document records the installation / runtime-contract verification already completed for `dsh-llm-fallbacks` in **this repo's verification environment (a sandbox-compatible scratch environment)**, plus the verification steps and expected results that **must be executed in the user's real dsh environment**.
 
-> 边界声明：本仓库的验证环境受沙箱约束，**无法对运行中的 dsh 安装（真实 `$DSH_HOME`）
-> 做任何写操作**，也无法操作 web 设置 GUI、发起真实模型调用或跨进程观察。因此下文
-> 「已验证」仅覆盖可在工作区内完成的证据（单元/集成测试、scratch profile 装入与
-> `--dump-config` 层序、构建管线）；「用户待执行」为真实环境步骤与预期，如实标注，
-> 不夸大已验范围。
+> **Scope statement**: this repo's verification environment is sandbox-constrained — it **cannot perform any write to a running dsh installation (a real `$DSH_HOME`)**, and it cannot operate the web settings GUI, issue real model calls, or observe across processes. Therefore "Verified" below covers only evidence completable inside the workspace (unit/integration tests, scratch-profile loading and `--dump-config` layer order, the build pipeline); "To be run by the user" lists the real-environment steps and expectations, labeled honestly without overstating the verified scope.
 
-## 已验证（本迭代证据汇总）
+## Verified (evidence summary for this iteration)
 
-### 1. 测试矩阵（单元 + 集成 + client + host gateway + 命令，20 files / 409 tests 全绿）
+### 1. Test matrix (unit + integration + client + host gateway + command; 20 files / 409 tests all green)
 
-| 范围 | 文件 | 数量 | 覆盖契约 |
+| Scope | Files | Count | Contract covered |
 |---|---|---|---|
-| host 单测（T1） | `gateway.spec.ts` | 35 | `/api/fallbacks/get|set|reset` 三端点：`get` 返回 composed（JSON 归一化省略 undefined、无 resolver）；`set` 未知键拒绝、合法 patch 写 user layer 返回新值、空/null patch no-op；`reset` 清空 user layer 返回默认 composed；无 settings 服务时 `get` 仍成功、`set`/`reset` 报清晰错误（KD-G5） |
-| 单元（T2） | `selectors.spec.ts` / `chains.spec.ts` / `roles.spec.ts` / `cooldown.spec.ts` | 11 / 34 / 15 / 12 | selector 解析与 specificity（exact → `provider/*` → 角色 → default）、`provider/*` 条目保留模型 id 仅换 provider、角色规则顺序匹配（rules-only：origin/provider/model → default）、cooldown/revert（惰性过期、never 无限 TTL、只读快照） |
-| 单元（T3） | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 25 / 50 | 状态机（pendingSwitch 产生→应用→清除、appliedTurnStep 防重放、step 推进重置）、`fallbacks/switch` 事件形状与 JSON 往返、`Config({})` 恒等于默认配置（no-op 基线）、小集成 Step 6 全项 |
-| 集成（T4） | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 19 / 4 / 5 | 端到端重集成（含 model-selection 组合的注册顺序依赖，T2）、**双插件共存顺序**（normal 先退避、预算耗尽后切换；不可重试码直切）、**always 先委托下游 + cap 在 request 边界**（ADR-2）、冷却/revert 集成、**安全阀**超限后原错误语义、组合顺序互不干扰 |
-| client（T5） | `fallbacks-store.spec.ts` / `fallbacks-card.spec.tsx` / `general-row.spec.tsx` / `conversation-switch.spec.tsx` | 88 / 29 / 9 / 15 | 卡片读写经 **gateway 通道**（`/api/fallbacks/get|set|reset` 的 rpc mock：`load` 从 `get` 取配置、`save` 走 `set`、`resetToDefaults` 走 `reset`）、`present` 标志与通道不可达骨架、describe 仅读 writable+其它命名空间（fallbacks 命名空间不再出现在 describe）、KD-G3 新错误路径（revision guard 移除后错误如实呈现）、draft 仅从真实 get 结果 seed（I-1 不变式）、chain/rule 行编辑往返、状态块最近切换提取（sessions.history 事件面）、卡片 chrome（插件配置页列表、折叠/展开、dirty/保存/丢弃）、controller 生命周期；General 页状态行（`settings.general.item` 注册形状 id `fallbacks` order 100、启用徽标 + 最近切换摘要、KD-G5 不可达不冒充 disabled、惰性首读与已读不重读）；会话切换行（`conversation.chat.node` keyed 注册 key `fallbacks-switch`、D1 定义状态机 match/start/update/buildViewNode、渲染行 `from → to（role · reason）` 未知 reason 原样、role=status、malformed 负载降级标题行不抛、zh 渲染 parity smoke） |
-| 命令（AC-5） | `command.spec.ts` | 30 | `/fallbacks` 注册形状（name/description/空 hint/handler、disposer 透传）、条件 `commands` 子注入（有注册表才注册；无服务静默）、快照构建（角色/链解析含 default 兜底、最近切换最新在前封顶、冷却只读快照）、输出状态（配置链 / 无链 / 切换有+无 / 冷却有+无 / never 不回主）、zh/en 渲染 smoke、真实运行状态集成（切换事件 + 冷却读自真实状态、只读不增状态） |
-| 回归 | `skeleton.spec.ts` / `host-native.spec.ts` / `peer-deps.test.ts` | 3 / 3 / 5 | bundle 契约（row id、空 schema 接受、host+client apply 入口）；宿主原生行为基线（真实 `@deepseek-ai/dsh-agent` 模块：触发码切换路由到链目标、always-cap 第二返回点、no-op 不变量）；registry peer 契约（`@deepseek-ai/*` 仅 peerDependencies、dsh-* 钉 `^0.1.0-rc.6`、autoInstallPeers、无 link farm） |
+| host unit tests (T1) | `gateway.spec.ts` | 35 | the three endpoints of `/api/fallbacks/get|set|reset`: `get` returns composed (JSON normalization omits undefined, no resolver); `set` rejects unknown keys, a valid patch writes the user layer and returns the new value, empty/null patches are no-ops; `reset` clears the user layer and returns default composed; without a settings service `get` still succeeds while `set`/`reset` report clear errors (KD-G5) |
+| unit (T2) | `selectors.spec.ts` / `chains.spec.ts` / `roles.spec.ts` / `cooldown.spec.ts` | 11 / 34 / 15 / 12 | selector parsing and specificity (exact → `provider/*` → role → default), `provider/*` entries keep the model id and only swap the provider, role-rule ordered matching (rules-only: origin/provider/model → default), cooldown/revert (lazy expiry, `never` unlimited TTL, read-only snapshot) |
+| unit (T3) | `state.spec.ts` / `events.spec.ts` / `config.spec.ts` / `runtime.spec.ts` | 13 / 4 / 25 / 50 | state machine (pendingSwitch created → applied → cleared, `appliedTurnStep` replay guard, reset on step advance), `fallbacks/switch` event shape and JSON round-trip, `Config({})` always equals the default config (no-op baseline), all items of mini-integration Step 6 |
+| integration (T4) | `plugin.spec.ts` / `coexist-llm-retry.spec.ts` / `always-mode.spec.ts` | 19 / 4 / 5 | end-to-end re-integration (including the registration-order dependency of the model-selection combination, T2), **two-plugin coexistence order** (normal backs off first, switches after the budget is exhausted; non-retryable codes switch directly), **always delegates downstream first + cap at the request boundary** (ADR-2), cooldown/revert integration, **safety-valve** original error semantics after the cap, combination order without mutual interference |
+| client (T5) | `fallbacks-store.spec.ts` / `fallbacks-card.spec.tsx` / `general-row.spec.tsx` / `conversation-switch.spec.tsx` | 88 / 29 / 9 / 15 | card read/write via the **gateway channel** (rpc mock of `/api/fallbacks/get|set|reset`: `load` fetches config from `get`, `save` goes through `set`, `resetToDefaults` goes through `reset`), `present` flag and unreachable-channel skeleton, describe only reads writable + other namespaces (the fallbacks namespace no longer appears in describe), KD-G3 new error path (errors surface truthfully after the revision guard was removed), draft seeded only from a real `get` result (I-1 invariant), chain/rule row-edit round trips, status-block recent-switch extraction (sessions.history event surface), card chrome (plugin-config page listing, collapse/expand, dirty/save/discard), controller lifecycle; General page status row (`settings.general.item` registration shape id `fallbacks` order 100, enabled badge + recent-switch summary, KD-G5 unreachable does not masquerade as disabled, lazy first read and no re-read once read); conversation switch row (`conversation.chat.node` keyed registration key `fallbacks-switch`, D1-defined state machine match/start/update/buildViewNode, renders `from → to (role · reason)` with unknown reasons passed through verbatim, role=status, malformed payloads degrade to the title row without throwing, zh rendering parity smoke) |
+| command (AC-5) | `command.spec.ts` | 30 | `/fallbacks` registration shape (name/description/empty hint/handler, disposer passthrough), conditional `commands` child injection (registers only when a registry exists; silent without a service), snapshot building (role/chain resolution with the default fallback, recent switches newest-first capped, cooldown read-only snapshot), output states (configured chain / no chain / switches present + absent / cooldown present + absent / `never` does not revert), zh/en rendering smoke, real runtime-state integration (switch events + cooldown read from real state; read-only, never adds state) |
+| regression | `skeleton.spec.ts` / `host-native.spec.ts` / `peer-deps.test.ts` | 3 / 3 / 5 | bundle contract (row id, empty schema accepted, host+client apply entry points); host-native behavior baseline (real `@deepseek-ai/dsh-agent` module: trigger-code switches route to the chain target, always-cap second return point, no-op invariant); registry peer contract (`@deepseek-ai/*` as peerDependencies only, dsh-* pinned to `^0.1.0-rc.6`, autoInstallPeers, no link farm) |
 
-结果：**20 files / 409 tests 全绿**（`pnpm test`，vitest run）；`pnpm build`（`tsc -p tsconfig.build.json` 先发 JS（标准装饰器降级 `__esDecorate`）→ tsdown host bundle →
-`pnpm run build-client` → `tsc` 声明 → `node scripts/verify-dist.mjs` 产物解析守卫）全绿——`tsc` 按
-真实宿主类型面驱动（registry peer `@deepseek-ai/*@0.1.0-rc.6`，无任何仓内类型 shim）。no-op 回归
-不变量（空链 / 未命中 / 链耗尽 / 安全阀超限 → 透传、不产生 `fallbacks/switch` 事件）由
-T3/T4 测试持久断言。
+Result: **20 files / 409 tests all green** (`pnpm test`, vitest run); `pnpm build` (`tsc -p tsconfig.build.json` emits JS first (standard decorator downgrade `__esDecorate`) → tsdown host bundle →
+`pnpm run build-client` → `tsc` declarations → `node scripts/verify-dist.mjs` artifact-parsing guard) all green — `tsc` is
+driven by the real host type surface (registry peer `@deepseek-ai/*@0.1.0-rc.6`, no in-repo type shims). The no-op regression
+invariants (empty chains / no match / chain exhausted / safety-valve cap exceeded → pass through without producing
+`fallbacks/switch` events) are persistently asserted by T3/T4 tests.
 
-### 2. bundle 层序（scratch profile `--dump-config` 实证）
+### 2. Bundle layer order (proven via scratch profile `--dump-config`)
 
-在**工作区内 scratch profile**（`DSH_HOME=<插件仓库>/.dsh-verify`，验证后删除）上：
+On a **scratch profile inside the workspace** (`DSH_HOME=<插件仓库>/.dsh-verify`, deleted after verification):
 
 ```
 $ dsh plugin --profile verify add <插件仓库>
@@ -47,34 +42,37 @@ $ dsh --profile verify --dump-config
     config: {}
 ```
 
-`llm-fallbacks` 作为**独立层插在 dsh-base（含 llm-retry）之后**——即 waterfall 注册
-顺序满足「llm-retry 之后介入」的硬性要求（对应 [docs/install.md](docs/install.md)
-bundle 层顺序一节；真实 web profile 层序 `dsh-base → dsh-web-app → @mstar-harness/dsh
-→(add) dsh-llm-fallbacks` 同理，`add` 追加到末尾即满足）。
+`llm-fallbacks` sits as an **independent layer after dsh-base (which contains llm-retry)** — i.e. the waterfall
+registration order satisfies the hard requirement to "intervene after llm-retry" (corresponding to the bundle layer
+order section of [docs/install.md](docs/install.md); the real web profile's layer order `dsh-base → dsh-web-app → @mstar-harness/dsh
+→(add) dsh-llm-fallbacks` works the same way — `add` appends to the end, which suffices).
 
-### 3. 运行契约（以测试证据支撑）
+### 3. Runtime contracts (backed by test evidence)
 
-- **切换可见性**：任何切换（含 always-cap 路径）产生 `fallbacks/switch` 事件（T3 事件
-  形状 + T4 集成断言；spec 硬性要求「无事件即无切换」）。
-- **回滚/失败语义**：链耗尽 / 安全阀超限 / 无匹配链 / 角色解析失败 / 未命中 triggerCodes
-  → `next()` 透传，原错误码与 message 原样保留（T3/T4 断言）。
-- **卸载无残留**：`agent/disposed` 删除、`agent/status` idle 防御清理、`ctx.effect`
-  dispose 清空（T3 断言）。
-- **真实类型契约**：类型层不走手写 `peer-stubs/`——`autoInstallPeers` 从 npm registry 解析真实
-  `@deepseek-ai/*@0.1.0-rc.6` peer（用户级 ~/.npmrc 认证，无本地 link farm）；
-  `tsc` 与集成测试（`tests/support/harness.ts` + llm-retry-stub + model-selection-stub）按真实
-  类型面驱动。运行时缝走真实实现：`installSettingsSection` 挂真实 `@deepseek-ai/dsh-settings`
-  （内存 provider `tests/support/memory-settings.ts`，继承真实 `SettingsProvider` 基类），
-  `createSnapshotStore` 用本地 node-safe 双（vitest alias 指向 `tests/support/snapshot-store.ts`，因 registry 包 `./client` 是浏览器 loader artifact）。
-  插件对 dsh 源码树**零本地修改**——安装 = bundle 行插入（`bundle/cordis.patch.yml`）+ client
-  inject（`dsh.client.inject`）+ 自有 gateway 通道；dsh 升级无需重打任何补丁（纯挂载语义）。
+- **Switch visibility**: every switch (including the always-cap path) produces a `fallbacks/switch` event (T3 event
+  shape + T4 integration assertions; the spec hard-requires "no event, no switch").
+- **Rollback / failure semantics**: chain exhausted / safety-valve cap exceeded / no matching chain / role-resolution
+  failure / no `triggerCodes` hit → `next()` passes through, preserving the original error code and message verbatim
+  (T3/T4 assertions).
+- **No residue on unload**: `agent/disposed` removes state, `agent/status` idle is defensively cleaned, `ctx.effect`
+  dispose clears everything (T3 assertions).
+- **Real-type contract**: the type layer does not use hand-written `peer-stubs/` — `autoInstallPeers` resolves the real
+  `@deepseek-ai/*@0.1.0-rc.6` peers from the npm registry (user-level `~/.npmrc` auth, no local link farm);
+  `tsc` and the integration tests (`tests/support/harness.ts` + llm-retry-stub + model-selection-stub) are driven by the
+  real type surface. Runtime seams run the real implementations: `installSettingsSection` mounts the real
+  `@deepseek-ai/dsh-settings` (in-memory provider `tests/support/memory-settings.ts`, inheriting the real
+  `SettingsProvider` base class), and `createSnapshotStore` uses a local node-safe double (vitest alias pointing at
+  `tests/support/snapshot-store.ts`, because the registry package's `./client` is a browser loader artifact).
+  The plugin makes **zero local modifications** to the dsh source tree — installation = bundle row insert
+  (`bundle/cordis.patch.yml`) + client inject (`dsh.client.inject`) + its own gateway channel; dsh upgrades never
+  require re-patching (pure-mount semantics).
 
-## 用户待执行（真实环境步骤与预期）
+## To be run by the user (real-environment steps and expectations)
 
-> 以下步骤需在**真实 dsh 环境**（有 `$DSH_HOME` 安装、可操作 web GUI、可发起真实模型
-> 调用）执行；路径一律以 `$DSH_HOME` 表达，不依赖本地绝对路径。
+> The following steps must be executed in a **real dsh environment** (a `$DSH_HOME` installation, an operable web GUI,
+> and the ability to issue real model calls); paths are always expressed as `$DSH_HOME` — no local absolute paths.
 
-### 1. 真实 profile 装入
+### 1. Loading a real profile
 
 ```sh
 cd <插件仓库目录>
@@ -83,134 +81,145 @@ dsh plugin --profile web add .
 dsh --profile web --dump-config   # 组合树末尾应出现 # == dsh-llm-fallbacks 层
 ```
 
-**预期**：`dsh.profile.bundles` 末尾追加 `dsh-llm-fallbacks`（在 `@deepseek-ai/dsh-base`
-之后）；`--dump-config` 中 `llm-fallbacks` 层出现在含 `llm-retry` 的 dsh-base 层之后。
-然后重启 dsh web 会话使 host 半与 client 半加载。
+**Expected**: `dsh-llm-fallbacks` is appended to the end of `dsh.profile.bundles` (after `@deepseek-ai/dsh-base`);
+in `--dump-config` the `llm-fallbacks` layer appears after the dsh-base layer that contains `llm-retry`.
+Then restart the dsh web session so the host half and the client half load.
 
-### 2. web 插件配置卡验证
+### 2. Web plugin-config card verification
 
-1. 打开 web 设置 GUI → Settings → 插件配置，确认出现 **Fallbacks 卡片**（与 bash / agent-loop / web-search / advisor 卡同列表）。
-2. **首次打开（尚无 `fallbacks` 配置）**：卡片显示骨架（卡片头 / 介绍 / 只读状态块 /
-   功能级开关 / 保存 / 恢复默认），功能级开关 `enabled` **默认 OFF**，配置表单主体隐藏、
-   显示「功能未开启」提示——卡片始终可用，不因命名空间缺失而空白。
-3. 打开 `enabled` 开关 → 配置表单主体出现（`triggerCodes` / `chains` / `roles` /
-   `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）。
-4. 编辑任一字段（如把 `cooldownMs` 改为 `600000`）并保存。
-5. **预期**：保存成功、无冲突横幅；`$DSH_HOME/settings.yaml`（或该 profile 的 settings
-   路径）写入新值（含 `enabled: true`）；再次进入页面显示已保存的值、开关保持 ON，
-   revision 正常（并发修改时出现冲突横幅 +「重新加载」按钮，不静默覆盖）。
-6. 关闭 `enabled` 开关 → 表单主体再次隐藏（编辑中的 draft 保留，重新打开仍在）；
-   一键「恢复默认」后确认配置回组合默认值（`enabled` 回 `false`）。
+1. Open the web settings GUI → Settings → **插件配置** (**Plugin Settings**), confirm the **Fallbacks card** appears (same list as the bash / agent-loop / web-search / advisor cards).
+2. **First open (no `fallbacks` config yet)**: the card shows its skeleton (card header / intro / read-only status block /
+   feature switch / save / reset to defaults), the feature switch `enabled` is **OFF by default**, the configuration form body is hidden
+   and the "Feature disabled" hint shows — the card is always usable and never blank just because the namespace is missing.
+3. Turn on the `enabled` switch → the configuration form body appears (`triggerCodes` / `chains` / `roles` /
+   `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`).
+4. Edit any field (e.g. change `cooldownMs` to `600000`) and save.
+5. **Expected**: the save succeeds with no conflict banner; `$DSH_HOME/settings.yaml` (or that profile's settings
+   path) gets the new value written (including `enabled: true`); re-entering the page shows the saved value with the switch
+   still ON, and revision behaves normally (a concurrent modification shows a conflict banner + a "Reload" button instead
+   of a silent overwrite).
+6. Turn off the `enabled` switch → the form body hides again (an in-progress draft is kept and still there when reopened);
+   after one-click "Reset to defaults" confirm the config is back to the composed defaults (`enabled` back to `false`).
 
-### 3. 运行期 fallback 验证（模拟失败）
+### 3. Runtime fallback verification (simulated failures)
 
-1. 在 `fallbacks` 命名空间配置 demo 链：`chains.default` 指向一个**备用模型**
-   （如 `openai/gpt-4o-mini`），把主模型（如 `deepseek/deepseek-chat`）的密钥配错或
-   把链指向不存在的 provider，构造**不可重试失败码**（`AUTH` / `QUOTA` 路径，不经退避
-   直达插件）。
-2. 发起一个请求触发失败。
-3. **预期**：
-   - 日志出现本插件 info 级记录（候选尝试顺序与跳过原因）；
-   - 会话事件流追加 `fallbacks/switch`（from/to/role/reason）；
-   - 请求在备用模型上继续，当前 step/turn 不中断。
-4. 可重试码路径（`RATE_LIMIT` / 5xx）：配置 `triggerCodes` 含 `RATE_LIMIT`，观察
-   llm-retry 先退避、预算耗尽后进入链决策——确认层序正确（fallback 未抢占退避）。
+1. Configure a demo chain in the `fallbacks` namespace: point `chains.default` at a **fallback model**
+   (e.g. `openai/gpt-4o-mini`), misconfigure the primary model's (e.g. `deepseek/deepseek-chat`) credentials or
+   point the chain at a non-existent provider, and construct a **non-retryable failure code** (`AUTH` / `QUOTA` path,
+   reaching the plugin directly without backoff).
+2. Issue a request to trigger the failure.
+3. **Expected**:
+   - info-level logs from this plugin appear (candidate attempt order and skip reasons);
+   - the session event stream gains a `fallbacks/switch` entry (from/to/role/reason);
+   - the request continues on the fallback model and the current step/turn is not interrupted.
+4. Retryable-code path (`RATE_LIMIT` / 5xx): with `RATE_LIMIT` in `triggerCodes`, observe
+   llm-retry backing off first and the chain decision being entered only after its budget is exhausted — confirming
+   the layer order (fallback does not preempt backoff).
 
-### 4. QA gate 端到端验证剧本（插件配置卡读写闭环 + 保存即生效 + 切换路由 + 状态块）
+### 4. QA gate end-to-end verification script (plugin-config card read/write loop + save-takes-effect + switch routing + status block)
 
-> 本节为 QA gate 阶段的 **mandatory 输入**：在真实 dsh 环境（`$DSH_HOME` 安装、web
-> profile、可操作 web 设置 GUI、可发起真实模型调用）按步骤执行并记录结果。路径一律
-> 以 `$DSH_HOME` 表达，不含本地绝对路径。4.2 的「保存即生效」
-> 以 4.1 记录的 host **PID + 启动时间基线**为锚（同 PID、同启动时间、不重载页面）。
+> This section is the **mandatory input** for the QA gate phase: execute and record the steps in a real dsh environment
+> (`$DSH_HOME` installation, web profile, operable web settings GUI, real model calls). Paths are always expressed as
+> `$DSH_HOME` — no local absolute paths. §4.2's "save takes effect" is anchored to the host **PID + start-time
+> baseline** recorded in §4.1 (same PID, same start time, no page reload).
 
-#### 4.1 环境准备（新快照基线）
+#### 4.1 Environment preparation (new snapshot baseline)
 
-1. **前置核对**：记录 `dsh --version`（快照）；插件侧 peer 依赖已从 npm registry 解析
-   （`@deepseek-ai/*@0.1.0-rc.6`，无需源码树）。
-2. **插件构建**：`cd <插件仓库目录> && pnpm build`（host bundle + client bundle + tsc
-   声明）绿——纯挂载语义：不修改 dsh 源码树、无任何补丁步骤；设置读写走插件 gateway
-   通道（`/api/fallbacks/get|set|reset`），安装即用。
-3. **重启 `dsh web`（web profile）**：停止旧 host 进程 → 以 web profile 启动 `dsh web`
-   （--dev 不可用时重建 web artifacts 后刷新验证 URL）。
-4. **记录基线**：`ps -o pid,lstart -p <dsh-web-pid>`（或 `pgrep -fl "dsh web"` 定位）——
-   **PID + 启动时间**作为 4.2「不重启 host」对照锚点；同时记录 `$DSH_HOME/settings.yaml`
-   当前 `fallbacks:` 段状态（应为无该段，或 `enabled: false`）。
+1. **Preflight check**: record `dsh --version` (snapshot); the plugin-side peer dependencies resolve from the npm registry
+   (`@deepseek-ai/*@0.1.0-rc.6`, no source tree needed).
+2. **Plugin build**: `cd <插件仓库目录> && pnpm build` (host bundle + client bundle + tsc
+   declarations) green — pure-mount semantics: no dsh source-tree modification, no patch step; settings read/write go through the plugin
+   gateway channel (`/api/fallbacks/get|set|reset`), usable right after installation.
+3. **Restart `dsh web` (web profile)**: stop the old host process → start `dsh web` with the web profile
+   (when `--dev` is unavailable, rebuild web artifacts and refresh the verification URL).
+4. **Record the baseline**: `ps -o pid,lstart -p <dsh-web-pid>` (or locate via `pgrep -fl "dsh web"`) —
+   **PID + start time** serve as the §4.2 "no host restart" comparison anchor; also record the current `fallbacks:` section
+   state in `$DSH_HOME/settings.yaml` (expected: no such section, or `enabled: false`).
 
-#### 4.2 插件配置卡读写闭环（保存即生效，AC-1）
+#### 4.2 Plugin-config card read/write loop (save-takes-effect, AC-1)
 
-1. 打开 web 设置 GUI → Settings → **插件配置** → **Fallbacks 卡片**。
-2. **预期①（gateway 通道生效）**：卡片渲染骨架（卡片头 / 介绍 / 只读状态块 /
-   `enabled` 开关 / 保存 / 恢复默认）——配置读写经插件 gateway 通道
-   （`/api/fallbacks/get|set|reset`），不依赖 dsh 本体的任何设置暴露机制（`fallbacks`
-   命名空间不出现在 describe 暴露集合属预期设计）；`get` 成功则 `present`，
-   通道不可达时显示可操作骨架而非死页。
-3. 开启 `enabled` 开关 → 配置表单主体出现（`triggerCodes` / `chains` / `roles` /
-   `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`）。
-4. **目录选择添加链**：在 `chains` 行编辑的 provider/model **下拉（模型目录）**中选择
-   目标添加一条链条目（如 `default` 链 → 目录内存在的备用 `provider/model`）；`roles.rules`
-   行编辑同理（可选）。新行只提供目录内选项，目录外值以合成选项标注保留。
-5. **保存** → UI saving → ready（`save` 经 `fallbacks/set` 写 user layer；`set` 为
-   merge 语义，无 revision guard——并发修改不再有冲突横幅，错误一律如实横幅呈现）。
-6. **磁盘证据**：`$DSH_HOME/settings.yaml` 出现 `fallbacks:` 段且与保存值一致
-   （`enabled: true` + 添加的链行）。
-7. **立即生效证据（AC-1 核心）**：**不重启 host、不重载页面**——先确认 host PID/启动
-   时间与 4.1 基线一致（`ps -o pid,lstart -p <pid>`），再触发一次触发码故障（4.3 方法
-   注入，如 AUTH/QUOTA）→ 预期：
-   - 日志出现 `llm-fallbacks: agent ... switch`（info 级，候选尝试顺序与跳过原因）；
-   - 会话事件流追加 `fallbacks/switch` 事件（from/to/role/reason/time）；
-   - 后续请求路由到链目标（provider/model 变为链首目标），当前 step/turn 不中断。
-   → **保存后下一次故障即切换 = 无需重启会话**。
-8. **读回证据**：重载页面 → 经 `fallbacks/get` 显示服务端真值（`enabled` 保持 ON、
-   链行在）；
-   状态块出现步骤 7 的切换条目（AC-7，见 4.3）。
-9. **反证控制**：若步骤 7 显示**需重启 host 才生效** → 如实记录（附 PID/启动时间变化
-   证据），并回写 compass/spec 产品承诺（Global Constraint 兜底条款）。
+1. Open the web settings GUI → Settings → **Plugin Settings** → **Fallbacks card**.
+2. **Expected ① (gateway channel works)**: the card renders its skeleton (card header / intro / read-only status block /
+   `enabled` switch / save / reset to defaults) — config read/write goes through the plugin's gateway channel
+   (`/api/fallbacks/get|set|reset`), independent of any settings-exposure mechanism of the dsh host (the `fallbacks`
+   namespace not appearing in the describe exposure set is by design); a successful `get` sets `present`,
+   and an unreachable channel shows an actionable skeleton rather than a dead page.
+3. Turn on the `enabled` switch → the configuration form body appears (`triggerCodes` / `chains` / `roles` /
+   `cooldownMs` / `revertPolicy` / `maxSwitchesPerStep` / `alwaysModeRetryCap`).
+4. **Add a chain via catalog selection**: in the `chains` row editor pick a target in the provider/model **dropdown
+   (model catalog)** to add a chain entry (e.g. a `default` chain → a fallback `provider/model` that exists in the
+   catalog); same for `roles.rules` row editing (optional). New rows only offer in-catalog options; out-of-catalog
+   values are kept, annotated as synthetic options.
+5. **Save** → UI saving → ready (`save` writes the user layer via `fallbacks/set`; `set` is
+   merge-semantics with no revision guard — concurrent modifications no longer show a conflict banner; errors always
+   surface truthfully in a banner).
+6. **Disk evidence**: `$DSH_HOME/settings.yaml` gains a `fallbacks:` section matching the saved values
+   (`enabled: true` + the added chain line).
+7. **Take-effect evidence (AC-1 core)**: **without restarting the host or reloading the page** — first confirm the host PID/start
+   time matches the §4.1 baseline (`ps -o pid,lstart -p <pid>`), then trigger one trigger-code failure (§4.3
+   injection method, e.g. AUTH/QUOTA) → expected:
+   - `llm-fallbacks: agent ... switch` appears in the logs (info level, candidate attempt order and skip reasons);
+   - the session event stream gains a `fallbacks/switch` event (from/to/role/reason/time);
+   - subsequent requests route to the chain target (provider/model becomes the first chain entry), and the current step/turn
+     is not interrupted.
+   → **the next failure after saving switches = no session restart needed**.
+8. **Read-back evidence**: reload the page → the server truth renders via `fallbacks/get` (`enabled` stays ON,
+   the chain line is there);
+   the status block shows step 7's switch entry (AC-7, see §4.3).
+9. **Counter-evidence control**: if step 7 shows the change **only takes effect after a host restart** → record it
+   truthfully (with PID/start-time change evidence), and report it back to the compass/spec product commitment (the
+   Global Constraint fallback clause).
 
-#### 4.3 切换路由 + 状态块（AC-2 / AC-7）
+#### 4.3 Switch routing + status block (AC-2 / AC-7)
 
-1. **故障注入**：配置 demo 链（`chains.default` 指向备用模型）；把主模型密钥配错或把
-   链指向不存在的 provider 构造**不可重试失败码**（`AUTH` / `QUOTA`，不经退避直达插件）；
-   可重试码路径（`RATE_LIMIT` / 5xx）观察 llm-retry 先退避、预算耗尽后进入链决策。
-2. **预期**：日志 `llm-fallbacks: agent ... switch` + `fallbacks/switch` 事件 + 请求在
-   链目标上继续、当前 step/turn 不中断（对应 §3 运行期验证）。
-3. **活跃 model-selection 下（文档化降级，T2 结论）**：存在活跃 model-selection（用户在
-   设置页 / `settings.yaml` 选择了 provider/model）时，触发码故障后的切换**仍然发生并记录**；
-   但该步的路由可能被外层 model-selection 监听器重新套用（web 前端手动选择的模型在切换后
-   重新应用）——这是去掉本地 patch 标记协调后的**宿主原生行为**，插件配置卡含一行降级说明
-   （`status.selectionNote`，zh/en）。request-error 触发链不受影响；无活跃 selection 时路由
-   到链目标。规格与 guides 记录见 `.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/role-and-model-selection-exploration.md`
-   （Model-selection 节）。
-4. **状态块条目（AC-7）**：插件配置卡状态块出现该切换条目（from/to/role/reason/时间，
-   「最近切换」列表、最新在前）；「当前生效模型」为**推导值**（配置 + 最近切换），
-   附非实时探测说明文案。摘要随 `settings/document-updated`（fallbacks 命名空间）/
-   `llm/adapters-updated`（仅目录）/ 会话切换 / 连接重置推送刷新——切换发生在页面打开期间时，
-   经重载页面（或下一次推送）后呈现，无需重启 host。
-5. **会话内诊断（AC-5）**：在同一会话键入 `/fallbacks`，输出应含会话来源（root/subagent）、
-   解析角色、解析链（含 default 兜底标注）、最近切换（最新在前，from/to/role/reason）与冷却
-   状态；命令只读，不改变任何 fallback 状态。
+1. **Failure injection**: configure a demo chain (`chains.default` pointing at a fallback model); misconfigure the primary
+   model's credentials or point the chain at a non-existent provider to construct a **non-retryable failure code**
+   (`AUTH` / `QUOTA`, reaching the plugin directly without backoff);
+   on the retryable-code path (`RATE_LIMIT` / 5xx) observe llm-retry backing off first and the chain decision
+   after its budget is exhausted.
+2. **Expected**: `llm-fallbacks: agent ... switch` in the logs + a `fallbacks/switch` event + the request
+   continuing on the chain target with the current step/turn uninterrupted (corresponding to the §3 runtime verification).
+3. **Under an active model-selection (documented degradation, T2 conclusion)**: with an active model-selection (the user
+   picked a provider/model in the settings page / `settings.yaml`), a switch after a trigger-code failure **still happens
+   and is recorded**; but that step's routing may be re-applied by the outer model-selection listener (a model manually
+   selected in the web front end is re-applied after the switch) — this is **host-native behavior** after removing the
+   local patch-marker coordination, and the plugin-config card carries a one-line degradation note
+   (`status.selectionNote`, zh/en). request-error-triggered chains are unaffected; without an active selection the request
+   routes to the chain target. Spec and guides records: `.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/role-and-model-selection-exploration.md`
+   (Model-selection section).
+4. **Status-block entry (AC-7)**: the plugin-config card's status block shows the switch entry (from/to/role/reason/time,
+   in the "recent switches" list, newest first); the "current effective model" is a **derived value** (configuration +
+   recent switches), with a non-real-time note. The summary refreshes via push on `settings/document-updated`
+   (fallbacks namespace) / `llm/adapters-updated` (catalog only) / session switch / connection reset — a switch
+   occurring while the page is open appears after a page reload (or the next push), with no host restart needed.
+5. **In-session diagnostics (AC-5)**: type `/fallbacks` in the same session; the output should contain the session origin
+   (root/subagent), the resolved role, the resolved chain (including the default-fallback annotation), recent switches
+   (newest first, from/to/role/reason) and the cooldown state; the command is read-only and never changes any fallback
+   state.
 
-#### 4.4 无回归抽查
+#### 4.4 No-regression spot checks
 
-1. **默认配置 no-op**：`fallbacks.enabled` 关回 `false`（或未配置状态）→ 触发同类故障 →
-   无切换、无 `fallbacks/switch` 事件，请求行为与未安装插件一致。
-2. **目录外值读回保留**：手写一个目录外 selector（如 `provider/legacy-model`）保存 →
-   重载页面仍显示该值（合成选项标注「目录外」），未被目录选择丢弃。
-3. **并发修改行为抽查（可选）**：另一会话/直接编辑 `settings.yaml` 后保存 → 错误横幅
-   如实呈现保存结果，不静默覆盖（gateway `set` 无 revision guard，冲突保护退化为
-   「错误如实呈现」，KD-G3）。
+1. **Default-config no-op**: set `fallbacks.enabled` back to `false` (or the unconfigured state) → trigger the same kind
+   of failure → no switch, no `fallbacks/switch` event, and request behavior identical to an uninstalled plugin.
+2. **Out-of-catalog values survive read-back**: hand-write an out-of-catalog selector (e.g. `provider/legacy-model`) and
+   save → reloading the page still shows the value (synthetic option annotated "outside catalog"), not discarded by the
+   catalog selection.
+3. **Concurrent-modification spot check (optional)**: after another session / a direct `settings.yaml` edit, saving → an
+   error banner truthfully presents the save result without silent overwrite (gateway `set` has no revision guard; conflict
+   protection degrades to "errors surfaced truthfully", KD-G3).
 
-#### 4.5 结果记录
+#### 4.5 Recording results
 
-- 以表格记录：步骤 / 预期 / 实际 / 证据（日志行、`settings.yaml` 片段、截图、PID 基线）。
-- 任一步与预期不符 → 记录为 QA finding（severity + 复现步骤），如实回报，不回写
-  「已验证」。
+- Record in a table: step / expected / actual / evidence (log lines, `settings.yaml` excerpts, screenshots, PID baseline).
+- Any step that deviates from expectations → record it as a QA finding (severity + reproduction steps), report it
+  truthfully, and do not write it back into "Verified".
 
-## 已知限制（沙箱无法覆盖的真实运行面）
+## Known limitations (real runtime surfaces the sandbox cannot cover)
 
-| 面 | 未覆盖原因 | 验证归属 |
+| Surface | Why not covered | Verification owner |
 |---|---|---|
-| web 设置 GUI 交互（卡片出现、编辑保存、冲突重载） | 沙箱无法操作真实 web 会话 | 用户待执行 §2 / §4（client 半逻辑已由 T5 141 例测试覆盖） |
-| 真实模型调用与失败注入（AUTH/QUOTA/RATE_LIMIT 触发、切换继续） | 沙箱无真实模型凭据与运行中会话 | 用户待执行 §3 / §4（决策逻辑已由 T3/T4 集成测试覆盖） |
-| 跨进程观察（日志、`fallbacks/switch` 会话事件在真实会话中的落地） | 沙箱无法运行真实 dsh 会话 | 用户待执行 §3/§4 |
-| `/fallbacks` 命令在真实会话中的输入输出 | 沙箱无法运行真实 dsh 会话与命令注册表 | 用户待执行 §4.3 步骤 5（命令逻辑已由 command.spec.ts 覆盖） |
-| 活跃 model-selection 下的真实路由复写（文档化降级） | 沙箱无真实 web 会话与模型选择 | 用户待执行 §4.3（组合顺序已由 T4 集成测试覆盖） |
+| web settings GUI interaction (card appears, edit & save, conflict reload) | the sandbox cannot operate a real web session | user §2 / §4 (client-half logic already covered by T5's 141 tests) |
+| real model calls and failure injection (AUTH/QUOTA/RATE_LIMIT triggers, switch continuation) | the sandbox has no real model credentials or running session | user §3 / §4 (decision logic already covered by T3/T4 integration tests) |
+| cross-process observation (logs, `fallbacks/switch` session events landing in a real session) | the sandbox cannot run a real dsh session | user §3/§4 |
+| `/fallbacks` command input/output in a real session | the sandbox cannot run a real dsh session and command registry | user §4.3 step 5 (command logic already covered by command.spec.ts) |
+| real routing override under an active model-selection (documented degradation) | the sandbox has no real web session and model selection | user §4.3 (combination order already covered by T4 integration tests) |


### PR DESCRIPTION
## Summary

User directive (2026-08-14): docs/ must be English-only or bilingual (decision: English-only, matching README.md + CHANGELOG.md); plus a root AGENTS.md documenting `.changes/` fragment rules and development conventions.

### Docs translation (3 parallel tracks, L2 worktree isolation)
- `docs/configuration.md` + `docs/verification.md` (Track A)
- `docs/install.md` + `docs/release.md` + `docs/consumer-api.md` (Track B)
- Commands/code blocks/YAML/tables/test counts preserved verbatim; only prose translated. CJK residual ≤ 1 per file (the real dsh UI label 插件配置, per README convention).
- QC caught + fixed stale content carried over from the Chinese originals: test counts refreshed to 23 files / 460 tests; legacy `chains`/`chains.default` references rewritten to the two-block model (rootChain / roles.list / roles.rules); §2/§4.2 conflict-banner contradiction resolved against source.

### Root AGENTS.md (Track C)
- New `AGENTS.md` (123 lines, English): source priority, repo identity, build/test interface, **`.changes/unreleased/` fragment rules** (one file one category, English-only bullets, zero fragments = publish failure), docs English-only rule, PR-driven release flow (zero secrets), code constraints (mount-only, public-registry peers, EN commits, branch → PR → main), harness SSOT note.

## Verification

- QC single-seat (docs-only): Request Changes → fix wave (verification.md) + micro-fix (release.md baseline) → re-review **Approve** (zero-residual)
- pm-acceptance: no open R#; CJK sweep final: ≤1 per file (UI label only); no code/test/workflow changes in the diff