### PR TITLE
fix: register fallbacks/switch session event type at startup (issue #52)

### DIFF
--- a/.changes/unreleased/session-event-registration.md
+++ b/.changes/unreleased/session-event-registration.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+- Sessions containing `fallbacks/switch` events no longer refuse to load after a dsh restart: the plugin registers its session event type at startup (a stopgap until the upstream registration surface lands; tracked in the .mstar plans).
+- When registration is unavailable, the switch still applies but the durable event is skipped — a session log is never written with an unregistered event type.

--- a/.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md
@@ -25,7 +25,7 @@ fallbacks-aux-seams D1+D2 门禁 POSITIVE 并落地）：`conversationEvents` �
 
 ## Context
 
-`fallbacks/switch` 事件已持久化（`SessionEventMap` merge + `session.append`），但**不是**
+`fallbacks/switch` 事件已持久化（`SessionEventMap` merge + `session.append`；跨重启可读依赖插件在 apply() 启动时把类型注册进宿主根导出 `KNOWN_SESSION_EVENT_TYPES`——rc.6 运行时注册 stopgap，上游注册面跟踪见 `.mstar/plans/llm-fallbacks-session-event-format/`），但**不是**
 SurfaceEventType（`user/message | assistant/message | tool/result`）——不进 surface 投影，
 会话转录默认完全不渲染。20260811 dsh 的兜底定义（`unknown-surface`）只 match surface
 事件，插件事件落在「已持久化但会话内不可见」的空白。本模式回答：如何让这类事件在转录中

--- a/.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md
@@ -37,7 +37,7 @@ dsh 的 agent loop 在模型请求失败时派发 agent/request-error waterfall�
 
 ### 核心模式：决策在 request-error、应用在 request（ADR-1/ADR-4）
 
-1. agent/request-error 监听（注册在 llm-retry 之后）：未启用 / code 不在 triggerCodes → next()（always 模式同样透传）；命中候选 → 写每-agent pendingSwitch + cooldown 抑制 + stepFailures 记账 + append fallbacks/switch 事件 → 返回 {kind:'retry'}（拥有恢复，不调 next）。无候选 / 安全阀超限 → next()（原错误语义不变）。
+1. agent/request-error 监听（注册在 llm-retry 之后）：未启用 / code 不在 triggerCodes → next()（always 模式同样透传）；命中候选 → 写每-agent pendingSwitch + cooldown 抑制 + stepFailures 记账 + append fallbacks/switch 事件（事件类型在 apply() 启动时注册进宿主根导出 `KNOWN_SESSION_EVENT_TYPES` 才可跨重启加载——rc.6 运行时注册 stopgap，issue #52；注册不可用时 append 守卫只跳过持久化事件，决策/冷却/记账不变）→ 返回 {kind:'retry'}（拥有恢复，不调 next）。无候选 / 安全阀超限 → next()（原错误语义不变）。
 2. agent/request 监听：await next() 后应用 pendingSwitch（provider/model 覆写、丢弃继承的 reasoningEffort——installModelSelection 的 withoutInheritedEffort 模式）并清除；appliedTurnStep 防重放。
 3. 候选过滤：当前模型 / 冷却中 / 本步已失败 / provider/* 条目目标 provider 无此模型 id（存在性探针，仅 wildcard 条目受探针约束；exact 条目永不探针过滤）。
 
@@ -83,7 +83,7 @@ Map<agent.id, AgentFallbackState>：pendingSwitch（产生→应用→清除；�
 真实组合下 `installModelSelection`（web 前端门 per-agent 注册、先于插件）在 `agent/request` 的 `await next()` 之后重新套用会话选择，会把 fallback 切换覆写回去。patch 时代的解法是 `markFallbackRouted` 标记让位（spec §2.5 D-1：dsh-agent `model-selection.ts` 内模块级 WeakSet + 外层 listener 命中即跳过覆写）；该 patch 与整套 patch 交付体系已在 iter-20260811-fallbacks-mount-only 删除，插件切换**不再打标记**，协调退化为**文档化降级**（T2 结论，证明见探索 guide Model-selection 节）：
 
 - **注册顺序决定当步路由**：插件 listener 在外（web profile 默认——插件随 bundle 加载先注册、model-selection 随 agent 创建后注册）→ 切换在当步生效；model-selection listener 在外（headless profile，或插件注册前已创建的 agent）→ 用户选择在当步重新套用、覆写切换（clobber）。
-- **决策与记录不受影响**：request-error 决策链、`fallbacks/switch` 事件、冷却、安全阀、always-cap 逻辑全部照旧；被覆写的是当步「实际路由」，不是切换决策。
+- **决策与记录不受影响**：request-error 决策链、`fallbacks/switch` 事件（事件跨重启可读依赖启动注册——issue #52 stopgap）、冷却、安全阀、always-cap 逻辑全部照旧；被覆写的是当步「实际路由」，不是切换决策。
 - **诚实呈现**：设置页一行降级说明（`status.selectionNote`，zh/en）；`tests/plugin.spec.ts` 组合测试钉住四种注册序 × 有无活跃 selection。
 - **未来 seam（未实现）**：若 dsh 未来在 `LlmCallConfig` 上暴露首类「coordinator-owned routing」位，标记让位可无 patch 恢复。
 
@@ -115,7 +115,7 @@ order 100）、会话转录切换行（`conversationEvents` + `conversation.chat
 
 ### 设置页只读状态块真实化（R1 关闭，spec §2.5 D-5/D-6）
 
-- **读取面**：`connection.api.sessions.history({ sessionId, maxMessages })` 原始事件面（`HistoryEntry.event` 含 `fallbacks/switch`）——**不用** `ctx.sessionHistory`（公开快照只含投影会话对话，无原始自定义事件）；当前会话 `ctx.sessions.list` current（注意 host/client Context merge 冲突——`ctx.get('sessions') as unknown as ISessions`，且 client fiber 的 `sessions` 注入应可选降级）；单页 50、seq 倒序取 N=5、会话切换重载、错误隔离不碰 settings 状态。
+- **读取面**：`connection.api.sessions.history({ sessionId, maxMessages })` 原始事件面（`HistoryEntry.event` 含 `fallbacks/switch`；跨重启可读依赖插件启动注册——issue #52 stopgap）——**不用** `ctx.sessionHistory`（公开快照只含投影会话对话，无原始自定义事件）；当前会话 `ctx.sessions.list` current（注意 host/client Context merge 冲突——`ctx.get('sessions') as unknown as ISessions`，且 client fiber 的 `sessions` 注入应可选降级）；单页 50、seq 倒序取 N=5、会话切换重载、错误隔离不碰 settings 状态。
 - **展示值推导**（非实时路由探测，恒附注）：未启用 / `rootChain` 未配置 → 空态；有最近切换 → 最新 `to`；无切换 → `rootChain` 首项（无角色链语境时，spec §7.4）。
 
 ### 纯挂载交付纪律（iter-20260811-fallbacks-mount-only，原 patch 交付纪律已删除）
@@ -132,7 +132,7 @@ order 100）、会话转录切换行（`conversationEvents` + `conversation.chat
 插件暴露程序化消费面，供其它插件（如 mstar-harness loader-probe + 决策点注入）探测与调用：
 
 - **库 API**：`src/index.ts` 统一 re-export 运行时函数（`resolveRole`/`resolveChain`/`selectCandidates`/`annotateCandidates`/`hasWildcardEntry`/`createCandidateFilter`/`resolveCandidate`/`resolveChainViews`/`parseSelector`/`validateFallbacksConfig`/`detectLegacyKeys`）+ 值（`INHERIT_ROLE_ID`/`ROLE_ID_PATTERN`/`defaultFallbacksConfig`/`SelectorError`）+ 类型——消费方 `import { resolveRole } from 'dsh-llm-fallbacks'`；导出面由 `tests/export-surface.spec.ts`（`LIBRARY_EXPORT_KEYS` SSOT + expectTypeOf dev-time pins）机械钉住。
-- **具名 service `'llm-fallbacks'`**：`ctx.get('llm-fallbacks') !== undefined` 即响应式能力探测（cordis 生命周期自动就绪/撤销）。6-key 纯函数面：`{ name, version, resolveRole, resolveChain, validateFallbacksConfig, detectLegacyKeys }`——**不暴露运行态**（store/事件）；运行态请走 `fallbacks/switch` 事件。多 fiber dedupe guard（镜像 gateway/typert 模式）+ `createRequire` 运行时读 version。注册细节 → `best-practices/dsh-cordis-plugin-authoring.md`。
+- **具名 service `'llm-fallbacks'`**：`ctx.get('llm-fallbacks') !== undefined` 即响应式能力探测（cordis 生命周期自动就绪/撤销）。6-key 纯函数面：`{ name, version, resolveRole, resolveChain, validateFallbacksConfig, detectLegacyKeys }`——**不暴露运行态**（store/事件）；运行态请走 `fallbacks/switch` 事件（注意：事件跨重启可读依赖插件启动注册——issue #52；上游注册面落地前，无插件时含事件会话拒绝加载）。多 fiber dedupe guard（镜像 gateway/typert 模式）+ `createRequire` 运行时读 version。注册细节 → `best-practices/dsh-cordis-plugin-authoring.md`。
 - **契约边界**：本包契约成立 ≠ 隔壁仓库已接上；消费文档 `docs/consumer-api.md` 是契约 SSOT。
 
 ### Role-seeds 能力：companion 自配置角色（iter-20260815-fallbacks-role-seeds）

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ No rule match → the built-in `inherit` → `rootChain`. `enabled` defaults to 
 
 ### Verify
 
-Save and restart the session, then type `/fallbacks` — the read-only in-session diagnostics (origin, resolved role, chain, recent `fallbacks/switch` events, cooldown status). In a dsh-tui profile, `/fallbacks config` additionally reads back the composed configuration (the TUI has no settings page — config is file-only; see [docs/configuration.md](docs/configuration.md)).
+Save and restart the session, then type `/fallbacks` — the read-only in-session diagnostics (origin, resolved role, chain, recent `fallbacks/switch` events, cooldown status). Sessions containing `fallbacks/switch` events load after a restart because the plugin registers the event type at startup (rc.6 runtime registration; an upstream registration surface is pending) — without the plugin installed, such sessions refuse to load again until the upstream surface lands (see the Features note below). In a dsh-tui profile, `/fallbacks config` additionally reads back the composed configuration (the TUI has no settings page — config is file-only; see [docs/configuration.md](docs/configuration.md)).
 
 ## Features
 
 - **Automatic fallback for root and subagents**: any agent switches down the chain to the next available provider/model on model failure — no manual model switching.
 - **Two-block config**: `rootChain` for the root agent; declared role entities (`roles.list`) referenced by `roles.rules` (or the built-in `inherit`).
 - **Cooldown and revert**: failed / switched-away models are not re-selected during cooldown; `revertPolicy: cooldown-expiry` returns to the primary model automatically.
-- **Visible behavior**: every switch appends a persisted `fallbacks/switch` session event (from/to/role/reason) with info-level logs — no silent model switching.
+- **Visible behavior**: every switch appends a persisted `fallbacks/switch` session event (from/to/role/reason) with info-level logs — no silent model switching. The event type is registered with the harness at plugin startup (rc.6 runtime registration; an upstream registration surface is pending), so persisted events stay loadable across restarts while the plugin is installed.
 - **Safety valves**: `maxSwitchesPerStep` caps switches per step and `alwaysModeRetryCap` caps always-mode retries — chain loops cannot amplify latency.
 - **No-config no-op**: `enabled` defaults to off; with no chains configured the plugin behaves exactly like not being installed.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,14 +52,14 @@ fallbacks:
 
 ### 验证
 
-保存并重启会话后，键入 `/fallbacks`——只读的会话内诊断（来源、解析角色、链、最近的 `fallbacks/switch` 事件、冷却状态）。在 dsh-tui profile 中，`/fallbacks config` 额外回读组合配置（TUI 无设置页——配置仅文件，见 [docs/configuration.md](docs/configuration.md)）。
+保存并重启会话后，键入 `/fallbacks`——只读的会话内诊断（来源、解析角色、链、最近的 `fallbacks/switch` 事件、冷却状态）。含 `fallbacks/switch` 事件的会话能在重启后正常加载，是因为插件在启动时注册了该事件类型（rc.6 运行时注册；上游注册面待落地）——卸载插件后，含此类事件的会话将再次拒绝加载，直到上游注册面落地（见下方「能力一览」说明）。在 dsh-tui profile 中，`/fallbacks config` 额外回读组合配置（TUI 无设置页——配置仅文件，见 [docs/configuration.md](docs/configuration.md)）。
 
 ## 能力一览
 
 - **root / subagent 自动降级**：任意 agent 在模型故障下按链切换到下一个可用 provider/model，无需手动换模型。
 - **两块制配置**：`rootChain` 管 root 代理；声明式角色实体（`roles.list`）供 `roles.rules` 引用（或内置 `inherit`）。
 - **冷却与回主**：被切离/失败的模型在冷却期内不再入选；`revertPolicy: cooldown-expiry` 冷却到期后自动回主模型。
-- **行为可见**：每次切换追加持久化会话事件 `fallbacks/switch`（from/to/role/reason），配合 info 级日志——无静默换模型。
+- **行为可见**：每次切换追加持久化会话事件 `fallbacks/switch`（from/to/role/reason），配合 info 级日志——无静默换模型。插件在启动时把该事件类型注册进宿主（rc.6 运行时注册；上游注册面待落地），持久化事件在插件安装期间可跨重启加载。
 - **安全阀**：`maxSwitchesPerStep` 限制每 step 切换次数、`alwaysModeRetryCap` 限制 always 模式重试——链循环不会放大延迟。
 - **无配置回归（no-op）**：`enabled` 默认关闭；未配置任何链时行为与未安装插件完全一致。
 

--- a/docs/consumer-api.md
+++ b/docs/consumer-api.md
@@ -80,7 +80,7 @@ Operator-facing behavior of the automatic declaration (config key `presets: 'bun
 
 ## Named service (`ctx.get('llm-fallbacks')`)
 
-After the plugin's `apply()`, a service is registered on the cordis `Context` under the name `'llm-fallbacks'`. **It is a small face over the library logic — not a second library API**: the four legacy callables are reference-identical to the library re-exports, and the three role-seed methods are per-apply closures over the seed manager (state stays behind the closure, spec §9.5) — no copied logic on either side. Runtime state (cooldown, recent switches, etc.) is not part of the contract — cross-plugin state reads should listen to `fallbacks/switch` events instead of reading service object internals.
+After the plugin's `apply()`, a service is registered on the cordis `Context` under the name `'llm-fallbacks'`. **It is a small face over the library logic — not a second library API**: the four legacy callables are reference-identical to the library re-exports, and the three role-seed methods are per-apply closures over the seed manager (state stays behind the closure, spec §9.5) — no copied logic on either side. Runtime state (cooldown, recent switches, etc.) is not part of the contract — cross-plugin state reads should listen to `fallbacks/switch` events instead of reading service object internals. Caveat: those events only survive a dsh restart while the plugin's startup registration is active (rc.6 runtime registration; an upstream registration surface is pending — see the README / [install.md](install.md) notes), so for state that must stay current in-process, prefer in-process reads over the persisted events.
 
 ### Shape
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -132,4 +132,4 @@ dsh plugin --profile web remove dsh-llm-fallbacks
 dsh --profile web --dump-config   # confirm the llm-fallbacks layer is gone
 ```
 
-Restart the dsh web session for the uninstall to take effect. After uninstalling, the plugin no longer participates in any request/error path; already-persisted `fallbacks/switch` session events remain as history and are unaffected by the uninstall.
+Restart the dsh web session for the uninstall to take effect. After uninstalling, the plugin no longer participates in any request/error path. Note: already-persisted `fallbacks/switch` session events are only loadable while the plugin registers their type at startup — after an uninstall, sessions containing them refuse to load again until the upstream registration surface lands (the startup registration is a stopgap; see the README Features note).

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -221,6 +221,6 @@ Then restart the dsh web session so the host half and the client half load.
 |---|---|---|
 | web settings GUI interaction (card appears, edit & save, conflict reload) | the sandbox cannot operate a real web session | user §2 / §4 (client-half logic already covered by T5's 155 tests) |
 | real model calls and failure injection (AUTH/QUOTA/RATE_LIMIT triggers, switch continuation) | the sandbox has no real model credentials or running session | user §3 / §4 (decision logic already covered by T3/T4 integration tests) |
-| cross-process observation (logs, `fallbacks/switch` session events landing in a real session) | the sandbox cannot run a real dsh session | user §3/§4 |
+| cross-process observation (logs, `fallbacks/switch` session events landing in a real session) | the sandbox cannot run a real dsh session — the untested reload path was the gap that shipped issue #52 (a session refused to load after restart until the startup registration fix); the registration + append-guard pins in `tests/session-event-registration*.spec.ts` cover the reload semantics | user §3/§4 |
 | `/fallbacks` command input/output in a real session | the sandbox cannot run a real dsh session and command registry | user §4.3 step 5 (command logic already covered by command.spec.ts) |
 | real routing override under an active model-selection (documented degradation) | the sandbox has no real web session and model selection | user §4.3 (combination order already covered by T4 integration tests) |

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@deepseek-ai/dsh-llm':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session':
+        specifier: ^0.1.0-rc.6
+        version: 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
       '@deepseek-ai/dsh-settings':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,14 @@ import { installSettingsSection } from '@deepseek-ai/dsh-settings'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { LlmCallConfig } from '@deepseek-ai/dsh-llm'
 import type { Session } from '@deepseek-ai/dsh-session'
+// issue #52 runtime registration seam: VALUE import of the dsh-session module
+// namespace, resolved from the package ROOT (same specifier as the type
+// import above — NOT the `./types` subpath, which is a divergent copy the
+// persistence read path never consults). Namespace import so that if a
+// future dsh removes `KNOWN_SESSION_EVENT_TYPES`, the plugin still loads
+// (namespace access yields `undefined`; a named import would fail at link
+// time and kill the whole plugin). Details/upstream tracking in apply().
+import * as dshSession from '@deepseek-ai/dsh-session'
 import { defaultFallbacksConfig, detectLegacyKeys, validateFallbacksConfig, type FallbacksConfig } from './config.ts'
 import { Config } from './schema.ts'
 import { annotateCandidates, createCandidateFilter, hasWildcardEntry, resolveChain, resolveChainViews, selectCandidates, type FailingModel } from './chains.ts'
@@ -300,6 +308,34 @@ function overrideConfig(seed: LlmCallConfig, to: { provider: string; model: stri
 
 export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksConfig): void {
   const logger = ctx.logger('llm-fallbacks')
+  // issue #52 (a session containing `fallbacks/switch` refuses to load after
+  // a dsh restart): the persistence read path
+  // (`dsh-session-persistence` `assertEventsSupported`) refuses a log whose
+  // event type is outside the host's baked `KNOWN_SESSION_EVENT_TYPES`
+  // catalog unless the event carries the envelope's `ignorable` marker —
+  // which `Session.append` cannot write (seed-only field). `fallbacks/switch`
+  // is a TYPE-ONLY augmentation (`src/events.ts` `declare module`), erased at
+  // runtime, so the type is registered HERE into the ROOT-exported catalog
+  // (not the `./types` subpath — a divergent copy): persistence imports the
+  // root export (`@deepseek-ai/dsh-session` main), and the plugin bundle
+  // externalizes `@deepseek-ai/*` (tsdown `neverBundle`), so at runtime this
+  // namespace IS the host's in-box module — the same Set the read path
+  // consults. Apply time, not module scope: session loads are LAZY
+  // (per open/resume via `ensureSession`, request-triggered post-boot), so
+  // registration here always precedes any load, and a module-level side
+  // effect is deliberately avoided (multi-fiber re-apply stays safe — the
+  // check + Set.add are idempotent). Registration failure is tolerated: the
+  // commit() guard below skips the durable event rather than writing one the
+  // read path would refuse. STOPGAP — remove when the upstream registration
+  // surface lands (tracked in
+  // .mstar/plans/llm-fallbacks-session-event-format/UPSTREAM-ISSUE.md).
+  const known = (dshSession as { KNOWN_SESSION_EVENT_TYPES?: ReadonlySet<string> }).KNOWN_SESSION_EVENT_TYPES
+  let sessionEventRegistered = false
+  if (known instanceof Set) {
+    try { (known as Set<string>).add('fallbacks/switch'); sessionEventRegistered = known.has('fallbacks/switch') } catch { sessionEventRegistered = false }
+  }
+  // Rate-limits the commit() guard warn to once per apply.
+  let sessionEventWarned = false
   // Cordis resolves the entry through the schema before apply, so `config` is
   // already defaulted; re-resolving keeps direct calls (tests) normalized.
   const entry = Config(config)
@@ -578,6 +614,25 @@ export function apply(ctx: Context, config: FallbacksConfig = defaultFallbacksCo
     states.suppress(state, fromKey, until)
     states.recordFailure(state, fromKey)
     states.recordSwitch(state)
+    // issue #52 append guard: never write an event the host read path would
+    // refuse. The apply() registration is the ONLY runtime seam that makes
+    // `fallbacks/switch` loadable after a restart; when it failed (export
+    // removed / catalog frozen), the durable event is SKIPPED — the switch
+    // decision, cooldown and step bookkeeping above stay intact, only the
+    // event is dropped, so a session log can never be poisoned by an
+    // unregistered type. Warn at most once per apply (rate-limited). STOPGAP
+    // — remove with the upstream registration surface (see the apply()
+    // comment / .mstar/plans/llm-fallbacks-session-event-format/
+    // UPSTREAM-ISSUE.md).
+    if (!sessionEventRegistered) {
+      if (!sessionEventWarned) {
+        sessionEventWarned = true
+        logger.warn(
+          'llm-fallbacks: session event type "fallbacks/switch" is not registered with this harness — skipping the durable event (the switch itself is applied)',
+        )
+      }
+      return
+    }
     agent.session.append('fallbacks/switch', {
       turn,
       step,

--- a/tests/session-event-registration-guard.spec.ts
+++ b/tests/session-event-registration-guard.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * issue #52 guard pin — when the runtime registration is unavailable,
+ * `commit()` must skip the durable `fallbacks/switch` append: never write an
+ * event the host read path would refuse, never throw, and leave the switch
+ * decision / cooldown / step bookkeeping untouched.
+ *
+ * The plugin's ONLY runtime use of `@deepseek-ai/dsh-session` is the
+ * namespace read of `KNOWN_SESSION_EVENT_TYPES` in `apply()` (src/index.ts;
+ * every other import is type-only, erased at runtime). Mocking the package
+ * with the export unavailable therefore drives the REAL `apply()`
+ * registration block into the failure branch — the same decision path an
+ * out-of-repo consumer hits, end to end, with no production test seam.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import { apply } from '../src/index.ts'
+import { MemorySettings } from './support/memory-settings.ts'
+import { cfg, dispatchRequest, dispatchRequestError, makeAgent, switchEvents } from './support/harness.ts'
+
+// Simulate the catalog export being unavailable (a future dsh may drop it,
+// or replace it with a real registration surface): `KNOWN_SESSION_EVENT_TYPES`
+// reads as `undefined`, so apply()'s registration block records
+// `sessionEventRegistered === false` and the commit() guard must engage.
+vi.mock('@deepseek-ai/dsh-session', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@deepseek-ai/dsh-session')>()
+  return { ...actual, KNOWN_SESSION_EVENT_TYPES: undefined }
+})
+
+let ctx: Context
+
+beforeEach(() => {
+  ctx = new Context()
+  ctx.plugin(MemorySettings)
+})
+
+afterEach(async () => {
+  await ctx.fiber.dispose()
+})
+
+describe('commit() append guard when registration is unavailable (issue #52)', () => {
+  it('skips the durable event, does not throw, keeps the switch, and warns once', async () => {
+    const logs: Array<{ type: string; args: unknown[] }> = []
+    ctx.logger.exporter({ levels: { default: 3 }, export: (message) => logs.push(message) })
+    apply(ctx, cfg({ rootChain: ['other/gpt-4o'] }))
+
+    const first = makeAgent('guard-a', { provider: 'mock', model: 'gpt-4o' })
+    const second = makeAgent('guard-b', { provider: 'mock', model: 'gpt-4o' })
+
+    // Two switches on two agents: both commit() runs hit the guard, but the
+    // warn is rate-limited to once per apply. The decision path still claims
+    // recovery ({ kind: 'retry' }) — only the durable event is skipped.
+    await expect(dispatchRequestError(ctx, first.agent, {
+      provider: 'mock',
+      failure: { message: 'quota exceeded', code: 'QUOTA' },
+    })).resolves.toEqual({ kind: 'retry' })
+    await expect(dispatchRequestError(ctx, second.agent, {
+      provider: 'mock',
+      failure: { message: 'quota exceeded', code: 'QUOTA' },
+    })).resolves.toEqual({ kind: 'retry' })
+
+    // The session event stream gains no fallbacks/switch entry.
+    expect(switchEvents(first.agent)).toHaveLength(0)
+    expect(switchEvents(second.agent)).toHaveLength(0)
+
+    // The switch bookkeeping is unaffected: the pending switch still applies
+    // at the next request of the same (turn, step).
+    const next = await dispatchRequest(ctx, first.agent, { provider: 'mock', model: 'gpt-4o' }, { turn: 1, step: 1 })
+    expect(next).toEqual({ provider: 'other', model: 'gpt-4o' })
+
+    // Exactly one warn naming the skipped event type (rate-limited per apply).
+    const warns = logs.filter((message) => message.type === 'warn' && String(message.args[0]).includes('fallbacks/switch'))
+    expect(warns).toHaveLength(1)
+  })
+})

--- a/tests/session-event-registration.spec.ts
+++ b/tests/session-event-registration.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * issue #52 regression pins — the runtime registration seam and the mirrored
+ * persistence predicate.
+ *
+ * `fallbacks/switch` is a type-only augmentation (`src/events.ts`), erased at
+ * runtime. The persistence read path (`dsh-session-persistence`
+ * `assertEventsSupported`) refuses a log containing an event type outside the
+ * host's baked `KNOWN_SESSION_EVENT_TYPES` catalog unless the event carries
+ * the envelope's `ignorable` marker — which `Session.append` can never write.
+ * The plugin therefore registers the type into the ROOT-exported catalog at
+ * apply time; these pins freeze the exact predicate the read path uses, so a
+ * future dsh that drops or freezes the mutable root export fails loudly here.
+ * The append guard (registration unavailable → durable event skipped) lives
+ * in `tests/session-event-registration-guard.spec.ts`.
+ *
+ * Vitest isolates each test file, so `KNOWN_SESSION_EVENT_TYPES` starts
+ * UNREGISTERED in this file — the pre-registration assertions below must
+ * stay before any `.add` in this file.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { KNOWN_SESSION_EVENT_TYPES } from '@deepseek-ai/dsh-session'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { makeAgent, switchEvents } from './support/harness.ts'
+import type { FallbacksSwitchEventData } from '../src/events.ts'
+
+/**
+ * The exact read-path refusal predicate, mirrored from
+ * `dsh-session-persistence` `assertEventsSupported`: a log is refused when
+ * the type is unknown AND the event is not marked ignorable.
+ */
+function refusedByReadPath(type: string, event: { ignorable?: true }): boolean {
+  return !KNOWN_SESSION_EVENT_TYPES.has(type) && event.ignorable !== true
+}
+
+function switchData(): FallbacksSwitchEventData {
+  return {
+    turn: 1,
+    step: 1,
+    from: { provider: 'mock', model: 'gpt-4o' },
+    to: { provider: 'other', model: 'gpt-4o' },
+    role: 'inherit',
+    reason: 'trigger-code',
+  }
+}
+
+describe('fallbacks/switch registration predicate (issue #52)', () => {
+  it('appended switch events carry no ignorable marker and are unknown pre-registration', () => {
+    const { agent } = makeAgent('registration-pre', { provider: 'mock', model: 'gpt-4o' })
+    agent.session.append('fallbacks/switch', switchData())
+    const event = switchEvents(agent)[0] as SessionEvent<'fallbacks/switch'>
+    // `Session.append` has no way to write the envelope's `ignorable` marker
+    // (seed-only field) — a persisted `fallbacks/switch` is always "required".
+    expect(event.ignorable).toBeUndefined()
+    // Before the plugin's apply() registration, the baked catalog does not
+    // know the type — the read path would refuse the whole session log.
+    expect(KNOWN_SESSION_EVENT_TYPES.has('fallbacks/switch')).toBe(false)
+    expect(refusedByReadPath('fallbacks/switch', event)).toBe(true)
+  })
+
+  it('registers into the mutable root-exported Set (the persistence predicate)', () => {
+    // The root export is a plain, unfrozen Set at runtime (the .d.ts only
+    // types it as ReadonlySet).
+    expect(KNOWN_SESSION_EVENT_TYPES).toBeInstanceOf(Set)
+    // Same cast the runtime uses in apply() (src/index.ts).
+    const known = KNOWN_SESSION_EVENT_TYPES as Set<string>
+    known.add('fallbacks/switch')
+    expect(known.has('fallbacks/switch')).toBe(true)
+    // Registration flips the mirrored refusal predicate to false — a log
+    // written with this event now passes `assertEventsSupported` on load.
+    const { agent } = makeAgent('registration-post', { provider: 'mock', model: 'gpt-4o' })
+    agent.session.append('fallbacks/switch', switchData())
+    const event = switchEvents(agent)[0] as SessionEvent<'fallbacks/switch'>
+    expect(event.ignorable).toBeUndefined()
+    expect(refusedByReadPath('fallbacks/switch', event)).toBe(false)
+  })
+
+  it('registration is idempotent (multi-fiber / re-apply safe)', () => {
+    const known = KNOWN_SESSION_EVENT_TYPES as Set<string>
+    known.add('fallbacks/switch')
+    known.add('fallbacks/switch')
+    expect(known.has('fallbacks/switch')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Fixes #52 — sessions containing a `fallbacks/switch` event refuse to load after a dsh restart (`SessionFormatUnsupportedError: ... unknown to this harness and not marked ignorable`).

Root cause: the plugin appends a custom session event type (`src/index.ts` `agent.session.append('fallbacks/switch', …)`) that is only TS-augmented (`src/events.ts` `declare module`), never registered at runtime. dsh's persistence read path (`assertEventsSupported`) hard-refuses types outside the build-time `KNOWN_SESSION_EVENT_TYPES` unless the envelope carries `ignorable: true` — which `Session.append` cannot write. Out-of-repo plugins have no official registration surface yet (tracked: `.mstar/plans/llm-fallbacks-session-event-format/UPSTREAM-ISSUE.md`).

## Change (user-approved B1 stopgap)

- **`src/index.ts`**: in `apply()`, register `fallbacks/switch` into the ROOT-exported `KNOWN_SESSION_EVENT_TYPES` Set (namespace import from package root — not the `./types` subpath copy; idempotent, no module-level side effects; apply-time registration precedes all lazy session loads, so already-persisted logs heal retroactively). `commit()` gains an append guard: if registration is unavailable, the durable event is skipped (rate-limited warn) — a session log is never written with an unregistered type.
- **Tests**: `tests/session-event-registration.spec.ts` (pins the root Set mutability + the exact read-path predicate pre/post registration + idempotency) and `tests/session-event-registration-guard.spec.ts` (registration-unavailable path: decision intact, no event, no throw, one warn).
- **Docs**: corrected the false "persisted / unaffected by uninstall" claims in README×2, docs/install.md, docs/consumer-api.md, docs/verification.md + knowledge docs; `.changes/unreleased/session-event-registration.md` fragment.
- **peerDependencies**: `@deepseek-ai/dsh-session` declared (now a runtime value import).

## Verification

- `pnpm test`: 600/600 (incl. peer-deps contract test)
- `pnpm typecheck` + `pnpm build`: clean
- QC single review + targeted re-review: **Approve** (0C/0W; S-001/S-002 tracked as residuals)
- Manual L4 (real host): restart dsh with the plugin installed and reopen an affected session — expected to load.

## Note

Stopgap until the upstream runtime registration surface lands (issue draft kept at `.mstar/plans/llm-fallbacks-session-event-format/UPSTREAM-ISSUE.md`); the same event type then switches to the official register call with zero surface changes.