### PR TITLE
docs: release status live (0.1.0-alpha.2 published)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-llm-fallbacks   # pin a version with @<version>
 
 A registry install fetches the **built package** (`dist/`) — nothing is built on the target machine. The plugin is **mount-only**: it never modifies the dsh source tree, and no patch / postinstall step exists — dsh upgrades never require re-patching. Versioning follows npm dist-tags (`latest` by default); pin an exact version with `dsh plugin --profile web add dsh-llm-fallbacks@<version>`.
 
-> **Release status**: the package is **not on the npm registry yet** — the first release (`0.1.0-alpha.2`) is pending (the release pipeline is in place; the first publish uses a one-time `NODE_AUTH_TOKEN` bootstrap secret, with Trusted Publishing configured afterwards for tokenless releases). All registry-based commands in this section are **preview** until the first release PR is merged; until then use the [git install](#git-install-works-today) channel.
+> **Release status**: published as `dsh-llm-fallbacks@0.1.0-alpha.2` (latest). The first publish used a one-time `NODE_AUTH_TOKEN` bootstrap secret; Trusted Publishing is configured afterwards for tokenless releases.
 
 ### Registry package (npm / pnpm)
 
@@ -43,7 +43,7 @@ A registry install fetches the **built package** (`dist/`) — nothing is built 
 npm install dsh-llm-fallbacks   # or: pnpm add dsh-llm-fallbacks
 ```
 
-> **Preview**: effective after `dsh-llm-fallbacks@0.1.0-alpha.2` is published. Release process → [docs/release.md](docs/release.md).
+> Release process → [docs/release.md](docs/release.md).
 
 ### Git install (works today)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-llm-fallbacks   # 钉版本：加 @<version>
 
 registry 安装拉取的是**已构建产物**（`dist/`），目标机无需构建。插件为**纯挂载**：对 dsh 源码树零修改，无任何补丁 / postinstall 步骤——dsh 升级无需重打。版本跟随 npm dist-tag（默认 `latest`）；钉精确版本：`dsh plugin --profile web add dsh-llm-fallbacks@<version>`。
 
-> **发布状态**：包**尚未发布到 npm registry**——首个版本（`0.1.0-alpha.2`）待发布（发布流水线已就绪；首次发布用一次性 `NODE_AUTH_TOKEN`，Trusted Publishing 在首次发布后配置）。本节的 registry 安装命令在首个 release PR merge 前均为**预告**；在此之前请用 [git 安装](#git-安装当前可用)。
+> **发布状态**：已发布 `dsh-llm-fallbacks@0.1.0-alpha.2`（latest）。首次发布用一次性 `NODE_AUTH_TOKEN` bootstrap；Trusted Publishing 后续配置为无 token 发布。
 
 ### registry 包安装（npm / pnpm）
 
@@ -43,7 +43,7 @@ registry 安装拉取的是**已构建产物**（`dist/`），目标机无需构
 npm install dsh-llm-fallbacks   # 或：pnpm add dsh-llm-fallbacks
 ```
 
-> **预告**：`dsh-llm-fallbacks@0.1.0-alpha.2` 发布后生效。发布流程见 [docs/release.md](docs/release.md)。
+> 发布流程见 [docs/release.md](docs/release.md)。
 
 ### git 安装（当前可用）
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,15 +49,15 @@ Registry install notes:
 - **Version**: follows the npm dist-tag (default `latest`); pinning an exact version `dsh-llm-fallbacks@<version>` prevents a later publish from silently changing the code that actually runs.
 - **Mount-only, no patch steps**: a registry install is complete as-is — the plugin makes zero modifications to the dsh source tree (bundle row insert + client inject + its own gateway), no apply/revert scripts, and nothing to re-patch after a dsh upgrade.
 
-> **Release status**: `dsh-llm-fallbacks` is **not published to the npm registry yet** — the first version `0.1.0-alpha.2` is pending (the release pipeline is in place; the first publish uses a one-time `NODE_AUTH_TOKEN`, with Trusted Publishing configured after the first release). The registry commands in this section are a **preview** until the first release PR is merged; what works today is the [git install](#4-git-install-currently-available). Release process → [docs/release.md](docs/release.md).
+> **Release status**: published as `dsh-llm-fallbacks@0.1.0-alpha.2` (latest). The first publish used a one-time `NODE_AUTH_TOKEN` bootstrap secret; Trusted Publishing is configured afterwards for tokenless releases. Release process → [docs/release.md](docs/release.md).
 
-## 3. npm / pnpm package install (preview)
+## 3. npm / pnpm package install
 
 ```sh
 npm install dsh-llm-fallbacks   # or: pnpm add dsh-llm-fallbacks
 ```
 
-> **Preview**: effective after `dsh-llm-fallbacks@0.1.0-alpha.2` is published. The package ships built artifacts (`dist/`); the consumer surface (library function imports, named service) is documented in [docs/consumer-api.md](docs/consumer-api.md).
+> The package ships built artifacts (`dist/`); the consumer surface (library function imports, named service) is documented in [docs/consumer-api.md](docs/consumer-api.md).
 
 ## 4. Git install (currently available)
 


### PR DESCRIPTION
npm publish succeeded (run 31809160595): dsh-llm-fallbacks@0.1.0-alpha.2 on latest tag. Removes the preview/pending markers from README.md / README.zh-CN.md / docs/install.md.