### PR TITLE
fix: revert-seed restores unsaved persona draft (issue #59)

### DIFF
--- a/.changes/unreleased/issue-59-revert-seed-draft.md
+++ b/.changes/unreleased/issue-59-revert-seed-draft.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+- Clicking "Restore default persona" on a seeded role now resets the in-card draft even when the saved value is already the seed default (issue #59).

--- a/src/client/FallbacksCard.tsx
+++ b/src/client/FallbacksCard.tsx
@@ -2048,15 +2048,16 @@ export function FallbacksCard({ controller, useSnapshot, t }: FallbacksCardProps
                                 size="sm"
                                 disabled={!writable || saving}
                                 onClick={() => {
-                                  // PR #62 UX round 3: the revert is a
-                                  // user-initiated NON-section write — the
-                                  // accepted config is the new truth, so the
-                                  // next config reseed must bypass the
-                                  // per-section dirty gates (the editor
-                                  // holds the pre-revert value and would
-                                  // otherwise look "dirty").
+                                  // Issue #59: revert must also snap the
+                                  // **draft** persona. The RPC no-ops when
+                                  // persisted already equals the seed, so
+                                  // the reseed effect never fires — apply
+                                  // the returned seed persona locally.
                                   forceReseed.current = true
-                                  void controller.revertSeed(row.id.trim())
+                                  void controller.revertSeed(row.id.trim()).then(persona => {
+                                    if (persona === undefined) return
+                                    updateRoleRow(index, { persona })
+                                  })
                                 }}
                               >
                                 {t('roles.revertPersona')}

--- a/src/client/fallbacks-store.ts
+++ b/src/client/fallbacks-store.ts
@@ -179,6 +179,17 @@ function parseSeedsWire(value: unknown): SeedsWireStatus[] {
   })
 }
 
+/** Seed-default persona from a revert-seed wire body (issue #59). */
+function revertOutcomePersona(value: unknown): string | undefined {
+  if (value === null || typeof value !== 'object' || !('outcome' in value)) return undefined
+  const outcome: unknown = value.outcome
+  if (outcome === null || typeof outcome !== 'object') return undefined
+  if (!('reverted' in outcome) || outcome.reverted !== true) return undefined
+  if (!('persona' in outcome) || typeof outcome.persona !== 'string') return undefined
+  return outcome.persona
+}
+
+
 /**
  * The provider dropdown's offer set (spec §2.5 D-4): catalog providers whose
  * settings profile resolves in the describe namespaces — the Models page's
@@ -1095,12 +1106,17 @@ export class FallbacksSettingsController {
    * reason }` outcome is still a successful RPC — the post-write read
    * result (config / legacyKeys / seeds) lands either way, and the revert
    * button stays disabled while the write is in flight.
+   *
+   * Returns the seed-default persona when the outcome is `{ reverted:
+   * true, persona }` — including the persist no-op (persisted already
+   * equals the seed). The card applies that string to the row's **draft**
+   * so an unsaved persona edit still snaps back (issue #59).
    * @param id - the seeded role id; the host matches it by trimmed id
    *   against the seed registry (spec §9.3).
    */
-  async revertSeed(id: string): Promise<void> {
+  async revertSeed(id: string): Promise<string | undefined> {
     const state = this.store.getSnapshot()
-    if (!state.writable || state.status === 'saving') return
+    if (!state.writable || state.status === 'saving') return undefined
     const generation = ++this.writeGeneration
     this.store.update((draft) => {
       draft.status = 'saving'
@@ -1108,7 +1124,7 @@ export class FallbacksSettingsController {
     })
     try {
       const result = await this.rpc.call('/api', 'fallbacks/revert-seed', { args: { id } })
-      if (generation !== this.writeGeneration) return
+      if (generation !== this.writeGeneration) return undefined
       if (!result.ok) throw result.error
       const value: unknown = result.value
       const config = value !== null && typeof value === 'object' && 'config' in value
@@ -1132,9 +1148,11 @@ export class FallbacksSettingsController {
         }
       }
       this.accept(config, true, legacyKeys, seeds)
+      return revertOutcomePersona(value)
     } catch (error) {
-      if (generation !== this.writeGeneration) return
+      if (generation !== this.writeGeneration) return undefined
       this.fail(error)
+      return undefined
     }
   }
 

--- a/tests/fallbacks-card.spec.tsx
+++ b/tests/fallbacks-card.spec.tsx
@@ -2368,6 +2368,33 @@ describe('FallbacksCard seeded roles (plan fallbacks-role-seeds T5)', () => {
     expect(scripted.revertSeed).toHaveBeenCalledTimes(1)
   })
 
+  it('revert snaps an unsaved persona draft back to the seed default (issue #59)', async () => {
+    // Persisted persona IS the seed default — gateway revert is a persist
+    // no-op. The button must still restore the in-card draft.
+    const { view, props, scripted } = await mountCard({
+      config: SEEDED_CONFIG,
+      seeds: [{ id: 'architect', overridden: false }],
+    })
+    toggleCard()
+    expandAllRoles()
+    view.rerender(<FallbacksCard {...props} />)
+    const personas = screen.getAllByLabelText(en['roles.persona']) as HTMLTextAreaElement[]
+    fireEvent.change(personas[0]!, { target: { value: 'Edited, not saved' } })
+    view.rerender(<FallbacksCard {...props} />)
+    expect(personas[0]!.value).toBe('Edited, not saved')
+    scripted.revertSeed.mockReturnValueOnce(okResult({
+      config: SEEDED_CONFIG,
+      seeds: [{ id: 'architect', overridden: false }],
+      outcome: { reverted: true, persona: 'Designs systems' },
+    }))
+    fireEvent.click(screen.getByRole('button', { name: en['roles.revertPersona'] }))
+    await waitFor(() => {
+      expect((screen.getAllByLabelText(en['roles.persona'])[0] as HTMLTextAreaElement).value).toBe('Designs systems')
+    })
+    expect(scripted.revertSeed).toHaveBeenCalledTimes(1)
+  })
+
+
   it('disables the revert affordance when the card cannot write or a write is in flight', async () => {
     // Read-only describe: the revert button is inert (the wrapping fieldset
     // also propagates disabled, but the button carries its own term).

--- a/tests/fallbacks-store.spec.ts
+++ b/tests/fallbacks-store.spec.ts
@@ -1217,7 +1217,7 @@ describe('FallbacksSettingsController', () => {
       seeds: [{ id: 'architect', overridden: false }],
       outcome: { reverted: true, persona: 'v1' },
     })))
-    await controller.revertSeed('architect')
+    await expect(controller.revertSeed('architect')).resolves.toBe('v1')
     expect(call).toHaveBeenLastCalledWith('/api', 'fallbacks/revert-seed', { args: { id: 'architect' } })
     expect(revertSeed).toHaveBeenCalledTimes(1)
     const state = controller.store.getSnapshot()
@@ -1226,6 +1226,25 @@ describe('FallbacksSettingsController', () => {
     expect(state.config.roles.list).toEqual([{ id: 'architect', persona: 'v1', chain: [], fallback: 'inherit-root' }])
     expect(state.seeds).toEqual([{ id: 'architect', overridden: false }])
   })
+
+  it('revertSeed returns the outcome persona even when persist is a no-op (issue #59)', async () => {
+    const alreadySeed = {
+      ...defaultFallbacksConfig,
+      roles: { list: [{ id: 'architect', persona: 'Designs systems' }], rules: [] },
+    }
+    const api = makeApi()
+    api.settings.describe.mockResolvedValue(ok({ writable: true, hasDocument: false, namespaces: [] }))
+    const { rpc, revertSeed } = makeRpc(alreadySeed)
+    const controller = new FallbacksSettingsController(api, rpc)
+    await controller.load()
+    revertSeed.mockReturnValueOnce(Promise.resolve(okResult({
+      config: alreadySeed,
+      seeds: [{ id: 'architect', overridden: false }],
+      outcome: { reverted: true, persona: 'Designs systems' },
+    })))
+    await expect(controller.revertSeed('architect')).resolves.toBe('Designs systems')
+  })
+
 
   it('a revert-seed response without seeds keeps the last badge state (W-1/F-1)', async () => {
     const api = makeApi()


### PR DESCRIPTION
Fixes #59.

**Bug:** On a seeded role whose *saved* persona is already the seed default, editing the persona (unsaved) and clicking Restore default persona did nothing. `revert-seed` short-circuits when persist already matches the seed; the card reseed key did not change, so the draft stayed edited.

**Fix:** `revertSeed` returns `outcome.persona` (including the persist no-op). The card applies that string to the row draft.

2215 tests + typecheck green.