### PR TITLE
fix(release-prep): create release PR with PAT secret

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -4,8 +4,10 @@ name: Release prep
 # and open a `release vX.Y.Z` PR. Merging that PR runs the Release workflow
 # (publish + tag + GitHub Release). No NPM_TOKEN / NODE_AUTH_TOKEN: npm auth
 # in the Release workflow is pure Trusted Publishing (OIDC; the npm-side
-# Trusted Publisher is configured — bootstrap token mode removed 2026-08-14);
-# this workflow uses only the built-in GITHUB_TOKEN.
+# Trusted Publisher is configured — bootstrap token mode removed 2026-08-14).
+# The PR create/reopen/edit step uses the PAT secret because the omdsh-dev
+# org disables GITHUB_TOKEN's createPullRequest capability; everything else
+# uses only the built-in GITHUB_TOKEN.
 #
 # Trigger: Actions -> "Release prep" -> Run workflow. Pass an explicit target
 # version (e.g. 0.1.0-alpha.2) or leave the input empty for an auto bump
@@ -137,7 +139,11 @@ jobs:
       # A closed PR is never edited in place.
       - name: Open or update release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The omdsh-dev org disables GITHUB_TOKEN's createPullRequest
+          # capability ("Allow GitHub Actions to create and approve pull
+          # requests" is off), so PR create/reopen/edit runs under the
+          # PAT secret (user identity) instead of the built-in token.
+          GH_TOKEN: ${{ secrets.PAT }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="release/v${VERSION}"


### PR DESCRIPTION
The omdsh-dev org disables GITHUB_TOKEN's createPullRequest capability, so `gh pr create` in Release prep fails with 'GitHub Actions is not permitted to create or approve pull requests'.

Switch the Open or update release PR step to the existing PAT secret (user identity, not subject to the org restriction). All other steps keep using the built-in GITHUB_TOKEN.