### PR TITLE
fix(package): add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,9 @@
     "tsx": "^4.22.4",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/omdsh-dev/dsh-llm-fallbacks.git"
   }
 }


### PR DESCRIPTION
Release run 31808703364 failed at Publish: npm E422 — provenance verification requires `repository.url` to match the GitHub repo (OIDC provenance); package.json had no repository field.\n\nFix: add `"repository": { "type": "git", "url": "https://github.com/omdsh-dev/dsh-llm-fallbacks.git" }`. No version bump (0.1.0 unchanged — publish never succeeded, no tag created).