### PR TITLE
release v0.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- release v0.1.0-alpha.2 -->
+
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]


### PR DESCRIPTION
Generated by the **Release prep** workflow path (0.1.0 publish attempt failed on provenance repository check; reverted to alpha line per user — 0.1.0-alpha.2).

Merging this PR publishes dsh-llm-fallbacks@0.1.0-alpha.2 to npm (--provenance; NODE_AUTH_TOKEN bootstrap), tags v0.1.0-alpha.2, and creates the GitHub Release (prerelease).

## Changelog

## [0.1.0-alpha.2] - 2026-08-14

### Changed

- In-conversation fallback switch notice now reads 模型已降级 / Model downgraded with a warn-tone title (was neutral 模型切换 / Model switch).
- Declared roles must configure a model chain: the settings card blocks saving a chain-less role (inline hint + banner), and host config validation warns on a missing/empty role chain (never crashes; runtime fallback to `rootChain` preserved).

### Added

- PR-driven npm release pipeline: GitHub Actions `release-prep` (changelog fragments → `release vX.Y.Z` PR) + `release` (Trusted Publishing publish with provenance, tag, GitHub Release), zero long-term secrets.
- Consumer surface: full runtime library API re-exported from the package root (`resolveRole` / `resolveChain` / `validateFallbacksConfig` / `detectLegacyKeys` / types) plus a named cordis service `llm-fallbacks` (`ctx.get('llm-fallbacks')` capability probe).
- GitHub Actions CI verify pipeline (tests + full build) on PRs and `main` pushes.
- Changelog fragment mechanism (`.changes/unreleased/`) with English `CHANGELOG.md`.

