### PR TITLE
fix(release): never reopen a closed release PR

### DIFF
--- a/.changes/unreleased/release-prep-no-reopen.md
+++ b/.changes/unreleased/release-prep-no-reopen.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+- Release prep no longer calls `gh pr reopen` on a closed release PR; it updates an open PR or creates a new one instead.

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -5,7 +5,7 @@ name: Release prep
 # (publish + tag + GitHub Release). No NPM_TOKEN / NODE_AUTH_TOKEN: npm auth
 # in the Release workflow is pure Trusted Publishing (OIDC; the npm-side
 # Trusted Publisher is configured — bootstrap token mode removed 2026-08-14).
-# The PR create/reopen/edit step uses the PAT secret because the omdsh-dev
+# The PR create/edit step uses the PAT secret because the omdsh-dev
 # org disables GITHUB_TOKEN's createPullRequest capability; everything else
 # uses only the built-in GITHUB_TOKEN.
 #
@@ -129,19 +129,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh label create release --color 0E8A16 --force
 
-      # State-aware PR handling. `gh pr view` also matches closed PRs, and
-      # `gh pr edit` silently keeps them closed — which would make a re-run
-      # after rollback (close PR -> re-run prep) look successful while
-      # leaving no open PR. Query state explicitly:
-      #   open PR   -> update it;
-      #   closed PR -> reopen it, then update the body;
-      #   none      -> create a new one.
-      # A closed PR is never edited in place.
+      # State-aware PR handling. Query open PRs explicitly:
+      #   open PR -> update title/body;
+      #   none    -> create a new PR (even when a closed PR exists for the
+      #              same head branch — never reopen a closed release PR).
       - name: Open or update release PR
         env:
           # The omdsh-dev org disables GITHUB_TOKEN's createPullRequest
           # capability ("Allow GitHub Actions to create and approve pull
-          # requests" is off), so PR create/reopen/edit runs under the
+          # requests" is off), so PR create/edit runs under the
           # PAT secret (user identity) instead of the built-in token.
           GH_TOKEN: ${{ secrets.PAT }}
           VERSION: ${{ steps.ver.outputs.version }}
@@ -162,16 +158,6 @@ jobs:
           if [ -n "$OPEN_NUM" ]; then
             gh pr edit "$OPEN_NUM" --title "$TITLE" --body-file /tmp/pr-body.md
             echo "Updated existing open release PR #${OPEN_NUM} for $BRANCH"
-            exit 0
-          fi
-
-          CLOSED_NUM="$(gh pr list --head "$BRANCH" --state closed --json number -q '.[0].number' 2>/dev/null || true)"
-          if [ -n "$CLOSED_NUM" ]; then
-            # Reopen first: `gh pr reopen` fails loudly on a merged PR instead
-            # of silently leaving the release blocked.
-            gh pr reopen "$CLOSED_NUM"
-            gh pr edit "$CLOSED_NUM" --title "$TITLE" --body-file /tmp/pr-body.md
-            echo "Reopened release PR #${CLOSED_NUM} for $BRANCH"
           else
             gh pr create --base main --head "$BRANCH" --title "$TITLE" \
               --body-file /tmp/pr-body.md --label release

--- a/.mstar/knowledge/best-practices/npm-release-pipeline.md
+++ b/.mstar/knowledge/best-practices/npm-release-pipeline.md
@@ -52,7 +52,7 @@ dsh-llm-fallbacks 建立 npm 发布流水线（单包），参考 mstar-harness 
 
 ### 坑 4：流水线重跑/版本一致性防护
 
-- **closed-PR 重跑**：`gh pr view $BRANCH` 会匹配已关闭 PR（`gh pr edit` 不 reopen）→ 静默死路。门控必须 state-aware：`gh pr list --head $BRANCH --state open` → open 则 edit；closed 则 `gh pr reopen` 再 edit；无则 create。
+- **closed-PR 重跑**：`gh pr view $BRANCH` 会匹配已关闭 PR（`gh pr edit` 不 reopen）→ 静默死路。门控必须 state-aware：`gh pr list --head $BRANCH --state open` → open 则 edit；无 open PR 则 `gh pr create`（**永不** `gh pr reopen` 已关闭的 release PR，merged 或 closed-unmerged 同理）。
 - **PR title 版本交叉校验**：release.yml 从 title 后缀推导期望版本 vs package.json version，mismatch → fail（防手工改分支导致的标题/版本脱钩）；changelog 提取空文件 → fail。
 - **reject 已存在 tag**：release-prep 前置 `git rev-parse v$V` 拒绝 + validate 双保险。
 - **publish 先于 tag**：发布失败不会产生坏 tag；tag push 不会重复触发 CI（push filter 只 main）。

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,7 +72,7 @@ The workflow then runs, in order:
 3. `pnpm release:validate -- v<v>`: package.json version matches the tag + the tag does not already exist (belt and suspenders).
 4. `pnpm build` smoke test.
 5. Commits `chore(release): prepare v<v>` to the `release/v<v>` branch and pushes (force-with-lease).
-6. Opens the PR `release v<v>` (base `main`, label `release`); **updates it if an open PR already exists**, **reopens then updates a closed PR if one exists**, and only creates a new PR when neither exists.
+6. Opens the PR `release v<v>` (base `main`, label `release`); **updates it if an open PR already exists**, otherwise **creates a new PR** (including when a closed PR exists for the same head branch — closed release PRs are never reopened).
 
 ### 3. Review the release PR
 
@@ -121,7 +121,7 @@ Each fragment focuses on one user-visible change.
 
 ## Rollback / re-run
 
-- **PR stage (not merged)**: wrong version or content → simply **close the PR**, or **re-run Release prep**. Re-running is idempotent: re-running with the same version regenerates the `release/v<v>` branch (force-with-lease push) and handles the PR — **updates it if an open PR exists**; **reopens the PR with `gh pr reopen` and updates the body if a closed PR exists**; creates a new one only when neither exists. **A closed PR is never edited in place** (that would silently stall the release).
+- **PR stage (not merged)**: wrong version or content → simply **close the PR**, or **re-run Release prep**. Re-running is idempotent: re-running with the same version regenerates the `release/v<v>` branch (force-with-lease push) and handles the PR — **updates it if an open PR exists**; **creates a new PR if none is open** (a previously closed release PR stays closed and is never reopened).
 - **Failed mid-publish after merge**: if `npm publish` succeeded but the tag / GitHub Release steps failed — **do not re-run the Release workflow directly**: `npm publish` would fail because the version already exists on the registry. Fixes:
   - manually add the tag and Release: `git tag -a -m "release v<v>" v<v> && git push origin v<v>`, then create the GitHub Release manually from the changelog section; or
   - fix-forward: go straight to the next version (see below).


### PR DESCRIPTION
## Summary

- Release prep edits an open `release v*` PR or creates a new one; it no longer calls `gh pr reopen` when a closed PR exists for the same head branch.
- `docs/release.md` and npm-release-pipeline knowledge (坑 4) updated to match.
- Changelog fragment: `.changes/unreleased/release-prep-no-reopen.md`.

## Context

Run https://github.com/omdsh-dev/dsh-llm-fallbacks/actions/runs/32113923726/job/95639461717 failed after assembling v0.3.0 because `gh pr reopen` on closed #66 returned `Could not open the pull request. (reopenPullRequest)`.

## Test plan

- [x] `git grep -n 'gh pr reopen'` empty under `.github/`
- [x] `docs/release.md` no longer instructs reopening a closed release PR
- [x] Knowledge 坑 4: closed → create new PR
- [x] Changelog fragment present
- [x] PR #66 remains `CLOSED` (not reopened)