### PR TITLE
docs(knowledge): migrate corpus to resolvable-reference conventions (compound validate green)

### DIFF
--- a/.mstar/knowledge/README.md
+++ b/.mstar/knowledge/README.md
@@ -15,3 +15,11 @@
 | [best-practices/dsh-settings-ui-fidelity.md](best-practices/dsh-settings-ui-fidelity.md) | llm-fallbacks-settings-ui-fidelity | dsh web 设置 UI 保真参考（参照文件地图含插件配置卡 chrome、几何/token 词表、逐维度对照方法、用户可见差异裁决） | Active |
 | [developer-experience/pnpm11-workspace-config-and-windows-link-farm.md](developer-experience/pnpm11-workspace-config-and-windows-link-farm.md) | fix/install 自检（dsh-advisor PR #11 经验 commit 294aff1b → ac994ea） | pnpm 11 workspace 配置迁移 + Windows 安全 link farm + cordis scoped 对齐（.npmrc 静默忽略/死 token、prerelease-tuple 规则实证、requiredPeers 豁免、legacy 清理、junction/file 分型、USERPROFILE） | Active |
 | [best-practices/npm-release-pipeline.md](best-practices/npm-release-pipeline.md) | fallbacks-npm-release | npm Release Pipeline（PR-driven + Trusted Publishing）：4 坑（TP 仅已存在包可配/无 pre-registration、node 24 provenance、npm≥11 prerelease 必须 --tag、closed-PR 重跑 state-aware）+ bootstrap 路径 + changelog fragments | Active |
+
+## Corpus conventions（语料约定）
+
+- 反引号 token 必须是仓库根可解析引用：仓库文件写仓库根相对路径（如 `src/client/switch-guard.ts`）；跨文档链接写 `.mstar/knowledge/<category>/<doc>.md`；迭代 package / sdd 产物写 `.mstar/iterations/<iter>/guides/<file>.md`、`.mstar/sdd/<plan>/<file>.md`。
+- 宿主（dsh-private）内部路径用 `{HOST}/…` 前缀（`{HOST}` = dsh 宿主源码仓库），保留 `:line` 后缀；checker 对 `{…}` 占位符形态跳过。
+- 域词汇（事件/服务/槽位名如 `fallbacks/switch`、点号符号 `session.append`）与 npm 包名（`@deepseek-ai/*`）一律纯文本、不加反引号；长内联代码示例同样去反引号或改围栏代码块。
+- `tags` 是 ≤8 项的 YAML 块列表（引擎不认 `[a, b]` 流式列表）；`symptoms` / `applies_when` 同为 YAML 块列表。
+- 其它 checker 跳过形态：URL / 绝对路径（`/` 开头）/ glob（含 `*`）/ `#anchor` / `~` 前缀。

--- a/.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md
@@ -10,7 +10,15 @@ applies_when:
   - 理解 conversationEvents 注册表 / conversation.chat.node keyed 座位的契约
   - 实现会话内可见的插件状态呈现（switch 行、通知、状态行）
   - 评估「注入模型上下文」vs「纯渲染」两条会话可见性路径的行为边界
-tags: [dsh, conversation, conversation-events, chat-node, slots, render-only, degrade-never-crash, mount-only]
+tags:
+  - dsh
+  - conversation
+  - conversation-events
+  - chat-node
+  - slots
+  - render-only
+  - degrade-never-crash
+  - mount-only
 related_components:
   - dsh-private (client/runtime conversation registry, ui-conversation)
   - dsh-llm-fallbacks (ConversationFallbackSwitch)
@@ -25,8 +33,8 @@ fallbacks-aux-seams D1+D2 门禁 POSITIVE 并落地）：`conversationEvents` �
 
 ## Context
 
-`fallbacks/switch` 事件已持久化（`SessionEventMap` merge + `session.append`；跨重启可读依赖插件在 apply() 启动时把类型注册进宿主根导出 `KNOWN_SESSION_EVENT_TYPES`——rc.6 运行时注册 stopgap，上游注册面跟踪见 `.mstar/plans/llm-fallbacks-session-event-format/`），但**不是**
-SurfaceEventType（`user/message | assistant/message | tool/result`）——不进 surface 投影，
+fallbacks/switch 事件已持久化（`SessionEventMap` merge + session.append；跨重启可读依赖插件在 apply() 启动时把类型注册进宿主根导出 `KNOWN_SESSION_EVENT_TYPES`——rc.6 运行时注册 stopgap，上游注册面跟踪见 `.mstar/plans/llm-fallbacks-session-event-format/`），但**不是**
+SurfaceEventType（user/message | assistant/message | tool/result）——不进 surface 投影，
 会话转录默认完全不渲染。20260811 dsh 的兜底定义（`unknown-surface`）只 match surface
 事件，插件事件落在「已持久化但会话内不可见」的空白。本模式回答：如何让这类事件在转录中
 可见，且不动宿主、不进模型上下文。
@@ -35,16 +43,16 @@ SurfaceEventType（`user/message | assistant/message | tool/result`）——不�
 
 ### 双段挂载：注册表 + keyed 座位
 
-1. **`conversationEvents` 服务**（`runtime/src/client/conversation/event-registry.ts:19-27`）：
+1. **`conversationEvents` 服务**（`{HOST}/runtime/src/client/conversation/event-registry.ts:19-27`）：
    `register(definition)`，**kind 唯一、重复抛错**；`registerFallback` 注册单例兜底定义。
    引擎把**每条摄入事件**（surface 与否不限）投喂给**每个定义**的 `match`
    （`conversation-assembler.ts:370-382`；live 路径 `session.ts:673` 全量 append）——
    `ConversationNodeDefinition = { kind; target?; match(event); start(context, match,
    reader); update(context, match); publication?; buildLocationData?; buildViewNode?(context) }`。
    外部注册实证：ui-workflow-run（非 surface 的 `tool-workflow/*` 事件在转录中渲染）。
-2. **`conversation.chat.node` keyed 座位**（`ui-conversation/src/client/contract/slots.ts:56-63`）：
-   `{ kind: 'keyed'; scope: 'session' }`，按 `ChatConversationViewNode.kind` 派发
-   （`chat/ChatNodeSeat.tsx:48-51`，`entryKey: routedNode.kind`）。注册 shape
+2. **`conversation.chat.node` keyed 座位**（`{HOST}/ui-conversation/src/client/contract/slots.ts:56-63`）：
+   `{ kind: 'keyed'; scope: 'session' }`，按 ChatConversationViewNode.kind 派发
+   （`{HOST}/chat/ChatNodeSeat.tsx:48-51`，`entryKey: routedNode.kind`）。注册 shape
    `{ name, key, locale }`，**inject 可选**（ui-tool 的 `tool-call` 即无 inject 注册——
    业务数据经 `node` prop 传入，`ChatNodeDataMap` 类型级 merge 承载 payload）。
 
@@ -61,8 +69,8 @@ ctx.slots.inject('conversation.chat.node', function* () {
 
 ### 座位 fallback 语义（易错点）
 
-未注册 kind 的节点渲染 **JsonBlock**（label `message.unknownSurface`，
-`chat/ChatNodeSeat.tsx:48-57`）——**不是** `UnknownNodeView`（后者是字面量 `unknown`
+未注册 kind 的节点渲染 **JsonBlock**（label message.unknownSurface，
+`{HOST}/chat/ChatNodeSeat.tsx:48-57`）——**不是** `UnknownNodeView`（后者是字面量 `unknown`
 key 的注册渲染器，`register-node-renderers.ts:44-45`）。两个概念不同：座位 fallback
 是通用 JSON 块，`unknown` 渲染器是注册表内的兜底条目。
 
@@ -80,7 +88,7 @@ key 的注册渲染器，`register-node-renderers.ts:44-45`）。两个概念不
 
 - `match` 对畸形信封（null/空 data、缺/非整数 seq）必须 **no-op**（不 match），不抛错；
 - `start` 必须**恒返回确定态**（如降级 `{seq, time}` 快照），对畸形载荷降级而非抛错；
-- 事件级守卫与渲染/装配共享同一形状守卫（`switch-guard.ts`），保证 match/start/buildViewNode
+- 事件级守卫与渲染/装配共享同一形状守卫（`src/client/switch-guard.ts`），保证 match/start/buildViewNode
   判定一致；
 - 注册返回的 disposer 显式接线（事件注册表无隐式清理）。
 
@@ -112,8 +120,8 @@ key 的注册渲染器，`register-node-renderers.ts:44-45`）。两个概念不
 
 ## Examples
 
-- fallbacks `ConversationFallbackSwitch.tsx`：`fallbackSwitchDefinition`（match 只认
-  `fallbacks/switch` 且 id = event seq；start 快照载荷、畸形降级确定态；buildViewNode 于
+- fallbacks `src/client/ConversationFallbackSwitch.tsx`：`fallbackSwitchDefinition`（match 只认
+  fallbacks/switch 且 id = event seq；start 快照载荷、畸形降级确定态；buildViewNode 于
   anchorSeq 产节点）+ keyed 渲染行（dim 标题 + 分隔点 + 省略摘要 `from → to（role ·
   reason）`，几何对齐上游 compaction 行 `MessageItem.module.css:38-122`）。
 - 外部注册先例：ui-tool（`tool-call`，无 inject）、ui-goal（`command-input`）、
@@ -121,5 +129,5 @@ key 的注册渲染器，`register-node-renderers.ts:44-45`）。两个概念不
 - 未选备选：D3 turnTail（每 Turn 尾部聚合行，后续可叠加）、D4 会话头动作（与 `/fallbacks`
   命令语义重叠）。
 
-*Source: iteration iter-20260812-fallbacks-plugin-config `guides/seam-exploration-session-visibility.md`
-（D1–D4 门禁证据）+ `guides/mount-point-map.md` D 节，2026-08-12 compound 提升。*
+*Source: iteration iter-20260812-fallbacks-plugin-config `.mstar/iterations/iter-20260812-fallbacks-plugin-config/guides/seam-exploration-session-visibility.md`
+（D1–D4 门禁证据）+ `.mstar/iterations/iter-20260812-fallbacks-plugin-config/guides/mount-point-map.md` D 节，2026-08-12 compound 提升。*

--- a/.mstar/knowledge/architecture-patterns/dsh-gateway-settings-channel.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-gateway-settings-channel.md
@@ -38,12 +38,12 @@ fallbacks）已验证：声明 `GatewayService` + 显式 `ctx.typert.register(co
 
 dsh 的 web 设置 RPC（`dsh-host-apiproxy`）对命名空间有**硬编码暴露白名单**
 （`exposedNamespaces()` 只含 model-provider 与产品命名空间），插件命名空间默认不可经
-`settings.describe/update/replace` 读写。旧 fallbacks 交付以两个本地 patch 强行打开门禁
+settings.describe/update/replace 读写。旧 fallbacks 交付以两个本地 patch 强行打开门禁
 （`exposeToWebClients` + `exposedNamespaces()` 并集）——违反纯挂载约束。advisor 证明的
-替代路径：插件声明自己的 `GatewayService` 通道，client 经 `connection.rpc.call('/api', …)`
-读写；宿主侧写操作走进程内 `ctx.settings`（该检查只存在于 apiproxy wire 层，进程内
+替代路径：插件声明自己的 `GatewayService` 通道，client 经 connection.rpc.call('/api', …)
+读写；宿主侧写操作走进程内 ctx.settings（该检查只存在于 apiproxy wire 层，进程内
 update/replace 无命名空间门禁）。展示挂载与数据通道正交——fallbacks 现经
-`settings.plugin.item` 卡（2026-08-12 起，旧 `settings.section` 导航已删）展示，配置数据
+`settings.plugin.item` 卡（2026-08-12 起，旧 settings.section 导航已删）展示，配置数据
 仍走本通道（见 CONCEPTS 已决歧义）。
 
 ## Guidance
@@ -52,25 +52,25 @@ update/replace 无命名空间门禁）。展示挂载与数据通道正交—�
 
 - host 半：`class XGateway extends TypertRemoteService { … }`，`super(ctx, '<ns>')`；
   **显式注册**端点——`ctx.typert.register(contribution())`（`TypertContribution` 来自
-  `@deepseek-ai/dsh-typert-registry`；invocation descriptor 镜像 SRC 派生形状：direct
+  @deepseek-ai/dsh-typert-registry；invocation descriptor 镜像 SRC 派生形状：direct
   receiver、JSON wire params、`src-json` codec），经条件 `ctx.inject(['typert'])` 子
   激活（无 typert registry 的组合照常跑运行时、只是没有 /api 端点）。
 - `TypertRemoteService` 基类**仅**为 `typertRemote` 绑定保留——dispatch 的
   `validateBinding` 要求 live service 上有可见绑定（纯实例属性，无模块私有状态）。
 - **SRC 发现限制（2026-08-13，rc.2 dlx host）**：旧路径 `@Remote` 标记靠
-  `remoteMethods()` 读 `@deepseek-ai/dsh-typert-protocol` 的**模块私有 WeakMap**。
+  `remoteMethods()` 读 @deepseek-ai/dsh-typert-protocol 的**模块私有 WeakMap**。
   `link:` 挂载的插件 peer 从真实目录解析（物理上与 dlx 宿主缓存树分离），宿主
   typertGateway 持有一张空的标记表 → SRC 认领 **0 个端点** → `/api/<ns>/*` 404、
   客户端报「settings gateway is not ready」，而插件本身 Mounted+Enabled 正常
   （settings.register 成功；跨副本 schemastery 已验证健康——schema 双装不是断点）。
   同版本 peer 必要但不充分：**模块身份**（而非版本）门控私有表。
-- **显式注册路径**：`TypertRegistry.register` 把 invocation descriptor 写入
+- **显式注册路径**：TypertRegistry.register 把 invocation descriptor 写入
   `ctx.typert.local`——`claimsEndpoint`/`resolveDescriptor` **先查它**（strict path），
   claim + dispatch 完全不碰私有表。单测里 SRC 仍能过（测试只 import 一个物理副本），
   分裂只出现在物理分离的模块实例之间。
-- 插件**不得**自行 `connection.rpc.intercept('/api')`——该拦截槽 host 全局单点，重复注册
+- 插件**不得**自行 connection.rpc.intercept('/api')——该拦截槽 host 全局单点，重复注册
   会抛错；`TypertRemoteService` 绑定 + 显式 contribution 是唯一受支持的注册方式。
-- client 半：`connection.rpc.call('/api', '<ns>/<method>', { args })`。
+- client 半：connection.rpc.call('/api', '<ns>/<method>', { args })。
 
 ### Wire 契约
 
@@ -82,7 +82,7 @@ update/replace 无命名空间门禁）。展示挂载与数据通道正交—�
 
 ### 写入语义：merge 与 reset 分离
 
-- `set(patch)` 是 MERGE（`ctx.settings.update`）——无法表达「清掉 user layer 让组合默认
+- `set(patch)` 是 MERGE（ctx.settings.update）——无法表达「清掉 user layer 让组合默认
   重新生效」：把默认值当 patch 写会把旧默认钉死在 user layer（默认值后续变更不再传导）。
 - 表单若拥有 reset-to-defaults 动作，加**第三个方法 `reset()`**：进程内
   `settings.replace(ns, {})`（真清除路径，证据：dsh-private `agent-default-model` /
@@ -116,7 +116,7 @@ gateway 通道是普通 RPC merge/replace，**无版本戳**。迁移时删除�
 
 ### 跨写者 RMW race（无 revision guard 的代价，2026-08-15 实证）
 
-`mergeLayers` 数组整替 + 无版本戳 → 任何「fresh-read → 计算 → `settings.update`」的写路径
+`mergeLayers` 数组整替 + 无版本戳 → 任何「fresh-read → 计算 → settings.update」的写路径
 （gateway `set`/`reset`、seeds `declare`/`revert`）之间没有互斥：读与写两个 await 点之间
 另一写者整替落地 → **last-writer-wins**，输方改动从 user layer 消失。影响有界且可恢复：
 registry 存活、re-declare 重新物化、card-save 丢失在 post-write read 可见；低概率（低频
@@ -136,7 +136,7 @@ fix wave 实证：declare/revert 直读 `config.roles.list` 被收口到守卫�
 
 gateway 响应加字段用 **additive** 模式：`readResult()` 统一附加（`legacyKeys`、`seeds`），
 缺字段的旧客户端忽略、老响应对新客户端 keep-last——wire 兼容前向/后向都不需要版本协商。
-新端点（如 `fallbacks/revert-seed`）在 `fallbacksTypertContribution()` 增加 invocation
+新端点（如 fallbacks/revert-seed）在 `fallbacksTypertContribution()` 增加 invocation
 即可，`ROLES_KEYS`/`CONFIG_KEYS` 等既有键集合不动。
 
 ### 写前校验与「不要发明 resolver」
@@ -157,29 +157,29 @@ gateway 响应加字段用 **additive** 模式：`readResult()` 统一附加（`
   并集）；插件自身命名空间将**不再出现**于 describe——停止按 ns 查找。
 - `present` 标志替代 namespace-found 检查：`get` 解析 → true；否则 false → 可操作骨架。
 - **失效刷新（20260811 起 remote events）**：进程内 update/replace **不再发**
-  `settings/changed`（该客户端事件与 `models/changed` 已于 20260811 dsh snapshot 移除，
+  settings/changed（该客户端事件与 models/changed 已于 20260811 dsh snapshot 移除，
   订阅即死代码）。client 失效刷新迁移到 remote 转发事件（`ctx.remote.$on`，需 `remote`
   在 inject 面）：
-  - `settings/document-updated(ns, revision)` —— ns **精确过滤**插件命名空间才刷新
+  - settings/document-updated(ns, revision) —— ns **精确过滤**插件命名空间才刷新
     （form + switches），他 ns 不刷新；
-  - `llm/adapters-updated()` —— payload-free，**只**刷 catalog，不碰表单；
-  - `connection/reset`（client 事件，保留）——全量刷新，微任务合并突发（burst
+  - llm/adapters-updated() —— payload-free，**只**刷 catalog，不碰表单；
+  - connection/reset（client 事件，保留）——全量刷新，微任务合并突发（burst
     coalesce，advisor 同款 debounce）。
   - 刷新仍走 `refresh*IfLoaded` + generation guard（只刷已读过的 store，未打开的面闲置）。
   - 检测纪律：死事件靠 link farm 真实类型 + `tsc`（`pnpm build` 含 tsc）暴露（TS2345）；
-    测试 double 钉事件名集合（drift-visible）；`grep settings/changed|models/changed`
+    测试 double 钉事件名集合（drift-visible）；grep settings/changed|models/changed
     零残留。
 
 ### 注入子注册序 = 激活序；SettingsProvider init publish 清 seed（2026-08-16 实证）
 
-- **cordis 注入子按注册序同波激活**（Fiber `_reload` 先 `await Promise.resolve()`，微任务 FIFO）：apply 内多个 `ctx.inject([...])` 子按注册先后激活。依赖「先注册子先执行」的隐式顺序（如 writeRoles live 先于 preset fire）成立但脆弱——**新 fire 点应注册于 apply 最尾部**，并在注释钉住理由（preset 子见 `dsh-llm-fallbacks.md` Preset roles 节）。
+- **cordis 注入子按注册序同波激活**（Fiber `_reload` 先 `await Promise.resolve()`，微任务 FIFO）：apply 内多个 `ctx.inject([...])` 子按注册先后激活。依赖「先注册子先执行」的隐式顺序（如 writeRoles live 先于 preset fire）成立但脆弱——**新 fire 点应注册于 apply 最尾部**，并在注释钉住理由（preset 子见 `.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md` Preset roles 节）。
 - **SettingsProvider init publish 清 seed（F-005 教训）**：cordis `Service` 构造同步 provide 但不跑 `[Service.init]`；dsh-settings init 的 `publish(await load())` 会**清掉 init 完成前 publish 的任何 seed**（测试 double 人造物；file-backed HMR 因文档持久化天然规避）。测试「settings 移除→恢复→注入子 re-fire」时，须手工构造 fresh provider 并在子再激活前同步 seed——四断言面（re-fire 证明 / no-delta 零写 / 无重复 / user section 未变）各自独立失败才算钉住。
 - **re-fire 语义**：settings 子每次激活 re-fire（无 per-apply 单发 guard）；declare 幂等 + registry re-commit 保持 badge 正确。
 
 ## Why This Matters
 
 - 设置数据面彻底离开 apiproxy expose 机制：插件命名空间在未打 patch 的宿主上不出现于
-  `settings.describe`（与 advisor 同态），client 必须读 gateway——这是迁移中最大的行为
+  settings.describe（与 advisor 同态），client 必须读 gateway——这是迁移中最大的行为
   变化与最易错点。
 - KD-G3/G5 把「失败面」钉成明确语义（可操作骨架 + 诚实错误横幅），杜绝白屏/死按钮与
   静默丢保存。
@@ -199,13 +199,13 @@ gateway 响应加字段用 **additive** 模式：`readResult()` 统一附加（`
 - **dsh-advisor**：`AdvisorConfigGateway` + `advisorTypertContribution()`（get/set 两
   方法；`resolveAdvisorConfig` 有 enabled 解析器——fallbacks 无，见下）。
 - **dsh-llm-fallbacks**：`FallbacksConfigGateway` + `fallbacksTypertContribution()`
-  （get/set/reset 三方法 + seeds wire `seeds` 字段 + `fallbacks/revert-seed` 端点
+  （get/set/reset 三方法 + seeds wire `seeds` 字段 + fallbacks/revert-seed 端点
   (2026-08-15)；无解析器；实例细节与 store 迁移 →
-  `architecture-patterns/dsh-llm-fallbacks.md`「设置命名空间 web 暴露」节）。
+  `.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md`「设置命名空间 web 暴露」节）。
 - 测试缝：`tests/gateway.spec.ts`（get 规范化、set 未知键拒绝/空 patch no-op、reset 走
   replace、KD-G5 无 settings 服务三分支、畸形 user layer 不崩 get）。
-- 展示挂载契约（`settings.section` slot 等）→ `architecture-patterns/dsh-settings-slot-contract.md`。
+- 展示挂载契约（settings.section slot 等）→ `.mstar/knowledge/architecture-patterns/dsh-settings-slot-contract.md`。
 
-*Source: iteration iter-20260811-fallbacks-mount-only `guides/gateway-channel-design.md`（ADR-1..ADR-5 契约），
+*Source: iteration iter-20260811-fallbacks-mount-only `.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/gateway-channel-design.md`（ADR-1..ADR-5 契约），
 与 dsh-advisor `src/gateway.ts` 对照验证。2026-08-12 compound 提升（结构化重写为模式层）。
 2026-08-15 刷新：跨写者 RMW race（R-002）、读写 containment 守卫、additive wire 字段先例。2026-08-16 刷新：注入子注册序=激活序、SettingsProvider init publish 清 seed（iter-20260816-fallbacks-preset-roles F-005 实证）。*

--- a/.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-llm-fallbacks.md
@@ -45,17 +45,17 @@ dsh 的 agent loop 在模型请求失败时派发 agent/request-error waterfall�
 
 **两块制配置模型**（用户只需记住两块，spec §2）：块 1 = `rootChain`（root 主代理的一条链，空 = root 不降级）；块 2 = 声明式角色实体 `roles.list`（id/label/description/prompt?/permissions?/chain?/fallback）+ `roles.rules`（origin/provider/model → 声明 id 或内置 `'inherit'` 的 enum 引用）。`prompt`/`permissions` 为 schema 预留（next iteration fallbacks-explicit-role-tool），本轮无消费者，YAML 写入不改变降级行为。D3：不引入 `system` 保留字——运行时「系统配置模型」= current，恒被 same-as-current 过滤，UI/文档展示「默认：当前系统模型」。
 
-**角色解析**（root 与 subagent 同构，spec §7.1）：`resolveRole` 顺序匹配 `roles.rules`（origin 读 `session.header.origin`，缺省 `'root'`；provider/model 读 `AgentOptions`——显式 `agent.options.role` 只存在于已删除的 dsh patch，mount-only 下不可读；字段省略即不约束，首个命中即停）→ 返回声明 id；命中规则但 `rule.role` ∉ 声明集 ∪ `{'inherit'}` → warn + 回退 `'inherit'`（防御，启动校验已告警）；未命中 → 内置 `'inherit'`。id 按 trim 规范化（qc2 F-001：padded YAML id + trimmed 规则引用解析到同一角色，不静默降级）。subagent persona 在决策点不可读（`AgentOptions` 仅 provider/model/maxTokens），persona→role 映射未实现——详见探索 guide（`.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/role-and-model-selection-exploration.md`，Role 节）。
+**角色解析**（root 与 subagent 同构，spec §7.1）：`resolveRole` 顺序匹配 `roles.rules`（origin 读 `session.header.origin`，缺省 `'root'`；provider/model 读 `AgentOptions`——显式 `agent.options.role` 只存在于已删除的 dsh patch，mount-only 下不可读；字段省略即不约束，首个命中即停）→ 返回声明 id；命中规则但 rule.role ∉ 声明集 ∪ `{'inherit'}` → warn + 回退 `'inherit'`（防御，启动校验已告警）；未命中 → 内置 `'inherit'`。id 按 trim 规范化（qc2 F-001：padded YAML id + trimmed 规则引用解析到同一角色，不静默降级）。subagent persona 在决策点不可读（`AgentOptions` 仅 provider/model/maxTokens），persona→role 映射未实现——详见探索 guide（`.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/role-and-model-selection-exploration.md`，Role 节）。
 
-**链解析 = append-not-replace**（spec §7.2）：`candidates = [...(roleDef?.chain ?? []), ...(roleDef?.fallback === 'none' ? [] : rootChain)]`——角色自身条目在前、`rootChain` 兜底在后；`fallback: 'none'` 仅角色链（空角色链 + none → no-op 透传）；内置 `'inherit'` 与未知角色 id 均解析为 `rootChain`（前者静默——合法的未命中角色，非 typo；后者 warn 一次，防御不崩溃）。条目语义不变：`provider/model` exact、`provider/*` 保留失败模型 id 仅换 provider（目标 provider 无此 id 则跳过）。**链键 specificity（exact provider/model 键 → provider/* 键 → 角色链 → default 键）已删除（D1）**——命名空间只剩角色名；`roles.default` 已删除（D4），「所有子代理默认 X」改写为一条 `{origin: subagent, role: X}` 规则；**root 参与 rules**（D2，`origin: root` 可命中角色——删除链键后 root 需要 provider 特异链的唯一逃生口；默认不配则走 rootChain）。
+**链解析 = append-not-replace**（spec §7.2）：`candidates = [...(roleDef?.chain ?? []), ...(roleDef?.fallback === 'none' ? [] : rootChain)]`——角色自身条目在前、`rootChain` 兜底在后；`fallback: 'none'` 仅角色链（空角色链 + none → no-op 透传）；内置 `'inherit'` 与未知角色 id 均解析为 `rootChain`（前者静默——合法的未命中角色，非 typo；后者 warn 一次，防御不崩溃）。条目语义不变：provider/model exact、`provider/*` 保留失败模型 id 仅换 provider（目标 provider 无此 id 则跳过）。**链键 specificity（exact provider/model 键 → provider/* 键 → 角色链 → default 键）已删除（D1）**——命名空间只剩角色名；`roles.default` 已删除（D4），「所有子代理默认 X」改写为一条 `{origin: subagent, role: X}` 规则；**root 参与 rules**（D2，`origin: root` 可命中角色——删除链键后 root 需要 provider 特异链的唯一逃生口；默认不配则走 rootChain）。
 
-**决策热路径（单遍历）**：`resolveRole` → `resolveChainViews` 一次遍历产出 `all` + wildcard 溯源（未知角色 warn **至多一次/决策**，此前 resolveChain 跑两遍 all+surviving）→ `hasWildcardEntry` 走与解析**同一拼接** `buildRoleEntries`（探针精确，`fallback:'none'` 正确排除 rootChain——qc1 S-3 单 SSOT / qc2 F-003）→ 仅 wildcard 条目可达时才构建 catalog 存在性探针（纯 exact 链零探针）→ `selectCandidates` 原位过滤（wildcard 条目受探针约束，exact 条目永不探针过滤；T2 review Important #1 决策路径契约）。防御性 warn 经注入的 `logger.warn`（qc2 F-002，非 console）。
+**决策热路径（单遍历）**：`resolveRole` → `resolveChainViews` 一次遍历产出 `all` + wildcard 溯源（未知角色 warn **至多一次/决策**，此前 resolveChain 跑两遍 all+surviving）→ `hasWildcardEntry` 走与解析**同一拼接** `buildRoleEntries`（探针精确，`fallback:'none'` 正确排除 rootChain——qc1 S-3 单 SSOT / qc2 F-003）→ 仅 wildcard 条目可达时才构建 catalog 存在性探针（纯 exact 链零探针）→ `selectCandidates` 原位过滤（wildcard 条目受探针约束，exact 条目永不探针过滤；T2 review Important #1 决策路径契约）。防御性 warn 经注入的 logger.warn（qc2 F-002，非 console）。
 
 ### 旧配置迁移：三通道 + schemastery 未知键保留（iter-20260813-fallbacks-role-model）
 
 **breaking（不自动迁移）**：`chains` / `roles.default` 从 schema 与类型零残留（docs 迁移表除外）。schemastery `Config()` 组合对未知键采用**保留策略（retain，实测 schemastery@3.18.0：顶层 / 嵌套对象 / 列表项均原值透传）**——旧键在组合对象上仍然可见，因此 legacy 检测直接读组合对象即准确（无需 raw 入参快照 fallback）。三通道提示，插件**绝不自动改写**配置：
 
-1. **启动告警**：`apply()` 内 `detectLegacyKeys(source())` 非空 → `logger.warn('llm-fallbacks: legacy config keys detected …; see docs/configuration.md migration table')`（warn-only，不迁移）。
+1. **启动告警**：`apply()` 内 `detectLegacyKeys(source())` 非空 → logger.warn('llm-fallbacks: legacy config keys detected …; see docs/configuration.md migration table')（warn-only，不迁移）。
 2. **gateway + UI 横幅**：`get()` 响应附 `legacyKeys: string[]`（`chains` / `roles.default` / `roles.rules[].role` 未声明值）；client 非空即渲染迁移横幅（zh/en，引用迁移表），表单保持可编辑、保存写出新格式（wire 字段权威，client 不自猜——W-1/F-1：save 是 merge，删不掉用户层旧键）。
 3. **docs/configuration.md 迁移映射表**：逐旧键 → 新写法对照（如 `roles.default` → 删除 + 一条 `{origin: subagent, role: X}` 规则；角色链无兜底 → `fallback: inherit-root` 默认；角色 id = `inherit` → 禁止写入 list）。
 
@@ -80,47 +80,47 @@ Map<agent.id, AgentFallbackState>：pendingSwitch（产生→应用→清除；�
 
 ### model-selection 协调：标记载体已移除 → 文档化降级（iter-20260811-fallbacks-mount-only）
 
-真实组合下 `installModelSelection`（web 前端门 per-agent 注册、先于插件）在 `agent/request` 的 `await next()` 之后重新套用会话选择，会把 fallback 切换覆写回去。patch 时代的解法是 `markFallbackRouted` 标记让位（spec §2.5 D-1：dsh-agent `model-selection.ts` 内模块级 WeakSet + 外层 listener 命中即跳过覆写）；该 patch 与整套 patch 交付体系已在 iter-20260811-fallbacks-mount-only 删除，插件切换**不再打标记**，协调退化为**文档化降级**（T2 结论，证明见探索 guide Model-selection 节）：
+真实组合下 `installModelSelection`（web 前端门 per-agent 注册、先于插件）在 agent/request 的 `await next()` 之后重新套用会话选择，会把 fallback 切换覆写回去。patch 时代的解法是 `markFallbackRouted` 标记让位（spec §2.5 D-1：dsh-agent `{HOST}/model-selection.ts` 内模块级 WeakSet + 外层 listener 命中即跳过覆写）；该 patch 与整套 patch 交付体系已在 iter-20260811-fallbacks-mount-only 删除，插件切换**不再打标记**，协调退化为**文档化降级**（T2 结论，证明见探索 guide Model-selection 节）：
 
 - **注册顺序决定当步路由**：插件 listener 在外（web profile 默认——插件随 bundle 加载先注册、model-selection 随 agent 创建后注册）→ 切换在当步生效；model-selection listener 在外（headless profile，或插件注册前已创建的 agent）→ 用户选择在当步重新套用、覆写切换（clobber）。
-- **决策与记录不受影响**：request-error 决策链、`fallbacks/switch` 事件（事件跨重启可读依赖启动注册——issue #52 stopgap）、冷却、安全阀、always-cap 逻辑全部照旧；被覆写的是当步「实际路由」，不是切换决策。
-- **诚实呈现**：设置页一行降级说明（`status.selectionNote`，zh/en）；`tests/plugin.spec.ts` 组合测试钉住四种注册序 × 有无活跃 selection。
+- **决策与记录不受影响**：request-error 决策链、fallbacks/switch 事件（事件跨重启可读依赖启动注册——issue #52 stopgap）、冷却、安全阀、always-cap 逻辑全部照旧；被覆写的是当步「实际路由」，不是切换决策。
+- **诚实呈现**：设置页一行降级说明（status.selectionNote，zh/en）；`tests/plugin.spec.ts` 组合测试钉住四种注册序 × 有无活跃 selection。
 - **未来 seam（未实现）**：若 dsh 未来在 `LlmCallConfig` 上暴露首类「coordinator-owned routing」位，标记让位可无 patch 恢复。
 
 ### 设置命名空间 web 暴露：插件自有 gateway 通道（iter-20260810-fallbacks-settings-gateway 起）
 
 dsh 的 web 设置 RPC（`dsh-host-apiproxy`）对命名空间有硬编码暴露白名单，插件命名空间默认不可经 wire 读写——早期 patch 方案（`exposeToWebClients` opt-in + apiproxy `exposedNamespaces()` 并集，spec §2.5 D-2）已随 gateway 方案作废。当前形态是**插件自有 gateway 通道，零 host patch**（`src/gateway.ts`）：
 
-- **端点**：`/api/fallbacks/get` + `/api/fallbacks/set` + `/api/fallbacks/reset`（显式 `ctx.typert.register(fallbacksTypertContribution())` 注册，2026-08-13 起替代 `@Remote` SRC 声明——SRC 读模块私有 `remoteMethods()` 标记表，link 插件与 dlx 宿主物理分离时认领 0 端点；网关 `/api` 拦截槽是 host 全局单点，插件不得再 `connection.rpc.intercept('/api')`）。
+- **端点**：`/api/fallbacks/get` + `/api/fallbacks/set` + `/api/fallbacks/reset`（显式 `ctx.typert.register(fallbacksTypertContribution())` 注册，2026-08-13 起替代 `@Remote` SRC 声明——SRC 读模块私有 `remoteMethods()` 标记表，link 插件与 dlx 宿主物理分离时认领 0 端点；网关 `/api` 拦截槽是 host 全局单点，插件不得再 connection.rpc.intercept('/api')）。
 - **读取**：`get` 读 `FallbacksSettingsBridge` source——与运行时同一份 live 组合配置（schema 默认 → 插件行 base → settings user layer）。
 - **写入**：`set` 先按 `Config` schema 校验 patch（未知键拒绝），再经 `ctx.settings.update` 写 user layer（进程内写不经过 wire 级 `exposedNamespaces()` 门）；`reset` 用 `ctx.settings.replace(ns, {})` 清 user layer（`set` 是 merge-only，无法表达「重置为组合默认」）。
 - **可选降级**：settings 服务可选——无 settings 服务时 `get` 仍可用（bridge source 直读），`set`/`reset` 返回明确错误（KD-G5）。
 - **冲突语义（KD-G3）**：gateway 通道是普通 RPC merge/replace、**无版本戳**——`expectedRevision`/`settings-conflict` 冲突 UX 随迁移删除，任何 `set`/`reset` 失败统一进既有错误横幅、表单保持可编辑供重试（旧冲突用例删除，新「set 拒绝 → 错误横幅」用例顶替）。
 - **Draft 播种不变量**：表单 draft 恒从真实解析配置播种（`accept(config, writable)`）；`get` 失败时骨架可以默认值展示，但**不得**用默认值播种 draft——瞬态通道故障恢复后，draft 与真实种子 diff 会送出全默认 patch，抹掉真实配置。
 
-通用模式（wire 契约、KD-G3/G5 语义、可选 settings 条件注入、写前未知键拒绝、无解析器原则、`present` 标志）→ `architecture-patterns/dsh-gateway-settings-channel.md`。
+通用模式（wire 契约、KD-G3/G5 语义、可选 settings 条件注入、写前未知键拒绝、无解析器原则、`present` 标志）→ `.mstar/knowledge/architecture-patterns/dsh-gateway-settings-channel.md`。
 
 **入口面（2026-08-12 起）**：设置展示挂载在官方插件配置页（`settings.plugin.item` 卡，
-替换旧 `settings.section` 独立导航，不并存）；另有三个互补表面——`/fallbacks` 会话内只读
+替换旧 settings.section 独立导航，不并存）；另有三个互补表面——`/fallbacks` 会话内只读
 诊断命令（条件注入 `commands` 服务；快照 `FallbacksCommandSnapshot {origin, role, chainRole, chain, inherit}`——链显示角色自身链优先、空则 `rootChain`（`fallback:'none'` 且空链 → 空），rootChain 兜底尾部标「（inherit-root）」）、General 页只读状态行（`settings.general.item`，
 order 100）、会话转录切换行（`conversationEvents` + `conversation.chat.node`，纯渲染）。
 卡 = 编辑入口、行 = 状态摘要、命令 = 会话内诊断、转录行 = 恢复可见性。挂载点全表 →
-`architecture-patterns/dsh-mount-point-map.md`；会话转录模式 → `architecture-patterns/dsh-conversation-surface-mounting.md`。
+`.mstar/knowledge/architecture-patterns/dsh-mount-point-map.md`；会话转录模式 → `.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md`。
 
 ### 目录驱动 provider/model 选择（iter-20260810-fallbacks-settings-ux，spec §2.5 D-3/D-4）
 
-- **数据源**：`llm.providers({})`（可配置 provider 目录）+ `llm.models({})`（`{ groups, failures }` 模型目录）；`llm/adapters-updated` remote 事件刷新（20260811 起；旧 `models/changed` 客户端事件已移除）。
-- **store catalog 快照**：独立 `loadCatalog()` + 独立 generation guard；`llm/adapters-updated` **只**刷 catalog、`connection/reset` 全刷；failures 降级诊断不拖垮 groups；catalog 失败不阻塞表单（settings 状态零触碰）。
-- **混合下拉**：provider select + model select 级联 + `provider/*` 通配（不依赖 models）+ 目录外合成选项（原值 + 「（目录外）」标注，value 携带原始字符串、读回默认选中）——**目录外值 round-trip 无损**，仅新增条目受限目录；行编辑态判别联合 `{kind:'catalog',id}|{kind:'outside',raw}|null`；序列化仍写原始字符串（`provider/model`、`provider/*` 条目语义不变；无链键——`rootChain` 行与角色链行的有序选择器列表即链本身）。
+- **数据源**：`llm.providers({})`（可配置 provider 目录）+ `llm.models({})`（`{ groups, failures }` 模型目录）；llm/adapters-updated remote 事件刷新（20260811 起；旧 models/changed 客户端事件已移除）。
+- **store catalog 快照**：独立 `loadCatalog()` + 独立 generation guard；llm/adapters-updated **只**刷 catalog、connection/reset 全刷；failures 降级诊断不拖垮 groups；catalog 失败不阻塞表单（settings 状态零触碰）。
+- **混合下拉**：provider select + model select 级联 + `provider/*` 通配（不依赖 models）+ 目录外合成选项（原值 + 「（目录外）」标注，value 携带原始字符串、读回默认选中）——**目录外值 round-trip 无损**，仅新增条目受限目录；行编辑态判别联合 `{kind:'catalog',id}|{kind:'outside',raw}|null`；序列化仍写原始字符串（provider/model、`provider/*` 条目语义不变；无链键——`rootChain` 行与角色链行的有序选择器列表即链本身）。
 
 ### 设置页只读状态块真实化（R1 关闭，spec §2.5 D-5/D-6）
 
-- **读取面**：`connection.api.sessions.history({ sessionId, maxMessages })` 原始事件面（`HistoryEntry.event` 含 `fallbacks/switch`；跨重启可读依赖插件启动注册——issue #52 stopgap）——**不用** `ctx.sessionHistory`（公开快照只含投影会话对话，无原始自定义事件）；当前会话 `ctx.sessions.list` current（注意 host/client Context merge 冲突——`ctx.get('sessions') as unknown as ISessions`，且 client fiber 的 `sessions` 注入应可选降级）；单页 50、seq 倒序取 N=5、会话切换重载、错误隔离不碰 settings 状态。
+- **读取面**：`connection.api.sessions.history({ sessionId, maxMessages })` 原始事件面（HistoryEntry.event 含 fallbacks/switch；跨重启可读依赖插件启动注册——issue #52 stopgap）——**不用** ctx.sessionHistory（公开快照只含投影会话对话，无原始自定义事件）；当前会话 `ctx.sessions.list` current（注意 host/client Context merge 冲突——`ctx.get('sessions') as unknown as ISessions`，且 client fiber 的 `sessions` 注入应可选降级）；单页 50、seq 倒序取 N=5、会话切换重载、错误隔离不碰 settings 状态。
 - **展示值推导**（非实时路由探测，恒附注）：未启用 / `rootChain` 未配置 → 空态；有最近切换 → 最新 `to`；无切换 → `rootChain` 首项（无角色链语境时，spec §7.4）。
 
 ### 纯挂载交付纪律（iter-20260811-fallbacks-mount-only，原 patch 交付纪律已删除）
 
-插件安装对 dsh 源树**零 diff**——patch 文件、apply/revert/verify 脚本、autopatch 安装期调用、ambient shim（`src/dsh-patch-ambient.d.ts`）全部删除：
+插件安装对 dsh 源树**零 diff**——patch 文件、apply/revert/verify 脚本、autopatch 安装期调用、ambient shim（src/dsh-patch-ambient.d.ts）全部删除：
 
 - **安装 = bundle 插行 + client inject + 自有 gateway**：`bundle/cordis.patch.yml` 在 profile bundle 栈上插插件行，`dsh.client.inject` 挂载 web 设置页，设置读写经 `/api/fallbacks/get|set|reset`。
 - **无 patch、无 autopatch 步骤**：一行 git 安装即用（pnpm ≥ 10 需 approve-builds 放行 `prepare` 自构建）；`prepare` = setup-dsh-links + build，无 postinstall。
@@ -132,7 +132,7 @@ order 100）、会话转录切换行（`conversationEvents` + `conversation.chat
 插件暴露程序化消费面，供其它插件（如 mstar-harness loader-probe + 决策点注入）探测与调用：
 
 - **库 API**：`src/index.ts` 统一 re-export 运行时函数（`resolveRole`/`resolveChain`/`selectCandidates`/`annotateCandidates`/`hasWildcardEntry`/`createCandidateFilter`/`resolveCandidate`/`resolveChainViews`/`parseSelector`/`validateFallbacksConfig`/`detectLegacyKeys`）+ 值（`INHERIT_ROLE_ID`/`ROLE_ID_PATTERN`/`defaultFallbacksConfig`/`SelectorError`）+ 类型——消费方 `import { resolveRole } from 'dsh-llm-fallbacks'`；导出面由 `tests/export-surface.spec.ts`（`LIBRARY_EXPORT_KEYS` SSOT + expectTypeOf dev-time pins）机械钉住。
-- **具名 service `'llm-fallbacks'`**：`ctx.get('llm-fallbacks') !== undefined` 即响应式能力探测（cordis 生命周期自动就绪/撤销）。6-key 纯函数面：`{ name, version, resolveRole, resolveChain, validateFallbacksConfig, detectLegacyKeys }`——**不暴露运行态**（store/事件）；运行态请走 `fallbacks/switch` 事件（注意：事件跨重启可读依赖插件启动注册——issue #52；上游注册面落地前，无插件时含事件会话拒绝加载）。多 fiber dedupe guard（镜像 gateway/typert 模式）+ `createRequire` 运行时读 version。注册细节 → `best-practices/dsh-cordis-plugin-authoring.md`。
+- **具名 service `'llm-fallbacks'`**：`ctx.get('llm-fallbacks') !== undefined` 即响应式能力探测（cordis 生命周期自动就绪/撤销）。6-key 纯函数面：`{ name, version, resolveRole, resolveChain, validateFallbacksConfig, detectLegacyKeys }`——**不暴露运行态**（store/事件）；运行态请走 fallbacks/switch 事件（注意：事件跨重启可读依赖插件启动注册——issue #52；上游注册面落地前，无插件时含事件会话拒绝加载）。多 fiber dedupe guard（镜像 gateway/typert 模式）+ `createRequire` 运行时读 version。注册细节 → `.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md`。
 - **契约边界**：本包契约成立 ≠ 隔壁仓库已接上；消费文档 `docs/consumer-api.md` 是契约 SSOT。
 
 ### Role-seeds 能力：companion 自配置角色（iter-20260815-fallbacks-role-seeds）
@@ -141,11 +141,11 @@ order 100）、会话转录切换行（`conversationEvents` + `conversation.chat
 
 - **双存储模型（R3 关键）**：持久面 = operator 配置 `roles.list[]` 普通行（seeded role 物化为仅 `{id, persona}` 两键行，写 settings user layer）；内存面 = per-apply `FallbacksSeedManager` registry（apply() 内创建，`declare` = 替换语义）。`seeded` / `personaOverridden` **派生不存储**（readback 时从 registry + 行 persona 对比得出）→ 配置 round-trip **构造性无孤儿 override**。同会话 at-default 行跟随新默认；跨重启保守按 override 处理（row-untouched + `persona-source` conflict）。
 - **R1 幂等**：无 delta 不写——AC-1 检查**按成员比较**（`list`/`rules` 两键），schemastery/mergeLayers 保留的 legacy 嵌套键（`roles.default` 等）不引发每次 declare 的 revision churn；compute → write → commit registry（写失败 registry 不更新，retry-safe）。
-- **R2 不可变 id**：seed id 按 **as-declared** 过 `ROLE_ID_PATTERN = /^[a-z0-9-]{1,32}$/`——空白填充/大小写/underscore/超长/`inherit` 一律按条 skip + warn，**零 coercion**（不 trim-and-accept、不改写）；冲突（同 id 异 persona 源 / 批内重复）三通道响亮（logger `llm-fallbacks: seeds:` 前缀 + 结构化 `SeedDeclareOutcome` + 持久 `seeds` wire badge），绝不静默合并/重复；移除声明不删角色行/chain，只丢 seed-default/revert affordance。
+- **R2 不可变 id**：seed id 按 **as-declared** 过 ROLE_ID_PATTERN = /^[a-z0-9-]{1,32}$/——空白填充/大小写/underscore/超长/`inherit` 一律按条 skip + warn，**零 coercion**（不 trim-and-accept、不改写）；冲突（同 id 异 persona 源 / 批内重复）三通道响亮（logger `llm-fallbacks: seeds:` 前缀 + 结构化 `SeedDeclareOutcome` + 持久 `seeds` wire badge），绝不静默合并/重复；移除声明不删角色行/chain，只丢 seed-default/revert affordance。
 - **R4 链归 human**：seeds 所有写路径 byte-for-byte 保留或整键省略 chain/fallback/prompt/permissions；新角色 chain 留空（卡片 `validateDraft` **仅对 seeded id** 放宽 `roleChainRequired`，非 seeded 行为逐字节不变）。
-- **释放面（9-key service，严格 additive）**：`FallbacksService` 从 6 key → 9 key——`declareSeeds`(a) / `getEffectiveRoles`(b，含 `seeded`/`personaOverridden`/`seedPersona`) / `revertSeededPersona`(c，恢复到**当前声明**的 seed 默认，非历史快照)。方法与 manager 单点真相（闭包委托，无复制逻辑）。gateway wire：`get/set/reset` 响应 additive `seeds: Array<{id, overridden}>`（legacyKeys 先例，旧客户端忽略）+ 新端点 `fallbacks/revert-seed`（业务失败为值，仅 settings 不可用才 throw）。
+- **释放面（9-key service，严格 additive）**：`FallbacksService` 从 6 key → 9 key——`declareSeeds`(a) / `getEffectiveRoles`(b，含 `seeded`/`personaOverridden`/`seedPersona`) / `revertSeededPersona`(c，恢复到**当前声明**的 seed 默认，非历史快照)。方法与 manager 单点真相（闭包委托，无复制逻辑）。gateway wire：get/set/reset 响应 additive `seeds: Array<{id, overridden}>`（legacyKeys 先例，旧客户端忽略）+ 新端点 fallbacks/revert-seed（业务失败为值，仅 settings 不可用才 throw）。
 - **防御纪律**：读写路径**同用** `roleRows()`/`roleRules()` containment 守卫（legacy/畸形 composed roles 降级不崩）；client store `revertSeed` 镜像 save 的 writable/saving/generation 守卫；卡片 `seededIds` 每次 render 派生（无存储状态）。seeds.ts io-seamed（零 `@deepseek-ai/*` value import，client bundle purity）。
-- **已知边界**：settings user-layer 跨写者 RMW race 无 revision guard（与既有 set/reset 同源通道限制，last-writer-wins，有界可恢复）——R-002 defer，见 `dsh-gateway-settings-channel.md`。
+- **已知边界**：settings user-layer 跨写者 RMW race 无 revision guard（与既有 set/reset 同源通道限制，last-writer-wins，有界可恢复）——R-002 defer，见 `.mstar/knowledge/architecture-patterns/dsh-gateway-settings-channel.md`。
 
 ### Preset roles：bundled 预设角色（iter-20260816-fallbacks-preset-roles）
 
@@ -156,7 +156,7 @@ order 100）、会话转录切换行（`conversationEvents` + `conversation.chat
 - **不得复用早注册的 writeRoles 注入子**：它注册先于 `installSettingsSection`，fire 时 `source()` 仍是 base-only → 以错误基线物化会**整键覆盖 operator user-layer 行**（写覆盖事故）；尾部新子保证 `writeRoles` live + `source()` composed（`setSource` 同步执行，无 load 竞态）。
 - **multi-fiber 门控**：fire 仅发生在成功注册 service 的 fiber（provide try 置 ownership 标志、dedupe catch 置 false）；second fiber 不 fire；declare 幂等 + settings 写队列串行为双兜底。
 - **`presets:'none'`**：fire 时读 live composed source 短路（零声明零写）；**无 `enabled` 门**（enabled:false 默认安装态仍物化 7 行——taxonomy 物化不在 no-op 短路范围内）。
-- **client 连锁**：host 默认值增长会连锁 client——`parseFallbacksConfig` fold 镜像（保持 `parseFallbacksConfig({})` toEqual `defaultFallbacksConfig` 不变量）+ `FallbacksCard` `assembleConfig` 携带新键（否则卡片 clean/dirty JSON 比较永久 dirty）；`export-surface.spec.ts` `LIBRARY_EXPORT_KEYS` SSOT 同步新导出。
+- **client 连锁**：host 默认值增长会连锁 client——`parseFallbacksConfig` fold 镜像（保持 `parseFallbacksConfig({})` toEqual `defaultFallbacksConfig` 不变量）+ `FallbacksCard` `assembleConfig` 携带新键（否则卡片 clean/dirty JSON 比较永久 dirty）；`tests/export-surface.spec.ts` `LIBRARY_EXPORT_KEYS` SSOT 同步新导出。
 - **测试隔离纪律**：legacy 套件若断言 roles.list 精确形状，须 pin `presets:'none'`（默认 bundled 会物化 7 行改变观测值）；`tests/support/harness.ts` `cfg()` 默认 pin none。
 - 冲突/覆盖/幂等语义**零新逻辑**（完全沿用 seeds 既有 declare 语义：operator 同名行保留 + conflict warn、no-delta 零写、derived seeded 不落盘）。
 - 发布：0.1.6 minor；fragment 命名 preset roles 表面（presetRoles 导出 + presets 键）。
@@ -167,7 +167,7 @@ order 100）、会话转录切换行（`conversationEvents` + `conversation.chat
 
 ## Why This Matters
 
-恢复语义归属（request-error 拥有恢复 vs request 路由覆写）分离使插件完全自包含、零侵入 dsh 核心；llm-retry 共存顺序与 always-cap 边界是移植中最易出错的两处，均有测试固化（双插件共存矩阵、mutation-red 验证）。两条 dsh 集成 seam 在纯挂载形态下闭合：设置暴露 = 插件自有 gateway 通道（无 host patch），model-selection 协调 = 文档化降级（注册顺序决定当步路由，marker 移除后无静默失效面——组合测试 + `status.selectionNote` 钉住语义）。
+恢复语义归属（request-error 拥有恢复 vs request 路由覆写）分离使插件完全自包含、零侵入 dsh 核心；llm-retry 共存顺序与 always-cap 边界是移植中最易出错的两处，均有测试固化（双插件共存矩阵、mutation-red 验证）。两条 dsh 集成 seam 在纯挂载形态下闭合：设置暴露 = 插件自有 gateway 通道（无 host patch），model-selection 协调 = 文档化降级（注册顺序决定当步路由，marker 移除后无静默失效面——组合测试 + status.selectionNote 钉住语义）。
 
 ## When to Apply
 

--- a/.mstar/knowledge/architecture-patterns/dsh-mount-point-map.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-mount-point-map.md
@@ -10,7 +10,15 @@ applies_when:
   - 为后续迭代挑选下一批可落地 seam（避免重新考古 dsh-private）
   - 判断「必须改宿主」类结论是否成立——先查地图与证据标准，再下结论
   - 复刻本轮的可行性门禁方法（falsifiable gate）评估新 seam
-tags: [dsh, mount-only, seams, slots, gateway, events, commands, conversation]
+tags:
+  - dsh
+  - mount-only
+  - seams
+  - slots
+  - gateway
+  - events
+  - commands
+  - conversation
 related_components:
   - dsh-private (ui-settings, ui-plugin-config, ui-conversation, ui-slots, host/apiproxy, api/remotes)
   - dsh-llm-fallbacks
@@ -20,7 +28,7 @@ related_components:
 
 系统性盘点 dsh（20260811 snapshot）可供外部插件挂载的 seam 的地图与评估方法（iter-20260812
 产出）。**地图结论 = 已实测（dsh-private file:line）的挂载事实**，不是推断；full evidence
-表存迭代 package（`iter-20260812-fallbacks-plugin-config/guides/mount-point-map.md`），本
+表存迭代 package（`.mstar/iterations/iter-20260812-fallbacks-plugin-config/guides/mount-point-map.md`），本
 文是模式层：分类摘要 + 判定方法与关键不变量。
 
 ## Context
@@ -41,15 +49,15 @@ Verdict（implement-now / gated / map-only + 理由）。
 ### 关键机制事实（所有 seam 共用）
 
 - **Bundle purity gate**：client 值导入仅允许 `CLIENT_EXTERNALS` = `PLATFORM_MODULES`
-  （10 项：react/*、`@deepseek-ai/cordis`、`dsh-client-ui-slots`、`dsh-client-web-react`、
+  （10 项：react/*、@deepseek-ai/cordis、`dsh-client-ui-slots`、`dsh-client-web-react`、
   `dsh-client-ui-primitives`、`dsh-client-ui-attachment`、`dsh-client-schema-form`，
-  `dsh-private/packages/client/web/src/platform.ts:8-15`）+ `@deepseek-ai/dsh-client-runtime/client`
+  `{HOST}/packages/client/web/src/platform.ts:8-15`）+ @deepseek-ai/dsh-client-runtime/client
   豁免。**跨插件值导入在构建门抛错**；type-only import 永远合法（emit 时擦除）。
   → 任何「值导入某 `@deepseek-ai/*` 包」的 seam 都需先查该包是否在表内。
 - **Slot 注册统一 `ctx.slots.inject`**（非裸 register）：等待声明就绪、声明坍缩时自动移除、
-  重声明后重跑（`runtime/src/client/slots.ts:130-192`）。
+  重声明后重跑（`{HOST}/runtime/src/client/slots.ts:130-192`）。
 - **List slot 排序**：`order` 升序，**同 order 按注册先后稳定排序**
-  （`ui-slots/src/index.ts:779-783`，V8 stable sort）——order tie 是稳定且可预期的。
+  （`{HOST}/ui-slots/src/index.ts:779-783`，V8 stable sort）——order tie 是稳定且可预期的。
 - **负 seam 也重要**：`exposedNamespaces()` 白名单（apiproxy wire）、单座 slot、无开放注册
   面的 host 上下文——这些是「为什么必须走替代路径」的存档。
 
@@ -69,38 +77,38 @@ Verdict（implement-now / gated / map-only + 理由）。
 | Seam | 契约要点 | 可行性 | 成本 | Verdict |
 |------|----------|--------|------|---------|
 | `settings.plugin.item` | list/root；卡自绘（owner `children?: never`） | ✅ | S | **implement-now**（fallbacks 卡，order 30） |
-| `settings.section` | list/root；整页导航 | ✅ | S | map-only（fallbacks 已迁出；其它产品仍可用） |
+| settings.section | list/root；整页导航 | ✅ | S | map-only（fallbacks 已迁出；其它产品仍可用） |
 | `settings.general.item` | list/root；owner 空、行自绘 | ✅ | S | **implement-now**（fallbacks 只读行，order 100） |
-| `settings.action` | list/root；头部操作 | ✅ | S–M | map-only（被 `/fallbacks` 命令覆盖） |
-| `settings.onboarding` | list/root；一次一个引导接管 | ✅ | M | map-only（偏好类功能不适用） |
-| `settings.trigger/header/close` | single，shell 自占 | ❌ | — | map-only（闭合） |
-| `ctx.locale` | ns 字典注册 | ✅ | S | implement-now（zh/en 文案） |
+| settings.action | list/root；头部操作 | ✅ | S–M | map-only（被 `/fallbacks` 命令覆盖） |
+| settings.onboarding | list/root；一次一个引导接管 | ✅ | M | map-only（偏好类功能不适用） |
+| settings.trigger/header/close | single，shell 自占 | ❌ | — | map-only（闭合） |
+| ctx.locale | ns 字典注册 | ✅ | S | implement-now（zh/en 文案） |
 
 **B. 数据面（host wire / settings 通道）**
 
 | Seam | 契约要点 | 可行性 | 成本 | Verdict |
 |------|----------|--------|------|---------|
 | 插件自有 gateway 通道（B1） | `TypertRemoteService` 绑定 + 显式 `ctx.typert.register(contribution)`（2026-08-13 起；`@Remote` SRC 标记对 link 插件失效）；`/api/<ns>/<method>`；wire `{ok,value}`/`{ok:false,error}` | ✅ | S | implement-now；多命名空间经第二个 `GatewayService` + `{namespace}` 选项 |
-| `connection.api` 目录面（B2） | settings.describe / llm.providers / llm.models / sessions.history | ✅ | S | implement-now（目录、切换历史、writable） |
+| connection.api 目录面（B2） | settings.describe / llm.providers / llm.models / sessions.history | ✅ | S | implement-now（目录、切换历史、writable） |
 | apiproxy `exposedNamespaces()`（B3） | 白名单外写请求拒绝 | ❌ 负 seam | — | map-only（替代 = B1 gateway） |
-| `ctx.settings` 进程内（B4） | register/update(MERGE)/replace(reset) | ✅ host 半 | S | implement-now；schema 非严格 → 写前必须拒绝未知键 |
+| ctx.settings 进程内（B4） | register/update(MERGE)/replace(reset) | ✅ host 半 | S | implement-now；schema 非严格 → 写前必须拒绝未知键 |
 | remote 转发事件（B5） | `ctx.remote.$on`；白名单 `API_REMOTE_FORWARDED_EVENTS` | ✅ 白名单内 | S | implement-now；新事件类型需改宿主白名单（非纯挂载路径） |
-| `connection/reset`（B6） | client 事件；连接代际重建时 emit | ✅ | S | implement-now |
+| connection/reset（B6） | client 事件；连接代际重建时 emit | ✅ | S | implement-now |
 
 **C. 运行时/agent 面（host）**
 
 | Seam | 契约要点 | 可行性 | 成本 | Verdict |
 |------|----------|--------|------|---------|
-| Session 生命周期（C1） | `session/created` / `session/event` / `session/disposed`，`{global:true}` | ✅ | S | **gated**（跨 scope 观察需双侧 dispose 纪律） |
-| Agent 事件（C2） | `agent/request-error` / `agent/request` / `agent/status` / created / disposed | ✅ | S | implement-now（fallback 决策本体） |
-| `SessionEventMap` merge（C3） | 类型级 merge + `session.append`；非 SurfaceEventType 不进 surface 投影 | ✅ | S | implement-now（`fallbacks/switch`） |
+| Session 生命周期（C1） | session/created / session/event / session/disposed，`{global:true}` | ✅ | S | **gated**（跨 scope 观察需双侧 dispose 纪律） |
+| Agent 事件（C2） | agent/request-error / agent/request / agent/status / created / disposed | ✅ | S | implement-now（fallback 决策本体） |
+| `SessionEventMap` merge（C3） | 类型级 merge + session.append；非 SurfaceEventType 不进 surface 投影 | ✅ | S | implement-now（fallbacks/switch） |
 | `MessageSourceMap` merge（C4） | `createUserMessage` 注入 user-role 消息 | ✅ | S–M | **gated**（改变模型上下文，需产品决策） |
 | Slash 命令（C5） | `commands` 服务注册；**条件注入子** `ctx.inject(['commands'])` | ✅ | S | implement-now（`/fallbacks`） |
-| `ctx.llm` 目录（C6） | listModels / listConfigurableProviders | ✅ host 半 | S | implement-now |
-| `ctx.logger`（C7） | cordis 内建 | ✅ | — | 琐碎，非挂载点 |
+| ctx.llm 目录（C6） | listModels / listConfigurableProviders | ✅ host 半 | S | implement-now |
+| ctx.logger（C7） | cordis 内建 | ✅ | — | 琐碎，非挂载点 |
 
 **D. Conversation 面（client，会话内展示）** → 详见
-`architecture-patterns/dsh-conversation-surface-mounting.md`（本轮单独提升）。
+`.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md`（本轮单独提升）。
 
 | Seam | 契约要点 | 可行性 | 成本 | Verdict |
 |------|----------|--------|------|---------|
@@ -108,15 +116,15 @@ Verdict（implement-now / gated / map-only + 理由）。
 | `conversation.chat.node`（D2） | keyed 座位按 node kind 派发；座位 fallback = JsonBlock | ✅ | S | implement-now（keyed 渲染行） |
 | `conversation.chat.turnTail`（D3） | chain 槽；每 Turn 尾部聚合行 | ✅ | M | map-only（信息密度低于逐条行） |
 | `conversation.session.header.actions`（D4） | list；会话头操作 | ✅ | M | map-only（与命令语义重叠） |
-| `conversation.input.overlay/dock` 等（D5） | composer 浮层/输入区 | ✅ | M | map-only |
-| `conversation.view` / hero 单座（D6） | view 环 / hero 单座已占用 | ✅/❌ | L | map-only（闭合） |
-| `ctx.slash`（D7） | client 触发管线 | ✅ | M | map-only（与 host 命令重复） |
+| conversation.input.overlay/dock 等（D5） | composer 浮层/输入区 | ✅ | M | map-only |
+| conversation.view / hero 单座（D6） | view 环 / hero 单座已占用 | ✅/❌ | L | map-only（闭合） |
+| ctx.slash（D7） | client 触发管线 | ✅ | M | map-only（与 host 命令重复） |
 | `conversation.chat.commandview`（D8） | keyed 命令行槽 | ✅ | M | map-only（命令成功文本已够） |
 
-**E. Sidebar / Workspace（闭合面）**：`sidebar.workspaces`/`sidebar.settings`、
+**E. Sidebar / Workspace（闭合面）**：sidebar.workspaces/sidebar.settings、
 `directoryFlow` 双单座均已占用 → map-only（闭合）。
 
-**F. 打包与清单（安装面）**：`pkg.dsh` manifest（bundle patch + client inject + platform）=
+**F. 打包与清单（安装面）**：pkg.dsh manifest（bundle patch + client inject + platform）=
 外部包声明即挂载；**bundle 插行顺序决定 host waterfall 顺序与 plugin.item 卡同序**
 （tie 语义）。implement-now。
 
@@ -161,7 +169,7 @@ prompt 装配；外部插件不能加 host 上下文。开放替代 = C4 消息�
 - **负 seam**：B3（插件命名空间不在 apiproxy 白名单 → 走 B1 gateway）、E1/E2/G1
   （单座占用/无开放注册面 → 闭合）。
 
-*Source: iteration iter-20260812-fallbacks-plugin-config `guides/mount-point-map.md`
-（32 seams 全证据表）+ `guides/seam-exploration-{general-row,session-visibility}.md`
+*Source: iteration iter-20260812-fallbacks-plugin-config `.mstar/iterations/iter-20260812-fallbacks-plugin-config/guides/mount-point-map.md`
+（32 seams 全证据表）+ guides/seam-exploration-{general-row,session-visibility}.md
 （门禁展开证据），2026-08-12 compound 提升（结构化重写为模式层；逐 seam file:line 证据
 以 package 为 SSOT）。*

--- a/.mstar/knowledge/architecture-patterns/dsh-settings-slot-contract.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-settings-slot-contract.md
@@ -6,8 +6,19 @@ problem_type: architecture_pattern
 category: architecture-patterns
 severity: medium
 plan_id: llm-fallbacks-settings-style
-applies_when: ["为 dsh web 添加新设置页/设置条目/头部操作", "判断某设置能力是否可经 slot 挂载而无需改 shell", "评估为 section 提供专属导航图标", "在官方插件配置页注册插件设置卡（settings.plugin.item）"]
-tags: [dsh, settings, slots, ui-settings, plugin, shell, navIcon]
+applies_when:
+  - 为 dsh web 添加新设置页/设置条目/头部操作
+  - 判断某设置能力是否可经 slot 挂载而无需改 shell
+  - 评估为 section 提供专属导航图标
+  - 在官方插件配置页注册插件设置卡（settings.plugin.item）
+tags:
+  - dsh
+  - settings
+  - slots
+  - ui-settings
+  - plugin
+  - shell
+  - navIcon
 ---
 
 # dsh Web Settings slot 契约（挂载新设置条目，不改 shell）
@@ -15,10 +26,10 @@ tags: [dsh, settings, slots, ui-settings, plugin, shell, navIcon]
 ## Context
 
 dsh web settings 是**纯组合面（shell 零自有内容）**——所有条目通过 slot 注册进来，契约的
-权威定义在 dsh-private `packages/client/ui-settings/src/client/contract/slots.ts`。契约设计
+权威定义在 dsh-private `{HOST}/packages/client/ui-settings/src/client/contract/slots.ts`。契约设计
 意图原文："A feature owns its settings surface — adding a setting never means editing the
 shell"（新增设置永远不用改 shell 本体）。本仓库 Fallbacks 设置入口即经 `settings.plugin.item`
-（插件配置页卡，id `fallbacks`，order 30）挂载（2026-08-12 起；旧 `settings.section` 独立
+（插件配置页卡，id `fallbacks`，order 30）挂载（2026-08-12 起；旧 settings.section 独立
 导航已删除，卡片替换 section 不并存）。
 
 ## Guidance
@@ -27,15 +38,15 @@ shell"（新增设置永远不用改 shell 本体）。本仓库 Fallbacks 设�
 
 | Slot | 用途 | 注册项要点 |
 |------|------|-----------|
-| `settings.plugin.item` | 官方**插件配置页**卡（`ui-plugin-config` 的 PluginConfigSection 经 `settings.section` id `plugins` order 30 挂载后渲染此列表）；卡自绘内部，折叠列表项 | `name`、`id`、`order`、`locale`、可选 `inject`（owner `children?: never`，`slots.ts:16,21-24`） |
-| `settings.section` | 一整页新设置（主入口；`kind: 'list'`，导航行 + 内容页按 order 排序） | `id`（导航 key + `only` 过滤键）、`order`、`label`（注册方本地化）、`locale`、可选 `inject`/`children` |
-| `settings.general.item` | General 页内单行偏好项 | 由 ui-settings-general GeneralSection 在 children 声明；**SlotMap 类型在 `ui-settings/slots.ts:77`**（locale 包只是注册范例）；owner 空（`slots.ts:81-84`），行自绘 |
-| `settings.action` | 内容列头部、Close 前的操作列表（如「打开配置文件」） | — |
-| `settings.onboarding` | root 级 onboarding 步骤（一次挂一个） | `order`/`stepId`/`complete`/`openSection` |
-| `settings.trigger` / `header` / `close` | `single` seat（chrome 文案位）——**不是**业务条目用 | — |
+| `settings.plugin.item` | 官方**插件配置页**卡（`ui-plugin-config` 的 PluginConfigSection 经 settings.section id `plugins` order 30 挂载后渲染此列表）；卡自绘内部，折叠列表项 | `name`、`id`、`order`、`locale`、可选 `inject`（owner `children?: never`，`slots.ts:16,21-24`） |
+| settings.section | 一整页新设置（主入口；`kind: 'list'`，导航行 + 内容页按 order 排序） | `id`（导航 key + `only` 过滤键）、`order`、`label`（注册方本地化）、`locale`、可选 `inject`/`children` |
+| `settings.general.item` | General 页内单行偏好项 | 由 ui-settings-general GeneralSection 在 children 声明；**SlotMap 类型在 `{HOST}/ui-settings/slots.ts:77`**（locale 包只是注册范例）；owner 空（`slots.ts:81-84`），行自绘 |
+| settings.action | 内容列头部、Close 前的操作列表（如「打开配置文件」） | — |
+| settings.onboarding | root 级 onboarding 步骤（一次挂一个） | `order`/`stepId`/`complete`/`openSection` |
+| settings.trigger / `header` / `close` | `single` seat（chrome 文案位）——**不是**业务条目用 | — |
 
 **List slot 排序语义（order tie）**：按 `order` 升序，**同 order 按注册先后稳定排序**
-（`ui-slots/src/index.ts:779-783`，V8 stable sort）。插件配置页卡（bash 0 / agent-loop 10 /
+（`{HOST}/ui-slots/src/index.ts:779-783`，V8 stable sort）。插件配置页卡（bash 0 / agent-loop 10 /
 web-search 20 / advisor 30 / fallbacks 30）中 advisor 与 fallbacks 同为 30——并列时顺序由
 bundle 插行顺序决定，调整卡序应改 bundle 顺序而非动 slot。
 
@@ -52,12 +63,12 @@ ctx.slots.inject('settings.section', () => ctx.slots.register({
 ```
 
 **注意**：
-1. **导航图标硬编码 fallback**：`SettingsRoot.tsx` 的 `navIcon(id)` 只为 `models` 与
+1. **导航图标硬编码 fallback**：`{HOST}/SettingsRoot.tsx` 的 `navIcon(id)` 只为 `models` 与
    `agent-presets` 提供专属图标；新 section id 一律落到齿轮图标（`IconSettingsOutline16`）。
    要专属图标须改宿主函数（独立决策项）。
 2. **挂载走 `ctx.slots.inject`**：等待声明就绪、声明坍缩时自动移除贡献、重声明后重跑。
-3. **全新插件包**需补三个注册面：`tsconfig.client.json` aggregate 引用、
-   `packages/bundle/web-app/cordis.patch.yml` 的 `dsh.client` 行、`package.json` 依赖；
+3. **全新插件包**需补三个注册面：`{HOST}/tsconfig.client.json` aggregate 引用、
+   `{HOST}/packages/bundle/web-app/cordis.patch.yml` 的 dsh.client 行、`package.json` 依赖；
    **在现有包内挂**只需 register 片段。
 
 ## Why This Matters
@@ -78,7 +89,7 @@ ctx.slots.inject('settings.section', () => ctx.slots.register({
 ### 现有注册者（对照）
 
 - `general`（ui-settings-general，order 0）、`models`（ui-models）、`agent-presets`
-  （ui-agent-preset，order 20）、`plugins`（ui-plugin-config，order 30，`settings.section`
+  （ui-agent-preset，order 20）、`plugins`（ui-plugin-config，order 30，settings.section
   承载插件配置页）
 - 插件配置页卡：bash（order 0）、agent-loop（10）、web-search（20）、advisor（30）、
   `fallbacks`（dsh-llm-fallbacks，order 30，`settings.plugin.item`）——同序并列按注册顺序

--- a/.mstar/knowledge/architecture-patterns/dsh-tui-client-seams.md
+++ b/.mstar/knowledge/architecture-patterns/dsh-tui-client-seams.md
@@ -17,7 +17,7 @@ dsh-tui（`dsh --profile dsh-tui`）是 dsh 的终端前端。插件在其上的
 profile 完全不同：**无 web client bundle 渲染、无 typert gateway、无插件设置页**。
 本 doc 是源码核实的 seam 地图（dsh-TUI @ 557a27a = 0.6.1；profile 安装 0.5.0 时
 seam 语义相同——2026-08-16 在 0.5.0 活体验证），与 web 向的
-`dsh-mount-point-map.md` 互补。
+`.mstar/knowledge/architecture-patterns/dsh-mount-point-map.md` 互补。
 
 ## Seam 一览
 
@@ -31,13 +31,13 @@ seam 语义相同——2026-08-16 在 0.5.0 活体验证），与 web 向的
 ## 1. Bundle composition（零改动可用）
 
 - `dsh plugin --profile dsh-tui add dsh-xxx` 读插件 `package.json` 的
-  `dsh.bundle.patch`（→ `cordis.patch.yml`，`- insert: id: xxx` 行），追加为
+  `dsh.bundle.patch`（→ `bundle/cordis.patch.yml`，`- insert: id: xxx` 行），追加为
   dsh-tui profile 的 composition layer。
 - profile 持久化：`~/.dsh/profiles/dsh-tui/{package.json, node_modules, cordis.yml,
   cordis.patch.yml}`；`cordis.yml` 是「空入口树」注释（**编辑 patch 层，不编辑
   该文件**）；`package.json` `dsh.profile.bundles` 数组 + `link:` 依赖（本地目录
   安装形态）。
-- launcher `bin/dsh-tui.js` 首启自举 profile（`dsh plugin --profile dsh-tui add
+- launcher bin/dsh-tui.js 首启自举 profile（`dsh plugin --profile dsh-tui add
   @deepseek-harness-tui/dsh-tui@<版本>`）；registry 安装可能落后于源码
   （2026-08-16：源码 0.6.1 vs profile 0.5.0，TUI 内提示 `/update`）。
 - 验证：`dsh --profile dsh-tui --dump-config | grep llm-fallbacks`（行在 = 组合层
@@ -45,7 +45,7 @@ seam 语义相同——2026-08-16 在 0.5.0 活体验证），与 web 向的
 
 ## 2. `tuiCommandTrees` —— 插件 TUI seam（核心）
 
-`src/dsh-adapter/command-trees.ts`（0.6.1）/ `lib/types/...`（0.5.0）：
+src/dsh-adapter/command-trees.ts（0.6.1）/ lib/types/...（0.5.0）：
 
 ```ts
 interface TuiCommandTreeProvider {
@@ -67,25 +67,25 @@ interface CommandCompletionNode {
   吞 → `[]`（补全永不阻塞执行）。`['fallbacks']` → 子命令节点；
   `['fallbacks', 'config']` → 叶子 `[]`。
 - `descriptions(root)`：覆盖 `/` 菜单 root 行的 description。
-- **结构类型本地声明**：不 import `@deepseek-harness-tui/dsh-tui`（零新 peer）；
+- **结构类型本地声明**：不 import @deepseek-harness-tui/dsh-tui（零新 peer）；
   在 `src/tui.ts` 复制最小形状即可。`tests/peer-deps.test.ts` 契约不变。
 - 条件注入：`ctx.inject(['tuiCommandTrees'], tctx => ...)`——服务缺失 → 子不激活
   → 干净 no-op（无 `dsh-tui-command-trees` 行的 profile 不受影响）。
-- 补全机制（0.6.1 `commands.ts`）：token 级 canonicalPath 走查（root 后遇分隔符
+- 补全机制（0.6.1 commands.ts）：token 级 canonicalPath 走查（root 后遇分隔符
   才进下一层、尾 token 前缀匹配）；补全/描述**只是 UI 元数据**，执行走
-  `commandService.execute(agent, '/'+name+rawInput, signal)`（channel.ts:1240）。
+  commandService.execute(agent, '/'+name+rawInput, signal)（channel.ts:1240）。
 
 ## 3. Command registry merge —— `/fallbacks` 自动浮现
 
 - `refreshCommandList`（channel.ts:2907-2925 / 0.5.0 同构）：`LOCAL_COMMANDS` +
   `commandService.list(target)`（external: true，`descriptions` 来自
-  `commandTrees?.descriptions(name)`）；locals 赢同名冲突；`commands/change` +
+  `commandTrees?.descriptions(name)`）；locals 赢同名冲突；commands/change +
   agent 切换时刷新。
 - 输入路由（PromptInput `tryRunCommand`）：`/` 前缀 + `parseCommandName` +
-  **名字在 `channel.commandList` 中** → `commandService.execute`；否则文本送模型。
+  **名字在 channel.commandList 中** → commandService.execute；否则文本送模型。
 - **命令注册元数据必须通过真实 `CommandRuntime` 校验**（`normalizeDefinition`）：
   `input: { hint: '' }` 抛「input hint must not be empty」（见
-  `best-practices/dsh-cordis-plugin-authoring.md` 的 20260816 实测坑）——stub
+  `.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md` 的 20260816 实测坑）——stub
   registry 测试会掩盖，必须活体验证。
 - 活体判别：TUI 里输入 `/xxx` 若被模型当消息处理 = 命令不在 commandList。
 
@@ -93,7 +93,7 @@ interface CommandCompletionNode {
 
 - TUI **无设置页 / 无 web client / 无 typert**；settings seam 只有 dsh settings
   service（channel.ts:2343 `/provider` 向导用它：describe/get/mutate）。
-- 持久化：`$DSH_HOME/settings.yaml`（全局、**跨 profile 共享**——web profile 写
+- 持久化：$DSH_HOME/settings.yaml（全局、**跨 profile 共享**——web profile 写
   的 `fallbacks:` 段在 dsh-tui 同样生效）+ profile patch 层
   `~/.dsh/profiles/dsh-tui/cordis.patch.yml`（插件行 `config` 覆盖；**patch 替换
   整行 config 而非合并**）。
@@ -108,14 +108,14 @@ interface CommandCompletionNode {
 - **活体验证流程（2026-08-16 实证）**：
   1. `pnpm build`（插件 dist 必须最新——profile link 指向 worktree，加载 dist）；
   2. 本地 dsh CLI 损坏时用专用安装：
-     `mkdir ~/.dsh-cli && cd ~/.dsh-cli && pnpm add @deepseek-ai/dsh@<版本>`，
-     经 `node ~/.dsh-cli/node_modules/@deepseek-ai/dsh/lib/bin.js --profile dsh-tui`
+     mkdir ~/.dsh-cli && cd ~/.dsh-cli && pnpm add @deepseek-ai/dsh@<版本>，
+     经 node ~/.dsh-cli/node_modules/@deepseek-ai/dsh/lib/bin.js --profile dsh-tui
      boot（pnpm global 安装可能不物化依赖树）；
   3. `--dump-config` 确认组合行；PTY boot 后发 `/fallbacks` + `/fallbacks config`，
      观察命令输出（成功 = 命令在列表 + 分发通）；
   4. 插件 apply 证据：settings.yaml 出现插件命名空间段（preset 自声明写入）；
-  5. 探针插件法：`--patch overlay.yml` 注入探针行（`- insert: - id: probe` +
-   `~/.dsh/profiles/dsh-tui/node_modules/probe/` 包），inject 子内 `console.error`
+  5. 探针插件法：--patch overlay.yml 注入探针行（`- insert: - id: probe` +
+   `~/.dsh/profiles/dsh-tui/node_modules/probe/` 包），inject 子内 console.error
    注册结果——cordis 吞子错误，探针是唯一可见面。
 - **QA 环境坑**：交互 boot 失败 ≠ 插件问题——先复现 `dsh --profile web` 是否同样
   失败（全局 CLI 损坏 vs profile 问题）；`dump-config` 可用 ≠ boot 可用。

--- a/.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md
+++ b/.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md
@@ -33,48 +33,48 @@ dsh 插件 = npm 包，package.json 声明 dsh.bundle.patch（指向 bundle/cord
 ### 包结构与构建
 
 - exports：主入口、./client、./bundle/cordis.patch.yml、./package.json；files 含 dist 与 bundle。
-- host 半：tsdown（`tsdown.config.ts`：node ESM bundle，`deps.neverBundle ['cordis', /^@deepseek-ai\//]`——外部化 import 由宿主 in-box 解析）+ tsc（d.ts，`emitDeclarationOnly`）。构建栈与 dsh 宿主一致（pnpm + tsdown + tsx，无 bun）。
-- client 半：closure-factory CJS bundle（`window.__ModuleLoader__.load` 契约；`tsx scripts/build-client.ts` 跑 tsdown，`deps.neverBundle` 加载器表 + `alwaysBundle` 内联其余），经 dshClient.inject 声明依赖；CSS-modules 需自定义 transform（rolldown 插件 resolveId/load 虚拟 id + 类名哈希 + style 标签内联注入/卸载）+ NODE_ENV define。
+- host 半：tsdown（`tsdown.config.ts`：node ESM bundle，deps.neverBundle ['cordis', /^@deepseek-ai\//]——外部化 import 由宿主 in-box 解析）+ tsc（d.ts，`emitDeclarationOnly`）。构建栈与 dsh 宿主一致（pnpm + tsdown + tsx，无 bun）。
+- client 半：closure-factory CJS bundle（`window.__ModuleLoader__.load` 契约；tsx scripts/build-client.ts 跑 tsdown，deps.neverBundle 加载器表 + `alwaysBundle` 内联其余），经 dshClient.inject 声明依赖；CSS-modules 需自定义 transform（rolldown 插件 resolveId/load 虚拟 id + 类名哈希 + style 标签内联注入/卸载）+ NODE_ENV define。
 - prepare 脚本自建（git 安装不跑 build；prepare 需自包含）。
 
 ### 类型访问（dsh link farm，取代 peer-stubs）
 
-- @deepseek-ai/* 不可安装（registry 404），运行期由宿主 in-box 解析；开发期用 `scripts/setup-dsh-links.mjs`（prepare 前置；独立入口 `pnpm dsh:link` / `pnpm dsh:link:check`）从 dsh 源码树链接**真实包**到 node_modules：`$DSH_SOURCE_DIR` → `${DSH_HOME}/source/current` → `~/.dsh/source/current`（取第一个存在）。链接范围 = 源码树 `packages/`+`vendor/` 下所有**无 `bin`** 的 `@deepseek-ai/*` 包（bin 工具包会让 pnpm 往共享 dsh 树写 `.bin`，跳过）。tsconfig 无需 paths。
-- **cordis 必须同物理文件**：真实包的 .d.ts 引用 dsh 树 vendor 的 cordis（非 npm 副本）——直接 symlink vendor/cordis 会带出它的 bin；改为生成 **bin-less shim**（`node_modules/cordis/`：package.json + index.js/index.d.ts/src 符号链接到 vendor 文件），`import 'cordis'` 两侧解析到同一 realpath，`Context`/`Events` 增广才合并（否则 TS2345 满屏）。
+- @deepseek-ai/* 不可安装（registry 404），运行期由宿主 in-box 解析；开发期用 scripts/setup-dsh-links.mjs（prepare 前置；独立入口 `pnpm dsh:link` / `pnpm dsh:link:check`）从 dsh 源码树链接**真实包**到 node_modules：`$DSH_SOURCE_DIR` → ${DSH_HOME}/source/current → `~/.dsh/source/current`（取第一个存在）。链接范围 = 源码树 `{HOST}/packages/`+`{HOST}/vendor/` 下所有**无 `bin`** 的 `@deepseek-ai/*` 包（bin 工具包会让 pnpm 往共享 dsh 树写 `.bin`，跳过）。tsconfig 无需 paths。
+- **cordis 必须同物理文件**：真实包的 .d.ts 引用 dsh 树 vendor 的 cordis（非 npm 副本）——直接 symlink vendor/cordis 会带出它的 bin；改为生成 **bin-less shim**（node_modules/cordis/：package.json + index.js/index.d.ts/src 符号链接到 vendor 文件），`import 'cordis'` 两侧解析到同一 realpath，`Context`/`Events` 增广才合并（否则 TS2345 满屏）。
 - 安全守卫：宿主 profile 的 pnpm store 内安装（git 依赖 prepare/postinstall 在 node_modules/.pnpm 内运行）或仓库根无 node_modules/ 时自动跳过（exit 0）——绝不把 staging 树链进宿主运行环境；源码树缺失/peer 不可链接 → 报错退出带指引（开发期硬性要求）。
-- 运行时值 import 保持 external；测试缝走真实实现：`installSettingsSection` 挂真实 `@deepseek-ai/dsh-settings`（内存 provider 继承真实 `Settings` 基类，只实现 load/persist + seed 播种），client 半 store 引擎 vitest alias 到 dsh 源码树 `src/.../store.ts`（built `./client` 是浏览器 loader artifact，不可直跑）。
+- 运行时值 import 保持 external；测试缝走真实实现：`installSettingsSection` 挂真实 @deepseek-ai/dsh-settings（内存 provider 继承真实 `Settings` 基类，只实现 load/persist + seed 播种），client 半 store 引擎 vitest alias 到 dsh 源码树 `{HOST}/src/.../store.ts`（built ./client 是浏览器 loader artifact，不可直跑）。
 
 ### 设置与 UI
 
 - settings 命名空间：installSettingsSection(ctx, settingsNamespace(命名空间名), Config, entry, {setSource, onChange})（参照 agent-default-model）；composition entry 作 base、用户文档作覆盖层。
 - web 设置入口两形态（2026-08-12 起 fallbacks 用卡片形态）：
   - **插件配置页卡（`settings.plugin.item`）**：`ctx.slots.inject('settings.plugin.item', generator)` 注册 `{ name, id, order, locale, inject }` + 自绘折叠卡组件（`<li>` + header + body + footer，chrome 对齐上游 `PluginCard`——组件**不可值导入**，必须 self-draw；advisor 自绘参考）。**卡替换 section 导航，不并存**（单入口）。卡内数据仍走插件自有 gateway 通道。
-  - **整页 section（`settings.section`）**：独立设置页（`ctx.slots.inject('settings.section', …)` 注册 name/id/order/label/locale）；仍适用于整页设置产品。
-  - 两种形态的**数据都走插件自有 gateway 通道**（client `connection.rpc.call('/api', '<ns>/<method>', { args })`，host 半 `TypertRemoteService` 绑定 + 显式 `ctx.typert.register(contribution)`——2026-08-13 起，`@Remote` SRC 标记对 link 插件失效）——apiproxy `exposedNamespaces()` 白名单对插件命名空间关闭，wire 读写（describe/update/replace）不可行；owner props 为空。
-  - slot 挂载全契约（settings.section / plugin.item / general.item / action / onboarding / navIcon fallback / 新包三注册面）→ `architecture-patterns/dsh-settings-slot-contract.md`。
-  - gateway 通道全契约（wire 规范化、KD-G3/G5、无 revision 守卫、set/reset 语义、draft 播种不变量、可选 settings 注入）→ `architecture-patterns/dsh-gateway-settings-channel.md`。
+  - **整页 section（settings.section）**：独立设置页（`ctx.slots.inject('settings.section', …)` 注册 name/id/order/label/locale）；仍适用于整页设置产品。
+  - 两种形态的**数据都走插件自有 gateway 通道**（client connection.rpc.call('/api', '<ns>/<method>', { args })，host 半 `TypertRemoteService` 绑定 + 显式 `ctx.typert.register(contribution)`——2026-08-13 起，`@Remote` SRC 标记对 link 插件失效）——apiproxy `exposedNamespaces()` 白名单对插件命名空间关闭，wire 读写（describe/update/replace）不可行；owner props 为空。
+  - slot 挂载全契约（settings.section / plugin.item / general.item / action / onboarding / navIcon fallback / 新包三注册面）→ `.mstar/knowledge/architecture-patterns/dsh-settings-slot-contract.md`。
+  - gateway 通道全契约（wire 规范化、KD-G3/G5、无 revision 守卫、set/reset 语义、draft 播种不变量、可选 settings 注入）→ `.mstar/knowledge/architecture-patterns/dsh-gateway-settings-channel.md`。
 - **会话内只读诊断命令（`/fallbacks` 模式）**：`commands` 服务**条件注入子**注册
   （`ctx.inject(['commands'], (commandCtx) => registerCommands(...))`，**不入顶层
   inject**）——commands 服务缺失时子不激活、命令静默缺席，不抛顶层注入错误；注册返回
   disposer。只读命令不改运行时状态（快照构建走现有 store 只读面）。
 - **命令注册元数据必须过真实 `CommandRuntime` 校验（20260816 活体实测坑）**：
-  `normalizeDefinition`（`@deepseek-ai/dsh-commands` 0.1.0-rc.6
-  `lib/types/index.js`）对 `input.hint.trim().length === 0` 抛
+  `normalizeDefinition`（@deepseek-ai/dsh-commands 0.1.0-rc.6
+  `{HOST}/lib/types/index.js`）对 `input.hint.trim().length === 0` 抛
   `TypeError: command "X" input hint must not be empty`——`input: { hint: '' }`
   在**任何真实 profile（web/TUI）注册即抛**；cordis 注入子吞错 → 命令静默不存在，
   连注册行都进不了菜单。stub registry 测试永不暴露（校验在真实实现里）。
-  **正确形态：省略 `input` 键**（`CommandDefinition.input` 可选；省略 = 「无自由
+  **正确形态：省略 `input` 键**（CommandDefinition.input 可选；省略 = 「无自由
   输入」，TUI tag 不显示——`descriptor.input?.hint` 可选链）。校验规则：
   name 正则 `COMMAND_NAME`、description 非空字符串、handler 函数、input 提供则
   hint 必须非空字符串。活体验证法：探针插件（`--patch` overlay）在 inject 子内
-  注册同名命令并 `console.error` 结果。
-- **失效刷新走 remote 转发事件（20260811+ 宿主）**：`settings/changed` / `models/changed`
+  注册同名命令并 console.error 结果。
+- **失效刷新走 remote 转发事件（20260811+ 宿主）**：settings/changed / models/changed
   客户端事件已移除（订阅即死代码）。迁移到 `ctx.remote.$on`（需 `remote` 在 inject 面）：
-  `settings/document-updated(ns, rev)`（ns 精确过滤）+ `llm/adapters-updated()`（payload-free）
-  + 保留 `ctx.on('connection/reset')`（微任务合并突发）；`refresh*IfLoaded` + generation
+  settings/document-updated(ns, rev)（ns 精确过滤）+ llm/adapters-updated()（payload-free）
+  + 保留 ctx.on('connection/reset')（微任务合并突发）；`refresh*IfLoaded` + generation
   guard 语义不变。**漂移检测纪律**：link farm 给真实 dsh 类型 → `pnpm build`（含 tsc）在
   事件名删除后 TS2345 报错（死订阅无处藏）；测试 double **钉事件名集合**
-  （drift-visible，新增订阅名自动失败）；`grep settings/changed|models/changed` 零残留。
+  （drift-visible，新增订阅名自动失败）；grep settings/changed|models/changed 零残留。
 - **设置页必须始终可用（不要死路）**：gateway `get` 失败（通道不可达）≠ 页面该显示「无法读取」通知——渲染可操作骨架（标题/介绍/只读状态块/主开关/保存动作）以默认值展示（`present=false`），`writable` 跟随 describe 顶层标志；`set`/`reset` 失败 → error 横幅如实呈现（不静默）、表单保持可编辑（KD-G3，无 revision 守卫）。通道恢复后骨架原地升级为就绪态。
 - **Draft 播种**：编辑状态从 gateway `get` 返回的**真实组合配置**初始化（`accept(config, writable)`），不用默认值播种——`get` 失败时骨架仅**展示**默认值，播种默认值会在通道恢复后 diff 出全默认 patch、抹掉真实配置。
 - **功能级开关（feature master switch）模式**：用配置字段本身（如 fallbacks 命名空间的 `enabled` 字段）作页面显隐开关——OFF 时隐藏表单主体 + 显示提示（隐藏不丢弃：draft 保留、拨动即时显隐），ON 时显示完整配置界面；开关状态 = 用户配置字段（保存持久化、重载保持），不是纯 UI 本地态。默认值如需翻转（如 enabled true→false），单点改 defaultFallbacksConfig + schema。
@@ -89,25 +89,25 @@ dsh 插件 = npm 包，package.json 声明 dsh.bundle.patch（指向 bundle/cord
 - **wire 层需显式规范化**：组合对象 ≠ 新 schema 形状——`validateConfigPatch` 按新键集 own-key membership 拒绝未知键（不受保留行为影响），`get` 响应按新键集组装。
 - **legacy 检测直接读组合对象**：`detectLegacyKeys(source())` 组合后即准确——无需 raw 入参快照 fallback 策略（fallbacks 实测：旧键随用户层写入保留在组合对象上，检测即准确）。
 
-**三通道迁移模式**（breaking 不自动迁移）：启动 `logger.warn` + gateway `legacyKeys` + UI 迁移横幅（表单保持可编辑）+ docs 迁移映射表；插件绝不自动改写配置。
+**三通道迁移模式**（breaking 不自动迁移）：启动 logger.warn + gateway `legacyKeys` + UI 迁移横幅（表单保持可编辑）+ docs 迁移映射表；插件绝不自动改写配置。
 
 **组合空值填充语义**（已声明可选字段的等价默认）：`chain` 缺省 → `[]`、`permissions` 缺省 → `{ allow: [], deny: [] }`、字符串可选字段（如 `prompt`）缺省 → 不出现——「无自身链 / 无权限」语义等价，消费方 `roleDef?.chain ?? []` 不变；空组合 `Config({})` 深等于默认配置（no-op 不变式的组合侧验证）。
 
 ### 事件监听组合顺序与运行时面可读性（waterfall 内外层）
 
-- **FIRST-registered listener is OUTER and has the final say**（cordis `events.ts` `waterfall`：按 `_hooks[name]` 注册序 first→outer 组合；`dispatch` 按 scope carrier 过滤但**不重排**）。同 ctx 两个 listener，先注册者的 post-`next()` 覆写赢。插件做 `agent/request` 类 override 前，先问「谁先注册」，不要按配置意图猜。
-- **`agent/created` 是 post-publish，经它注册必为 inner**：`agents.create` 工厂先 `await setup`（`installModelSelection` 等在此注册）再 insert/announce；`agent/created` 里注册的 listener 严格内层，其 post-`next()` 改动会被外层 listener 重套覆写（clobber）。
-- **注册时机不由插件控制**：bundle 行序（`cordis.patch.yml` 插行）与 agent 创建时机归宿主——headless profile 中 agent 在宿主 runner 插件 apply 内创建，晚挂载的兄弟插件天然 inner；web profile 中插件随 bundle 加载先注册、model-selection 随 agent 创建后注册（插件 outer）。结论必须按 profile 分述。
-- **把预判转证实**：对「无挂载替代」类结论，写组合测试钉住注册序 × 行为矩阵（同 ctx 两 listener / 先外后内 / `agent/created` seam / headless 序），把 architect 预判变 proven（iter-20260811 Plan B T2 范式，证据见该迭代 `guides/role-and-model-selection-exploration.md`）。
-- **persona 运行时不可读**（2026-08-11 源码验证）：`AgentOptions` 原生仅 `{ provider, model, maxTokens }`（注释明确 "Persona belongs to system-prompt sections"）；persona 是 subagent provider 能力，在 `agents.create` 未发布 setup 窗口以**作用域 system-prompt section**（`deployment:persona`）安装（spawn/fork provider 才有该能力），live `Agent` handle 与 child `SessionHeader` 均无 persona 字段。插件决策点（`agent/request-error` 只持 `Agent`）读不到 persona；hook `system-prompt/assemble` 捕获是 provider-scoped 内部装配面且值为 prompt 文本（非可作规则键的标识）——脆弱，不做。若 dsh 未来把 persona 上提为 `AgentOptions`/session header 字段，映射才可行（schema 向后兼容扩展）。
+- **FIRST-registered listener is OUTER and has the final say**（cordis events.ts `waterfall`：按 `_hooks[name]` 注册序 first→outer 组合；`dispatch` 按 scope carrier 过滤但**不重排**）。同 ctx 两个 listener，先注册者的 post-`next()` 覆写赢。插件做 agent/request 类 override 前，先问「谁先注册」，不要按配置意图猜。
+- **agent/created 是 post-publish，经它注册必为 inner**：agents.create 工厂先 `await setup`（`installModelSelection` 等在此注册）再 insert/announce；agent/created 里注册的 listener 严格内层，其 post-`next()` 改动会被外层 listener 重套覆写（clobber）。
+- **注册时机不由插件控制**：bundle 行序（`bundle/cordis.patch.yml` 插行）与 agent 创建时机归宿主——headless profile 中 agent 在宿主 runner 插件 apply 内创建，晚挂载的兄弟插件天然 inner；web profile 中插件随 bundle 加载先注册、model-selection 随 agent 创建后注册（插件 outer）。结论必须按 profile 分述。
+- **把预判转证实**：对「无挂载替代」类结论，写组合测试钉住注册序 × 行为矩阵（同 ctx 两 listener / 先外后内 / agent/created seam / headless 序），把 architect 预判变 proven（iter-20260811 Plan B T2 范式，证据见该迭代 `.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/role-and-model-selection-exploration.md`）。
+- **persona 运行时不可读**（2026-08-11 源码验证）：`AgentOptions` 原生仅 `{ provider, model, maxTokens }`（注释明确 "Persona belongs to system-prompt sections"）；persona 是 subagent provider 能力，在 agents.create 未发布 setup 窗口以**作用域 system-prompt section**（`deployment:persona`）安装（spawn/fork provider 才有该能力），live `Agent` handle 与 child `SessionHeader` 均无 persona 字段。插件决策点（agent/request-error 只持 `Agent`）读不到 persona；hook system-prompt/assemble 捕获是 provider-scoped 内部装配面且值为 prompt 文本（非可作规则键的标识）——脆弱，不做。若 dsh 未来把 persona 上提为 `AgentOptions`/session header 字段，映射才可行（schema 向后兼容扩展）。
 
 ### 关键坑
 
 - Config 类型 + z 类型注解的 schemastery ObjectT 输出键全 required：.default(undefined as unknown as {...}) 的 cast 类型必须与 schema 输出全等，否则 tsc -b 报 TS2345。
 - cordis 插件命名导出约定：Loader 丢弃 namespace（含 inject 元数据）当存在 default export——只用 named exports。
-- **上游清单契约会改名**（2026-08-11 实测）：client 半的 package.json 声明字段由 `dshClient` 改为 **`dsh.client`**（新 loader 只认 `dsh.client`，旧字段被忽略 → client 半在 GUI 完全不可见，无报错）。插件必须跟随：`"dsh": { "bundle": { "patch": ... }, "client": { "inject": [...], "platform": "web" } }`，且 `exports["./client"]` 必须存在（loader 校验）。升级 dsh 快照后核对 manifest 字段名 + exports。
-- **Purity 门必须建在模块图面（resolveId），不是 require 文本面**：`deps.alwaysBundle` 会把表外依赖**静默内联**——值导入对等包不产生 require，require-only 断言失明（实测 94.37 kB 内联产物零 require 通过旧门）。双层：resolveId 插件抛错 + emitted-surface token 扫描（`/@deepseek-ai\/[\w./-]+/g` 超集）。每次新增 type-only 对等包后做负向探针（误值导入应红）。→ `build-errors/dsh-client-bundle-purity-gate.md`。
-- **会话转录挂载走 conversationEvents + conversation.chat.node（纯渲染）**：非 surface 插件事件默认转录不可见；双段注册（注册表决定是否渲染 + keyed 座位决定如何渲染）；**宿主引擎对节点生命周期无 try/catch——match/start 对畸形载荷必须降级绝不 throw**；type-only 引用 `dsh-client-ui-conversation`；业务数据经 `node` prop。→ `architecture-patterns/dsh-conversation-surface-mounting.md`。
+- **上游清单契约会改名**（2026-08-11 实测）：client 半的 package.json 声明字段由 `dshClient` 改为 **dsh.client**（新 loader 只认 dsh.client，旧字段被忽略 → client 半在 GUI 完全不可见，无报错）。插件必须跟随：`"dsh": { "bundle": { "patch": ... }, "client": { "inject": [...], "platform": "web" } }`，且 exports["./client"] 必须存在（loader 校验）。升级 dsh 快照后核对 manifest 字段名 + exports。
+- **Purity 门必须建在模块图面（resolveId），不是 require 文本面**：deps.alwaysBundle 会把表外依赖**静默内联**——值导入对等包不产生 require，require-only 断言失明（实测 94.37 kB 内联产物零 require 通过旧门）。双层：resolveId 插件抛错 + emitted-surface token 扫描（`/@deepseek-ai\/[\w./-]+/g` 超集）。每次新增 type-only 对等包后做负向探针（误值导入应红）。→ `.mstar/knowledge/build-errors/dsh-client-bundle-purity-gate.md`。
+- **会话转录挂载走 conversationEvents + conversation.chat.node（纯渲染）**：非 surface 插件事件默认转录不可见；双段注册（注册表决定是否渲染 + keyed 座位决定如何渲染）；**宿主引擎对节点生命周期无 try/catch——match/start 对畸形载荷必须降级绝不 throw**；type-only 引用 `dsh-client-ui-conversation`；业务数据经 `node` prop。→ `.mstar/knowledge/architecture-patterns/dsh-conversation-surface-mounting.md`。
 - 配置字段默认值跨 host/client 重复硬编码会漂移：从单一 defaultFallbacksConfig 派生。
 
 ### 具名 cordis 服务注册（消费面，iter-20260814 实测）
@@ -117,10 +117,10 @@ dsh 插件 = npm 包，package.json 声明 dsh.bundle.patch（指向 bundle/cord
 - **`ctx.provide(name, VALUE)` 是值形式**（cordis 4.0.1 `reflect.ts:277-292` 验证）：传**对象值**，不是 factory——传函数会被当作服务值本身注册（`fb.resolveRole === undefined`）。
 - **`export const provide = ['<name>'] as const` 只是声明性元数据**（loader/工具可见）；实际注册只发生在 `apply()` 内 `ctx.provide()`——registry 不自动注册（`registry.ts:106-108`），无双注册风险。
 - **多 fiber 同 root apply 必须 dedupe guard**：cordis 对重复服务键 fail-loud（`reflect.ts:289-290` throw「service X has been registered」）。镜像插件内既有 gateway/typert dedupe 模式：`try { ctx.provide(...) } catch (e) { if (e instanceof Error && e.message.includes('has been registered')) { debug('already registered — no service on this fiber (multi-fiber dedupe)') } else throw }`——第一 fiber 拥有服务、后续 fiber 优雅降级，**未加 guard 会让 apply() 中止在其它 dedupe 注册之前**。
-- **类型面**：`declare module '@deepseek-ai/cordis' { interface Context { '<name>'?: ServiceShape } }`（cordis-4 interface-Context 合并；先例 dsh-settings `settings`、dsh-agent-default-model `agentDefaultModel`）；消费方 import 后 `ctx.get` 自动带类型。
-- **严格 get 语义**：服务未注册/已撤销 → `ctx.get` 返回 `undefined`（不 throw）——消费方 `if (fb !== undefined)` 即生命周期探测。
-- **版本元信息**：运行时 `createRequire(import.meta.url)('../package.json').version`（模块级读一次）——src/vitest 与 dist/发布后（npm 恒带 package.json）均解析；不要 build-time 内联。
-- **服务面纪律**：只暴露**纯函数面**（解析/校验函数 + name/version 元信息），**不暴露运行态**（store/事件发射器）——跨插件读状态是实现细节非契约；运行态请走事件（如 `fallbacks/switch`）。
+- **类型面**：`declare module '@deepseek-ai/cordis' { interface Context { '<name>'?: ServiceShape } }`（cordis-4 interface-Context 合并；先例 dsh-settings `settings`、dsh-agent-default-model `agentDefaultModel`）；消费方 import 后 ctx.get 自动带类型。
+- **严格 get 语义**：服务未注册/已撤销 → ctx.get 返回 `undefined`（不 throw）——消费方 `if (fb !== undefined)` 即生命周期探测。
+- **版本元信息**：运行时 createRequire(import.meta.url)('../package.json').version（模块级读一次）——src/vitest 与 dist/发布后（npm 恒带 package.json）均解析；不要 build-time 内联。
+- **服务面纪律**：只暴露**纯函数面**（解析/校验函数 + name/version 元信息），**不暴露运行态**（store/事件发射器）——跨插件读状态是实现细节非契约；运行态请走事件（如 fallbacks/switch）。
 - 单点真相：服务方法 = 直接引用 index re-export 的同一函数（`toBe` 同一性测试钉住），不复制逻辑。
 - **有状态方法的身份（2026-08-15 实证）**：服务面可以是「无状态纯函数 + 有状态闭包」混合——legacy 纯函数方法与库 re-export **同一绑定**（`toBe` 同一），但 per-apply 有状态方法（如 seeds `declareSeeds`/`revertSeededPersona`）是**闭包**（捕获 apply() 内建的 manager），与库 re-export **不是**同一引用。文档必须区分两种身份（写「与库导出同一绑定」会过度声称，2026-08-15 修过此 doc bug）；测试同样分型钉住（纯函数 `toBe` vs 闭包行为）。
 
@@ -129,10 +129,10 @@ dsh 插件 = npm 包，package.json 声明 dsh.bundle.patch（指向 bundle/cord
 插件需要在 apply 后做**异步后台动作**（如经 settings 通道物化默认数据）时的安全模式：
 
 - **apply 保持同步签名**：cordis 虽 await thenable 返回值，但 rejection 经 `_reload` 使整条 fiber **FAILED**（插件整体不加载）——headless 组合会把运行时整个拖死；且 `void → Promise<void>` 是公共库面非 additive 变更。异步动作一律 fire-and-forget + **同步挂 `.catch`**（无 unhandled rejection 窗口）。
-- **不要在 apply 尾部同步触发**：`ctx.inject` 子一个 tick 后才激活，同步触发必中「服务未就绪」stub。定案：**注册新的条件注入子**（`ctx.inject(['settings'])`），子激活回调内执行动作；子不激活 = 服务结构性不存在 = 零副作用（headless 边界天然成立）。
+- **不要在 apply 尾部同步触发**：ctx.inject 子一个 tick 后才激活，同步触发必中「服务未就绪」stub。定案：**注册新的条件注入子**（`ctx.inject(['settings'])`），子激活回调内执行动作；子不激活 = 服务结构性不存在 = 零副作用（headless 边界天然成立）。
 - **不要复用早注册的注入子**：早注册子激活时 `setSource`/绑定可能尚未就绪（base-only 基线 → 整键覆盖事故）；新 fire 点注册于 apply 最尾部，按注册序激活保证依赖先 live。
 - **multi-fiber 门控**：同一动作只应发生在成功注册 service 的 fiber（provide try 置 ownership 标志、dedupe catch 置 false）；second fiber 不重复执行；动作本身幂等（no-delta）作双兜底。
-- 失败面：logger.error 一条带前缀、状态不 commit、不阻断 apply、无进程内重试（下次 apply / 子再激活即重试）。测试须 `vi.waitFor`（fire 在激活后一个 tick）+ 负向断言 settle 窗口。
+- 失败面：logger.error 一条带前缀、状态不 commit、不阻断 apply、无进程内重试（下次 apply / 子再激活即重试）。测试须 vi.waitFor（fire 在激活后一个 tick）+ 负向断言 settle 窗口。
 
 ## Why This Matters
 

--- a/.mstar/knowledge/best-practices/dsh-settings-ui-fidelity.md
+++ b/.mstar/knowledge/best-practices/dsh-settings-ui-fidelity.md
@@ -33,7 +33,7 @@ iter-20260812 插件配置卡扩展）。
 
 用户对插件设置页的观感要求是「与 dsh web 本体 sections（Models/General）同屏一致」，不是
 「和 advisor 差不多」——参照优先级：**dsh web 本体 sections 第一，advisor 第二**。本体 sections
-的形态权威在 dsh-private client 包的 `.module.css`；插件 CSS 全部色值必须走
+的形态权威在 dsh-private client 包的 .module.css；插件 CSS 全部色值必须走
 `--dsw-alias-*` token（light/dark 双主题解析），零硬编码色值。对照方法 = 逐维度（几何/
 字级/token/控件形态）比对 + 显式记录「用户可见差异」裁决。
 
@@ -43,26 +43,26 @@ iter-20260812 插件配置卡扩展）。
 
 | 代号 | 文件 | 角色 |
 |------|------|------|
-| MS | `packages/client/ui-models/src/client/ModelsSection.module.css` | 主参照（section 词表 + 行卡 + 输入/胶囊） |
-| MSX | `…/ui-models/src/client/ModelsSection.tsx` / `ProviderEditor.tsx` / `DeepSeekModelsEditor.tsx` / `ModelListEditor.tsx` | 结构参照（field、editor、候选行） |
-| GR | `…/ui-conversation/src/client/settings/EnterBehaviorRow.module.css` | General 项行（title+desc+控件右置） |
-| AR | `…/ui-theme/src/client/AppearanceRow.module.css` | General 项行（16/0 padding + hairline） |
-| GS | `…/ui-settings-general/src/client/GeneralSection.module.css` | section 容器（列布局，末项去分隔线） |
-| SR | `…/ui-settings-general/src/client/SettingsRoot.module.css` | 外壳几何（panel 800 / options 24 padding） |
-| SC | `…/ui-subagent/src/client/SubagentCatalogAction.module.css` | 静默 notice 盒（padding 10/12） |
+| MS | `{HOST}/packages/client/ui-models/src/client/ModelsSection.module.css` | 主参照（section 词表 + 行卡 + 输入/胶囊） |
+| MSX | `{HOST}/…/ui-models/src/client/ModelsSection.tsx` / `{HOST}/ProviderEditor.tsx` / `{HOST}/DeepSeekModelsEditor.tsx` / `{HOST}/ModelListEditor.tsx` | 结构参照（field、editor、候选行） |
+| GR | `{HOST}/…/ui-conversation/src/client/settings/EnterBehaviorRow.module.css` | General 项行（title+desc+控件右置） |
+| AR | `{HOST}/…/ui-theme/src/client/AppearanceRow.module.css` | General 项行（16/0 padding + hairline） |
+| GS | `{HOST}/…/ui-settings-general/src/client/GeneralSection.module.css` | section 容器（列布局，末项去分隔线） |
+| SR | `{HOST}/…/ui-settings-general/src/client/SettingsRoot.module.css` | 外壳几何（panel 800 / options 24 padding） |
+| SC | `{HOST}/…/ui-subagent/src/client/SubagentCatalogAction.module.css` | 静默 notice 盒（padding 10/12） |
 
-**已知误导**：`ui-settings/src/client/SettingsRoot.module.css` 不存在（该包仅
+**已知误导**：`{HOST}/ui-settings/src/client/SettingsRoot.module.css` 不存在（该包仅
 contract/index/settings-scope）；外壳几何实际在 `ui-settings-general` 包内。
 
 ### 插件配置卡参照（`settings.plugin.item` 卡 chrome，iter-20260812 扩展）
 
 | 代号 | 文件 | 角色 |
 |------|------|------|
-| PC.tsx | `packages/client/ui-plugin-config/src/client/PluginCard.tsx`（98 行） | 上游卡组件——chrome 契约（`<li>` 折叠列表项：header 按钮 + name/description + dirty pill + chevron + body + footer） |
-| PC.css | `…/PluginCard.module.css`（158 行） | 上游卡 CSS——**尺寸权威**（card r12 border-l2 / header padding 14 16 gap 12 / pending pill r999 / footer 等） |
-| PCS.tsx | `…/PluginConfigSection.tsx` | 卡列表渲染（section 经 `settings.section` id `plugins` order 30 挂载） |
-| SC.ts | `…/slot-contract.ts`（24 行） | `settings.plugin.item` slot 类型（owner `children?: never`——卡自绘） |
-| AC.tsx / AC.css | dsh-advisor `src/client/advisor-card.tsx` / `.module.css` | 兄弟插件自绘参考——**chrome 类与上游字节级一致**（advisor 逐字复制上游 chrome 类，仅增 body 通知/表单类）；最接近 fallbacks 需求的自绘参照 |
+| PC.tsx | `{HOST}/packages/client/ui-plugin-config/src/client/PluginCard.tsx`（98 行） | 上游卡组件——chrome 契约（`<li>` 折叠列表项：header 按钮 + name/description + dirty pill + chevron + body + footer） |
+| PC.css | `{HOST}/…/PluginCard.module.css`（158 行） | 上游卡 CSS——**尺寸权威**（card r12 border-l2 / header padding 14 16 gap 12 / pending pill r999 / footer 等） |
+| PCS.tsx | `{HOST}/…/PluginConfigSection.tsx` | 卡列表渲染（section 经 settings.section id `plugins` order 30 挂载） |
+| SC.ts | `{HOST}/…/slot-contract.ts`（24 行） | `settings.plugin.item` slot 类型（owner `children?: never`——卡自绘） |
+| AC.tsx / AC.css | dsh-advisor src/client/advisor-card.tsx / .module.css | 兄弟插件自绘参考——**chrome 类与上游字节级一致**（advisor 逐字复制上游 chrome 类，仅增 body 通知/表单类）；最接近 fallbacks 需求的自绘参照 |
 | ACI.ts | dsh-advisor `src/client/index.ts` | 注册范式（inject + apply + slot.inject） |
 
 **卡 chrome 词表要点**：`--dsw-alias-border-l2`/`bg-layer-3`（卡）、`bg-layer-2`（open）、
@@ -148,13 +148,13 @@ padding-bottom 8px、footer gap 8 padding 12 0 4 border-top。折叠态 `aria-ex
 
 - iter-20260811-fallbacks-mount-only Plan C：A1–A14 全维度对照表 + C 节 9 条落地清单 +
   「用户可见差异」4 条裁决（卡片形态/checkbox/banner/data-tip），QA CSSOM 全生效。
-- iter-20260812 插件配置卡：`guides/card-fidelity-checklist.md` 逐维度对照表（结构/几何/
+- iter-20260812 插件配置卡：`.mstar/iterations/iter-20260812-fallbacks-plugin-config/guides/card-fidelity-checklist.md` 逐维度对照表（结构/几何/
   tokens/行为/a11y，上游 PluginCard.module.css:1-158 ↔ fallbacks card css）+ 7 条已知差异
   裁决；light/dark 截图 + CSSOM 规则数 == 文本规则数验证。
-- 参照实现：`FallbacksCard.module.css` / `FallbacksCard.tsx`（插件侧；2026-08-12 起取代
-  整页 `FallbacksSection`）；本体 `ModelsSection.module.css`、`GeneralSection.module.css`
+- 参照实现：`src/client/FallbacksCard.module.css` / `src/client/FallbacksCard.tsx`（插件侧；2026-08-12 起取代
+  整页 `FallbacksSection`）；本体 `{HOST}/ModelsSection.module.css`、`{HOST}/GeneralSection.module.css`
   （dsh-private）。
 
-*Source: iteration iter-20260811-fallbacks-mount-only `guides/ui-fidelity-checklist.md` +
-iter-20260812-fallbacks-plugin-config `guides/card-fidelity-checklist.md`，2026-08-12
+*Source: iteration iter-20260811-fallbacks-mount-only `.mstar/iterations/iter-20260811-fallbacks-mount-only/guides/ui-fidelity-checklist.md` +
+iter-20260812-fallbacks-plugin-config `.mstar/iterations/iter-20260812-fallbacks-plugin-config/guides/card-fidelity-checklist.md`，2026-08-12
 compound 提升（保留参照地图/词表/方法/裁决，剥离一次性现状快照）。*

--- a/.mstar/knowledge/best-practices/npm-release-pipeline.md
+++ b/.mstar/knowledge/best-practices/npm-release-pipeline.md
@@ -29,8 +29,8 @@ dsh-llm-fallbacks 建立 npm 发布流水线（单包），参考 mstar-harness 
 
 ### 架构：PR-driven release（不直接 push tag 发版）
 
-- **`release-prep.yml`**（`workflow_dispatch` + 可选 version 输入）：reject 已存在 tag → `prepare-release` 脚本（bump + changelog fragments 组装 + 归档）→ validate → build 冒烟 → commit `release/vX.Y.Z` 分支 → 开 `release vX.Y.Z` PR。
-- **`release.yml`**（`pull_request: types: [closed]` + branches [main] + `merged == true` + title `startsWith('release v')` + head.ref `release/v*`）：checkout merge_commit → validate → build → `npm publish --provenance --access public` → tag + GitHub Release。
+- **`.github/workflows/release-prep.yml`**（`workflow_dispatch` + 可选 version 输入）：reject 已存在 tag → `prepare-release` 脚本（bump + changelog fragments 组装 + 归档）→ validate → build 冒烟 → commit release/vX.Y.Z 分支 → 开 `release vX.Y.Z` PR。
+- **`.github/workflows/release.yml`**（`pull_request: types: [closed]` + branches [main] + `merged == true` + title `startsWith('release v')` + head.ref `release/v*`）：checkout merge_commit → validate → build → `npm publish --provenance --access public` → tag + GitHub Release。
 - 发布动作 = merge release PR：可审查、可回滚、无 secrets。**不写** push:tags 自动发布路径。
 
 ### 坑 1：npm Trusted Publishing 只对**已存在**的包可配置（无 pre-registration）
@@ -48,7 +48,7 @@ dsh-llm-fallbacks 建立 npm 发布流水线（单包），参考 mstar-harness 
 
 - npm 11.x（Node 24 自带）发布 `X.Y.Z-pre.N` 无 `--tag` → hard-throw「You must specify a tag using --tag when publishing a prerelease version」（npm 11 源码 v11.0.0-v11.6.2 验证；npm 10 无此 guard）。
 - 首发 prerelease 用 `--tag latest`：默认 dist-tag 是 latest，`npm i <pkg>` 能解析；正式版后续自然接管。
-- 对应地，GitHub Release 的 `prerelease` 标志按版本推导：`prerelease=$(node -p "/-/.test(require('./package.json').version)")`。
+- 对应地，GitHub Release 的 `prerelease` 标志按版本推导：prerelease=$(node -p "/-/.test(require('./package.json').version)")。
 
 ### 坑 4：流水线重跑/版本一致性防护
 
@@ -56,12 +56,12 @@ dsh-llm-fallbacks 建立 npm 发布流水线（单包），参考 mstar-harness 
 - **PR title 版本交叉校验**：release.yml 从 title 后缀推导期望版本 vs package.json version，mismatch → fail（防手工改分支导致的标题/版本脱钩）；changelog 提取空文件 → fail。
 - **reject 已存在 tag**：release-prep 前置 `git rev-parse v$V` 拒绝 + validate 双保险。
 - **publish 先于 tag**：发布失败不会产生坏 tag；tag push 不会重复触发 CI（push filter 只 main）。
-- **fragments 机制**：`.changes/unreleased/*.md`（frontmatter `category:` 可选 + 英文 bullets）→ prepare-release 插入 `## [v] - date`（UTC）→ 归档 `.changes/archive/<v>/`。auto-bump 对 `X.Y.Z-pre.N` 只递增 N（`0.1.0-alpha.1 → alpha.2`，**别学 mstar 的 parseInt 朴素 split**——会把 alpha 静默跳成正式版）。
+- **fragments 机制**：`.changes/unreleased/*.md`（frontmatter `category:` 可选 + 英文 bullets）→ prepare-release 插入 `## [v] - date`（UTC）→ 归档 .changes/archive/<v>/。auto-bump 对 `X.Y.Z-pre.N` 只递增 N（`0.1.0-alpha.1 → alpha.2`，**别学 mstar 的 parseInt 朴素 split**——会把 alpha 静默跳成正式版）。
 
 ### 工具细节
 
 - scripts 用 `tsx` 跑（node:fs/node:path only，不引 Bun API）；逻辑导出（parseArgs/autoBumpPatch/insertSection/validateReleaseVersion）供 vitest 套件——bump 分支/插入/validate 正反例全部提交进仓库（fixture 干跑不落仓 = 无保护）。
-- action pins：`checkout@v4` / `setup-node@v4` / `pnpm/action-setup@v4`（11.21.0）；release workflows 对齐 pnpm/action-setup → setup-node(cache: pnpm) 顺序。
+- action pins：`checkout@v4` / `setup-node@v4` / pnpm/action-setup@v4（11.21.0）；release workflows 对齐 pnpm/action-setup → setup-node(cache: pnpm) 顺序。
 - `git tag -a -m "release vX.Y.Z"`（git 2.55+ 无 message 拒绝 tag）。
 - 工作流权限：release-prep `contents: write, pull-requests: write`；release `contents: write, id-token: write`；无 `NPM_TOKEN`。
 
@@ -77,4 +77,4 @@ dsh-llm-fallbacks 建立 npm 发布流水线（单包），参考 mstar-harness 
 
 ## Examples
 
-本仓库：`.github/workflows/release-prep.yml` + `release.yml` + `scripts/prepare-release.ts` + `scripts/validate-release-version.ts` + `tests/release-scripts.spec.ts` + `docs/release.md`（SOP 含 Trusted Publishing 前置清单）。
+本仓库：`.github/workflows/release-prep.yml` + `.github/workflows/release.yml` + `scripts/prepare-release.ts` + `scripts/validate-release-version.ts` + `tests/release-scripts.spec.ts` + `docs/release.md`（SOP 含 Trusted Publishing 前置清单）。

--- a/.mstar/knowledge/build-errors/css-modules-hash-invalid-selector.md
+++ b/.mstar/knowledge/build-errors/css-modules-hash-invalid-selector.md
@@ -4,11 +4,22 @@ date: 2026-08-11
 problem_type: build_error
 category: build-errors
 severity: high
-symptoms: ["Fallbacks 设置页约 60% 样式从未渲染（标题/开关/字段标签/hint/chevron 丢失）", "页面呈现无层级、无间距的裸控件堆叠", "代码级 diff 审查与单元测试全部通过，视觉验收仍失败", "注入 <style> 文本 57 条规则，浏览器 sheet.cssRules 仅 20 条生效（≈35%）"]
+symptoms:
+  - Fallbacks 设置页约 60% 样式从未渲染（标题/开关/字段标签/hint/chevron 丢失）
+  - 页面呈现无层级、无间距的裸控件堆叠
+  - 代码级 diff 审查与单元测试全部通过，视觉验收仍失败
+  - 注入 <style> 文本 57 条规则，浏览器 sheet.cssRules 仅 20 条生效（≈35%）
 root_cause: CSS Modules 哈希类名以数字开头（FNV-1a `8hex_local` → `.8b697c55_fieldRow`）是非法 CSS 标识符，浏览器按 CSS 规范静默丢弃整条规则；10/16 概率数字开头，导致大部分样式从未解析。
 resolution_type: code_fix
 plan_id: llm-fallbacks-settings-style
-tags: [css-modules, hash, invalid-identifier, selector, build-client, cssom, contract-assertion]
+tags:
+  - css-modules
+  - hash
+  - invalid-identifier
+  - selector
+  - build-client
+  - cssom
+  - contract-assertion
 ---
 
 # CSS Modules 哈希类名数字开头 → 浏览器静默丢弃样式规则
@@ -22,8 +33,8 @@ tags: [css-modules, hash, invalid-identifier, selector, build-client, cssom, con
 
 ## Symptoms
 
-- 注入 `<style data-plugin-css="dsh-llm-fallbacks/FallbacksSection.module.css">` 文本 57 条
-  规则，`sheet.cssRules` 仅 20 条（≈35%）
+- 注入 <style data-plugin-css="dsh-llm-fallbacks/FallbacksSection.module.css"> 文本 57 条
+  规则，sheet.cssRules 仅 20 条（≈35%）
 - 被丢弃的关键规则：`.title`、`.intro`、`.fieldLabel`、`.hint`、`.fieldRow`、`.switch`、
   `.optionRow input`、`.selectInput`（chevron）、`.iconButton`、`.banner`
 - 上一轮 polish 迭代（llm-fallbacks-settings-ux-polish）视觉验收失败，根因即此

--- a/.mstar/knowledge/build-errors/dsh-client-bundle-purity-gate.md
+++ b/.mstar/knowledge/build-errors/dsh-client-bundle-purity-gate.md
@@ -11,29 +11,36 @@ symptoms:
 root_cause: "deps.alwaysBundle 会把 CLIENT_EXTERNALS 之外的依赖全部内联——值导入的对等包根本不产生 require，旧的 require-only 文本断言（只匹配 require(\"@deepseek-ai/...\")）对「已内联的非法值导入」完全不可见；断言与内联路径错位。"
 resolution_type: code_fix
 plan_id: fallbacks-plugin-config-card
-tags: [client-bundle, purity, alwaysBundle, resolveId, externals, build-contract, mount-only]
+tags:
+  - client-bundle
+  - purity
+  - alwaysBundle
+  - resolveId
+  - externals
+  - build-contract
+  - mount-only
 ---
 
 # Client bundle purity：alwaysBundle 静默内联 → require-only 断言失明（94 kB 缺口）
 
 `scripts/build-client.ts` 的 purity 门曾只扫 `require(...)` 文本——但 rolldown 的
-`deps.alwaysBundle` 会把表外依赖**内联进产物**，值导入根本不产生 `require`。负向探针实证
+deps.alwaysBundle 会把表外依赖**内联进产物**，值导入根本不产生 `require`。负向探针实证
 缺口：故意值导入 3 个 type-only 对等包构建**成功**（94.37 kB 内联产物、零 require、
 旧断言通过）。修复 = resolveId 门 + 更严的 emitted-surface token 扫描。
 
 ## Problem
 
 client 半的 bundle purity 契约：浏览器可加载产物只能值导入冻结表 `CLIENT_EXTERNALS`
-（`PLATFORM_MODULES` 10 项 + `@deepseek-ai/dsh-client-runtime/client` 豁免）。旧断言
+（`PLATFORM_MODULES` 10 项 + @deepseek-ai/dsh-client-runtime/client 豁免）。旧断言
 `require\(\s*["'](@deepseek-ai\/[^"']+)` 只匹配**显式 require**——对 alwaysBundle
-内联的模块不可见：值导入 `@deepseek-ai/dsh-client-ui-plugin-config/client` 等对等包会被
+内联的模块不可见：值导入 @deepseek-ai/dsh-client-ui-plugin-config/client 等对等包会被
 **静默内联**（peer 自动外部化列表之外的全进 alwaysBundle），产物无 require 残留，断言
 照过。这正是 Task 4 引入新 type-only 对等包时的真实风险面。
 
 ## Symptoms
 
 - 负向探针（临时入口值导入 3 个新对等包）`pnpm build` **exit 0**，产物 94.37 kB、零
-  `require("@deepseek-ai/...")`——旧门无感。
+  require("@deepseek-ai/...")——旧门无感。
 - 修复后同探针 exit 1：`client bundle purity: value import of … is not in CLIENT_EXTERNALS`。
 - 门与内联路径错位：断言看「require 面」，内联走「模块图面」，两者对不上。
 
@@ -52,8 +59,8 @@ client 半的 bundle purity 契约：浏览器可加载产物只能值导入冻�
 2. **emitted-surface token 扫描升级**：`/@deepseek-ai\/[\w./-]+/g` 全 token 扫描，严格
    超集——现在能捕获内联模块（闭合 94 kB 缺口）与 peer 自动外部化 require
    （`dsh-client-locale` 等）。当前产物每个命中 token 都在表内。
-3. 表格与 plan 文档同步：`PLATFORM_MODULES` 10 项实测对齐 `web/src/platform.ts:8-15`
-   （补 `@deepseek-ai/dsh-client-ui-attachment`；`cordis` vs `@deepseek-ai/cordis` 双名
+3. 表格与 plan 文档同步：`PLATFORM_MODULES` 10 项实测对齐 `{HOST}/web/src/platform.ts:8-15`
+   （补 @deepseek-ai/dsh-client-ui-attachment；`cordis` vs @deepseek-ai/cordis 双名
    注记——shim 名与宿主名同表）。
 
 ```ts
@@ -81,10 +88,10 @@ verification-only——不改任何运行时值导入，产物面零变化。
 - 双道防线缺一不可：resolveId 门（面） + token 扫描（文本超集）。
 - 已知残余（roadmap，loud-failure 接受）：token 扫描是 text-agnostic——comment/string
   命中外包名会假阳性（当前靠产物干净）；split-literal specifier
-  （`'@deepseek-ai/' + 'dsh-client-ui-plugin-config'`）可同时绕过两层（非可分析 require，
+  （'@deepseek-ai/' + 'dsh-client-ui-plugin-config'）可同时绕过两层（非可分析 require，
   loader 期失败）；门只覆盖 `src/client/index.ts` 单入口——未来新增 client 入口需挂同
   插件。
 
 *Source: iteration iter-20260812-fallbacks-plugin-config plan `fallbacks-plugin-config-card`
-Task 4（`sdd/fallbacks-plugin-config-card/task-4-report.md` 负向探针 + qc 复核），
+Task 4（`.mstar/sdd/fallbacks-plugin-config-card/task-4-report.md` 负向探针 + qc 复核），
 2026-08-12 compound 提升。*

--- a/.mstar/knowledge/developer-experience/pnpm11-workspace-config-and-windows-link-farm.md
+++ b/.mstar/knowledge/developer-experience/pnpm11-workspace-config-and-windows-link-farm.md
@@ -11,17 +11,11 @@ tags:
   - pnpm
   - pnpm-workspace-yaml
   - npmrc
-  - node-linker
-  - allow-builds
   - peer-dependencies
   - prerelease
-  - semver
   - cordis
-  - junction
   - link-farm
   - windows
-  - userprofile
-  - dsh
 applies_when:
   - 任何 pnpm ≥ 10/11 仓库：非认证 pnpm 设置（autoInstallPeers/nodeLinker/allowBuilds）必须放 pnpm-workspace.yaml，.npmrc 只留 registry/auth
   - 对只发布 prerelease 版本的 @deepseek-ai/* 包声明 peerDependencies
@@ -34,11 +28,11 @@ applies_when:
 
 ## Context
 
-dsh-llm-fallbacks 按 dsh-advisor PR #11 沉淀的 `developer-experience/pnpm11-workspace-config-and-windows-link-farm.md`（commit `294aff1b`）对自身安装工具链做自检，发现 5 类问题并全部修复（commit `ac994ea`，21 files）。与 advisor 文档的关系：advisor 记录通用 pnpm-11/Windows 失败模式；本文记录 fallbacks 的修复实证，并新增两条 advisor 未覆盖的教训——**node-semver prerelease-tuple 规则**与 **cordis peer 必须 scoped 对齐**（用户明确要求对齐 advisor 的 `@deepseek-ai/cordis` 声明）。
+dsh-llm-fallbacks 按 dsh-advisor PR #11 沉淀的 `.mstar/knowledge/developer-experience/pnpm11-workspace-config-and-windows-link-farm.md`（commit `294aff1b`）对自身安装工具链做自检，发现 5 类问题并全部修复（commit `ac994ea`，21 files）。与 advisor 文档的关系：advisor 记录通用 pnpm-11/Windows 失败模式；本文记录 fallbacks 的修复实证，并新增两条 advisor 未覆盖的教训——**node-semver prerelease-tuple 规则**与 **cordis peer 必须 scoped 对齐**（用户明确要求对齐 advisor 的 @deepseek-ai/cordis 声明）。
 
 ## Guidance
 
-1. **pnpm 11+ 非认证设置只读 `pnpm-workspace.yaml`。** `autoInstallPeers` / `nodeLinker` / `allowBuilds` 留在 `.npmrc` 被**静默忽略**——这是最危险的失败模式：安装表面成功，实际违反设计不变量（私有 peer 永不来自 registry），布局约定丢失。三件套必须同放：
+1. **pnpm 11+ 非认证设置只读 `pnpm-workspace.yaml`。** `autoInstallPeers` / `nodeLinker` / `allowBuilds` 留在 .npmrc 被**静默忽略**——这是最危险的失败模式：安装表面成功，实际违反设计不变量（私有 peer 永不来自 registry），布局约定丢失。三件套必须同放：
 
 ```yaml
 # pnpm-workspace.yaml
@@ -49,44 +43,44 @@ allowBuilds:
   esbuild: true
 ```
 
-2. **`.npmrc` 只留 registry/auth。** 删除 `_authToken=${NPM_TOKEN}`：安装路径不从私有 registry 取包（peer 由 link farm 提供），token 是死配置，还让**每次** pnpm 调用报 `Failed to replace env in config: ${NPM_TOKEN}` WARN（实测症状）。
+2. **.npmrc 只留 registry/auth。** 删除 `_authToken=${NPM_TOKEN}`：安装路径不从私有 registry 取包（peer 由 link farm 提供），token 是死配置，还让**每次** pnpm 调用报 `Failed to replace env in config: ${NPM_TOKEN}` WARN（实测症状）。
 
 3. **peer range 必须带 prerelease tag。** 无 prerelease 的范围（`^0.0.1`）永不匹配 prerelease 版本（`0.0.1-rc.1`）。14 个 `@deepseek-ai/*` peer 全部改为 `^0.0.1-rc.1`（树内发布版本实测均为 `0.0.1-rc.1`）。这是 `autoInstallPeers` 意外开启时的最后防线。
 
 4. **node-semver prerelease-tuple 规则（本仓实证，advisor 未记录）。** `^4.0.0-rc.7` **不匹配** `4.0.1-rc.1`：带 prerelease 的 comparator 只接受同 `[major, minor, patch]` tuple 的 prerelease，不同 tuple 的 prerelease 候选被排除。范围必须精确到发布 tag——vendored cordis 为 `4.0.1-rc.1`，peer 必须写 `^4.0.1-rc.1`，不能想当然写 `^4.0.0-rc.7`（表面"同系列"）。
 
-5. **cordis peer 必须 scoped（用户裁决，对齐 advisor）。** 声明 `@deepseek-ai/cordis` 而非裸 `cordis`，连带四点：
-   - **shim 位置与名字**：`node_modules/@deepseek-ai/cordis`，package.json `name: '@deepseek-ai/cordis'`（vendored 只接受 `@deepseek-ai/cordis` 名；legacy 裸名不再支持）。
-   - **requiredPeers 豁免**：vendored cordis 声明 `bin` → `collectDeepseekPackages()` 跳过 → 不豁免会落入 missingPeers 报错。`filter(name => startsWith('@deepseek-ai/') && name !== '@deepseek-ai/cordis')`。
-   - **legacy 清理**：write 路径 `rmSync(node_modules/cordis)`（裸 shim 残留会让旧解析存活）；check 路径 `existsSync` 报错 `legacy node_modules/cordis shim present`。
-   - **import 全量迁移**：src/tests 全部 `from '@deepseek-ai/cordis'`；client externals 表删除裸 `'cordis'` 条目只留 scoped（死条目留在 frozen 表里是错误契约声明）。
+5. **cordis peer 必须 scoped（用户裁决，对齐 advisor）。** 声明 @deepseek-ai/cordis 而非裸 `cordis`，连带四点：
+   - **shim 位置与名字**：`node_modules/@deepseek-ai/cordis`，package.json name: '@deepseek-ai/cordis'（vendored 只接受 @deepseek-ai/cordis 名；legacy 裸名不再支持）。
+   - **requiredPeers 豁免**：vendored cordis 声明 `bin` → `collectDeepseekPackages()` 跳过 → 不豁免会落入 missingPeers 报错。filter(name => startsWith('@deepseek-ai/') && name !== '@deepseek-ai/cordis')。
+   - **legacy 清理**：write 路径 rmSync(node_modules/cordis)（裸 shim 残留会让旧解析存活）；check 路径 `existsSync` 报错 legacy node_modules/cordis shim present。
+   - **import 全量迁移**：src/tests 全部 from '@deepseek-ai/cordis'；client externals 表删除裸 `'cordis'` 条目只留 scoped（死条目留在 frozen 表里是错误契约声明）。
 
-6. **Windows link farm：按目标选链接类型。** junction 仅限目录（无需特权），文件 symlink 需 Developer Mode/管理员 shell——cordis shim 的 `index.js`/`index.d.ts` 是文件条目，统一 junction 会得到坏链接。`statSync(target).isDirectory() ? 'junction' : 'file'`（statSync 失败回退 `'file'`）。`HOME` 在 Windows 不存在 → `process.env.HOME ?? process.env.USERPROFILE`。
+6. **Windows link farm：按目标选链接类型。** junction 仅限目录（无需特权），文件 symlink 需 Developer Mode/管理员 shell——cordis shim 的 index.js/index.d.ts 是文件条目，统一 junction 会得到坏链接。`statSync(target).isDirectory() ? 'junction' : 'file'`（statSync 失败回退 `'file'`）。`HOME` 在 Windows 不存在 → `process.env.HOME ?? process.env.USERPROFILE`。
 
 7. **shim 目录在 farm 目录内天然免疫 pruneStale。** shim 是真实目录（非 symlink），`readlinkSync` 失败 → `continue`（"not a symlink — never ours, never touched"）。把 shim 放进 `node_modules/@deepseek-ai/` 后无需改 prune 逻辑。
 
 ## Why This Matters
 
-第 1、3 条守护设计不变量（私有 peer 永不来自 registry）：`.npmrc` 静默忽略让不变量在"安装成功"的表面下被破坏，事后以错误模块身份/ERESOLVE 暴露。第 4 条是本仓独有的深坑——范围"看起来对"（同 4.x 系列）实际不匹配，且只在 pnpm 真正解析该 peer 时才显形。第 5 条是插件生态一致性：所有 dsh 插件对 cordis 的声明必须统一为 scoped 名，裸名 shim 与裸名 import 是迁移残留。第 6 条让 bundle 在用户实际运行 pnpm 11 的 Windows 上可安装。
+第 1、3 条守护设计不变量（私有 peer 永不来自 registry）：.npmrc 静默忽略让不变量在"安装成功"的表面下被破坏，事后以错误模块身份/ERESOLVE 暴露。第 4 条是本仓独有的深坑——范围"看起来对"（同 4.x 系列）实际不匹配，且只在 pnpm 真正解析该 peer 时才显形。第 5 条是插件生态一致性：所有 dsh 插件对 cordis 的声明必须统一为 scoped 名，裸名 shim 与裸名 import 是迁移残留。第 6 条让 bundle 在用户实际运行 pnpm 11 的 Windows 上可安装。
 
 ## When to Apply
 
 - 任何 pnpm ≥ 10/11 仓库：检查 pnpm 设置是否在 `pnpm-workspace.yaml`（pnpm ≥ 10.26 已接受 `allowBuilds`）。
 - 声明 peer 指向只发 prerelease 的包：范围必须带发布 tag，且 tuple 必须与发布版本一致（第 4 条）。
-- 新建/移植 dsh 插件 bundle：cordis peer、shim、import、externals 表全部用 `@deepseek-ai/cordis`；link farm 脚本用第 6、7 条的 Windows 安全写法。
+- 新建/移植 dsh 插件 bundle：cordis peer、shim、import、externals 表全部用 @deepseek-ai/cordis；link farm 脚本用第 6、7 条的 Windows 安全写法。
 - 升级 dsh 源码树 vendor/cordis 版本：同步 `package.json` peer range 到新版本 tag。
 
 ## Examples
 
 ### Before（broken）
 
-`.npmrc` 含 `_authToken=${NPM_TOKEN}`（每次 pnpm 调用 WARN）；`pnpm-workspace.yaml` 只有 `autoInstallPeers`；peers `^0.0.1` + `cordis: ^4.0.0-rc.7`；shim 发布裸名 `cordis` 位于 `node_modules/cordis`；`linkKind()` win32 全 junction；`process.env.HOME` 无回退。
+.npmrc 含 `_authToken=${NPM_TOKEN}`（每次 pnpm 调用 WARN）；`pnpm-workspace.yaml` 只有 `autoInstallPeers`；peers `^0.0.1` + `cordis: ^4.0.0-rc.7`；shim 发布裸名 `cordis` 位于 node_modules/cordis；`linkKind()` win32 全 junction；`process.env.HOME` 无回退。
 
 ### After（verified, pnpm 10.28.1 macOS）
 
-设置三件套进 `pnpm-workspace.yaml`；token 删除（pnpm 调用零 WARN）；14 个 peer `^0.0.1-rc.1` + `@deepseek-ai/cordis: ^4.0.1-rc.1`；shim 在 `node_modules/@deepseek-ai/cordis` 发布 scoped 名（入口 symlink 指向 vendored 文件）；`linkKind(target)` 按 statSync 分型 + try/catch；`HOME ?? USERPROFILE`。验证：fresh `pnpm install` → prepare 链接 215 包 + cordis shim → build 绿 → `dsh:link:check` ok → 319/319 tests 过。Windows 侧（junction/file、USERPROFILE）未实测——逻辑逐条对齐 advisor 已验证实现。
+设置三件套进 `pnpm-workspace.yaml`；token 删除（pnpm 调用零 WARN）；14 个 peer `^0.0.1-rc.1` + @deepseek-ai/cordis: ^4.0.1-rc.1；shim 在 `node_modules/@deepseek-ai/cordis` 发布 scoped 名（入口 symlink 指向 vendored 文件）；`linkKind(target)` 按 statSync 分型 + try/catch；`HOME ?? USERPROFILE`。验证：fresh `pnpm install` → prepare 链接 215 包 + cordis shim → build 绿 → `dsh:link:check` ok → 319/319 tests 过。Windows 侧（junction/file、USERPROFILE）未实测——逻辑逐条对齐 advisor 已验证实现。
 
 ### 相关
 
-- 上游：`dsh-external/dsh-advisor` `.mstar/knowledge/developer-experience/pnpm11-workspace-config-and-windows-link-farm.md`（通用失败模式）。
-- 本仓 link farm 设计：`best-practices/dsh-cordis-plugin-authoring.md`（real-code-linking、shim 动机、react 身份）。
+- 上游：dsh-external/dsh-advisor `.mstar/knowledge/developer-experience/pnpm11-workspace-config-and-windows-link-farm.md`（通用失败模式）。
+- 本仓 link farm 设计：`.mstar/knowledge/best-practices/dsh-cordis-plugin-authoring.md`（real-code-linking、shim 动机、react 身份）。


### PR DESCRIPTION
## What

`mstar compound validate` failed on 12/13 knowledge docs (228 violations: 8 frontmatter schema + 220 reference-existence flags). This migrates `.mstar/knowledge/` to the harness's documented corpus conventions so all 13 docs validate clean.

## Conventions applied (token-form only, no content/meaning changes)

- Real repo file refs → repo-root-resolvable paths (`switch-guard.ts` → `src/client/switch-guard.ts`, `cordis.patch.yml` → `bundle/cordis.patch.yml`, …)
- Cross-doc knowledge links → `.mstar/knowledge/<cat>/<doc>.md`; iteration/SDD process-artifact refs → `.mstar/iterations/…` / `.mstar/sdd/…` (verified on disk)
- Host (dsh-private) internal paths → `{HOST}/…` prefix (checker placeholder-skip shape; `:line` suffixes kept)
- Domain vocabulary (event/service/slot names), npm scoped packages, dotted symbols without a local module, and long inline code tokens → un-backticked to plain text
- Frontmatter fixes: `tags` → YAML **block** lists (≤8; pnpm11 doc trimmed 14→8), `symptoms` / `applies_when` → block lists
- `.mstar/knowledge/README.md`: added a "Corpus conventions" section to prevent regression

## Verification

- Engine re-check (`validateSchemaYaml` + `referenceExists` + `assertIndexRows`, all 13 docs): `TOTAL violations: 0`, `INDEX ok: true` (independently re-run by PM after implementation)
- `pnpm test`: 600/600 (knowledge markdown not part of build inputs)
- Diff reviewed: token/path-form edits only; no prose or code-sample content changed

Note: the engine's YAML-lite parser only accepts **block** list syntax for frontmatter lists — flow lists (`tags: [a, b]`) fail validation, hence block lists.