### PR TITLE
fix(release-prep): gh label create --force (not --if-not-exists)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Ensure release label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh label create release --if-not-exists --color 0E8A16
+        run: gh label create release --color 0E8A16 --force
 
       # State-aware PR handling. `gh pr view` also matches closed PRs, and
       # `gh pr edit` silently keeps them closed — which would make a re-run


### PR DESCRIPTION
Run 31810124742 failed at Ensure release label: `gh label create --if-not-exists` is not a valid flag (gh label create supports -c/-d/-f only) — the mstar reference's `|| true` masked this. Use `--force` (idempotent update when the label exists).