### PR TITLE
fix(release-prep): label creation permission (issues: write) + fail-loud

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # gh label create requires issues:write (labels API) — without it the
+  # ensure-label step silently fails (previously swallowed by `|| true`) and
+  # `gh pr create --label release` errors with "label 'release' not found".
+  issues: write
 
 concurrency:
   group: release-prep
@@ -121,7 +125,7 @@ jobs:
       - name: Ensure release label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh label create release --if-not-exists --color 0E8A16 || true
+        run: gh label create release --if-not-exists --color 0E8A16
 
       # State-aware PR handling. `gh pr view` also matches closed PRs, and
       # `gh pr edit` silently keeps them closed — which would make a re-run


### PR DESCRIPTION
Release prep run 31808229083 failed at 'Open or update release PR': `could not add label: 'release' not found`. Root cause: `gh label create` uses the labels API which requires `issues: write` — workflow only had `contents/pull-requests: write`; the `|| true` swallowed the silent failure, then `gh pr create --label release` errored.\n\nFix: add `issues: write` to the workflow permissions (matches mstar-harness reference) + remove `|| true` so permission problems fail loudly at the label step.