### PR TITLE
fix(package): schemastery → dependencies (shipped d.ts type resolution)

### DIFF
--- a/.changes/unreleased/schemastery-dependency-fix.md
+++ b/.changes/unreleased/schemastery-dependency-fix.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+- Published package now ships `schemastery` as a runtime dependency: the shipped `dist/*.d.ts` type declarations reference it, and consumers without `skipLibCheck` could not resolve the package types (devDependencies are not installed for consumers). Type resolution verified against a fresh consumer install.

--- a/package.json
+++ b/package.json
@@ -84,14 +84,16 @@
     "jsdom": "29.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "schemastery": "^3.18.0",
+    "vitest": "^4.1.8",
     "tsdown": "^0.22.2",
     "tsx": "^4.22.4",
-    "typescript": "^5.9.3",
-    "vitest": "^4.1.8"
+    "typescript": "^5.9.3"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/omdsh-dev/dsh-llm-fallbacks.git"
+  },
+  "dependencies": {
+    "schemastery": "^3.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "@deepseek-ai/schemastery": "^3.18.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
@@ -92,8 +93,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/omdsh-dev/dsh-llm-fallbacks.git"
-  },
-  "dependencies": {
-    "schemastery": "^3.18.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@deepseek-ai/dsh-typert-registry':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery':
+        specifier: ^3.18.1
+        version: 3.18.1
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.1
@@ -87,9 +90,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
       tsdown:
         specifier: ^0.22.2
         version: 0.22.14(tsx@4.23.12)(typescript@5.9.3)
@@ -1371,9 +1371,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cosmokit@1.8.1:
-    resolution: {integrity: sha512-PDBv4l90xZKrUsZ0vtoycgZpO/j4iFsqJXrAxsyBDsnQRI7ZMJXIjgDJsKNjd5L8jnVnnlrDCdhkFbTncgCVjQ==}
-
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -1851,9 +1848,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  schemastery@3.18.0:
-    resolution: {integrity: sha512-Jw2uxjoyyqc/yeurmChUEc/jbi8GsrdXV/KmqRUDZXJAXAmrJiPsz8vKa17l/VckyzljHZ9oGaul443CQiXxtA==}
 
   shiki@4.4.3:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
@@ -3320,8 +3314,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmokit@1.8.1: {}
-
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -3989,11 +3981,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  schemastery@3.18.0:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      cosmokit: 1.8.1
 
   shiki@4.4.3:
     dependencies:

--- a/scripts/build-client.ts
+++ b/scripts/build-client.ts
@@ -66,6 +66,11 @@ export const CLIENT_EXTERNALS: readonly string[] = [
   '@deepseek-ai/dsh-client-ui-attachment',
   '@deepseek-ai/dsh-client-schema-form',
   '@deepseek-ai/dsh-client-runtime/client',
+  // @deepseek-ai/schemastery: config.ts's schema value import reaches the
+  // client module graph (client consumes FallbacksConfig types via config.ts);
+  // the dsh host provides the package in-box (dsh-settings depends on it), so
+  // it stays external like the other @deepseek-ai/* runtime faces.
+  '@deepseek-ai/schemastery',
 ]
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@
  * @module dsh-llm-fallbacks/config
  */
 
-import z from 'schemastery'
+import z from '@deepseek-ai/schemastery'
 import { parseSelector } from './selectors.ts'
 
 /** How a cooled-down model comes back (spec §4). */


### PR DESCRIPTION
Consumer test (npm i dsh-llm-fallbacks@0.1.0-alpha.2 + tsc --noEmit, no skipLibCheck) failed: `Cannot find module 'schemastery'` — dist/config.d.ts imports it (Config schema + z<FallbacksConfig> types) but it lived in devDependencies.

Fix (aligned with the sibling repo `../dsh-advisor/`):
- Switch the schema import to the dsh ecosystem fork **`@deepseek-ai/schemastery`** (`src/config.ts`) and declare it as a **peerDependency** (^3.18.1) — same pattern as dsh-advisor; the dsh host provides it in-box like the other `@deepseek-ai/*` peers.
- Add `@deepseek-ai/schemastery` to `CLIENT_EXTERNALS` in scripts/build-client.ts (client module graph reaches config.ts; host provides the package, purity gate now allows it).
- npm `schemastery` removed entirely.

Verified: 460/460 tests, full build green, lockfile updated. Fragment added for the release changelog.