### PR TITLE
fix(release): GitHub Release always regular (drop dynamic prerelease flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,6 @@ jobs:
         id: ver
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Detect prerelease
-        id: pre
-        run: echo "prerelease=$(node -p "/-/.test(require('./package.json').version)")" >> "$GITHUB_OUTPUT"
-
       # The Release prep workflow derives the version from the PR title
       # ("release v<version>") and bumps package.json to match. If the merged
       # PR drifted from that contract (e.g. the version was edited inside the
@@ -157,4 +153,8 @@ jobs:
           name: v${{ steps.ver.outputs.version }}
           body_path: ${{ steps.changelog.outputs.notes_file }}
           draft: false
-          prerelease: ${{ steps.pre.outputs.prerelease == 'true' }}
+          # User decision (2026-08-14): alpha versions publish as regular
+          # GitHub Releases (no Pre-release marker) — the npm dist-tag
+          # (`latest`) is the real channel signal; the GitHub Release is the
+          # visible record.
+          prerelease: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ PR-driven, two steps — merging the release PR is the ONLY publish path
    for an auto `--patch` bump.
 2. **Merge the PR** → `release.yml` runs on the merge commit: validate →
    build → `npm publish --provenance --access public --tag latest` →
-   tag `vX.Y.Z` → GitHub Release (prerelease when the version contains `-`).
+   tag `vX.Y.Z` → GitHub Release (always a regular release — no Pre-release marker, user decision 2026-08-14; the npm `latest` dist-tag carries the channel semantics).
 
 Secrets: **zero long-term secrets**. npm auth is Trusted Publishing (OIDC,
 tokenless) once the package exists; the one-time `NODE_AUTH_TOKEN` bootstrap

--- a/docs/release.md
+++ b/docs/release.md
@@ -103,7 +103,7 @@ After the merge, `release.yml` triggers (`pull_request: closed` + `merged == tru
 1. Checks out the merge commit → `release:validate` → `pnpm build`;
 2. `npm publish --provenance --access public --tag latest` — **explicit `--tag latest`**: npm ≥ 11 (bundled with Node 24) requires an explicit `--tag` when publishing a prerelease, otherwise it hard-throws; the first version (`0.1.0-alpha.2`) lands on the default `latest` dist-tag (`npm i dsh-llm-fallbacks` resolves), and the later stable `0.1.0` naturally takes over `latest`. npm authentication is selected automatically: TP configured → OIDC; bootstrap period → `NODE_AUTH_TOKEN` (see the "npm authentication" section);
 3. Tags `v<v>` and pushes (skipped if it exists);
-4. Creates the GitHub Release from the changelog section (`prerelease: true` when the version contains `-`).
+4. Creates the GitHub Release from the changelog section — **always a regular release** (no Pre-release marker, user decision 2026-08-14); the npm `latest` dist-tag is the channel signal, the GitHub Release is the visible record.
 
 ## Changelog fragment format
 


### PR DESCRIPTION
User report: '只有 tag 没有 release (是 pre-release)' — the two alpha releases were marked Pre-release by the dynamic version-based detection in release.yml, so the Releases page showed them as Pre-releases. Fix:\n- release.yml: remove the 'Detect prerelease' step; GitHub Release always created with prerelease: false. npm latest dist-tag stays the real channel signal.\n- Existing releases edited to non-prerelease (v0.1.0-alpha.3 is now 'Latest').\n- docs/release.md + AGENTS.md synced.