### PR TITLE
release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-08-15
+
 ## [0.1.0-alpha.4] - 2026-08-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dsh",
     "dsh-plugin"
   ],
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Generated by the **Release prep** workflow.

Merging this PR publishes dsh-llm-fallbacks@v0.1.2 to npm (--provenance; Trusted Publishing OIDC, tokenless), tags v0.1.2, and creates the GitHub Release.

## Changelog

## [0.1.2] - 2026-08-15

