### PR TITLE
fix(selectors): support model ids containing slashes (NVIDIA NIM etc.)

### DIFF
--- a/.changes/unreleased/selector-multislash-models.md
+++ b/.changes/unreleased/selector-multislash-models.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+- Support selectors whose model id contains `/` (e.g. NVIDIA NIM `nvidia/minimaxai/minimax-m3`), previously rejected as an "extra separator".

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,14 +85,14 @@ The plugin ships **7 bundled omp-style preset roles** — generic subagent roles
 
 **Chain entries** (the values of `roles.list[].chain` / `timeSlots[].chain`, ordered; the all-day `rootChain` is a single-entry list — exactly one official V4 model):
 
-- `provider/model` — exact switch: switch to the specified model;
+- `provider/model` — exact switch: switch to the specified model; the model id may itself contain `/` (e.g. NVIDIA NIM `nvidia/minimaxai/minimax-m3` or Hugging Face `org/repo`-style names);
 - `provider/*` — keep the failed model id and switch the provider only; when the target provider lacks this model id the candidate is skipped (fuzzy near-match resolution is out of scope for this iteration).
 
 > **The chain-key namespace is removed**: the three key semantics of the old `chains` key (`provider/model` exact, `provider/*` wildcard, role-name keys) no longer exist — model-specific routing on failure is now approximated by `roles.rules` (matching to a role by provider/model pattern), and role membership is expressed by declared entities. The entry-side `provider/*` wildcard stays a valid YAML entry everywhere (role chains and `timeSlots[].chain`); the settings GUI no longer offers a wildcard checkbox in any chain editor (role and time-slot chains alike) — chains are edited as provider/model lines, a hand-written `provider/*` entry reads back with a conversion hint and becomes an exact entry once a model is picked, and provider-any matching is expressed through…
 
 Whitespace padding: whitespace padding in a selector (e.g. `other/ gpt-4o`) is **preserved as-is** on save (the GUI does not rewrite user input); runtime parsing normalizes it (`parseSelector` tolerates whitespace), so the semantics are identical to the unpadded form.
 
-Invalid/unknown entries (missing separator, empty segment, extra separator, etc.) warn at save validation and **block the save** (card) or warn at startup (validation function); they never crash and never take effect. In a running dsh environment (with a model-catalog service) `*/*` never matches — the target provider has no `*` model catalog, so the existence probe skips that candidate.
+Invalid/unknown entries (missing separator, empty segment, wildcard inside a model id, etc.) warn at save validation and **block the save** (card) or warn at startup (validation function); they never crash and never take effect. `*` is only valid as the entire model segment (the `provider/*` wildcard) and is rejected inside a model id. In a running dsh environment (with a model-catalog service) `*/*` never matches — the target provider has no `*` model catalog, so the existence probe skips that candidate.
 
 ## Role resolution and chain composition
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,8 +1,10 @@
 /**
  * Selector parsing for `fallbacks` chains (spec §4, plan Task 2).
  *
- * Grammar: `provider/model` (exact) and `provider/*` (wildcard — the parsed
- * `model` is `undefined`). Illegal selectors throw {@link SelectorError} —
+ * Grammar: `provider/model` (exact — the model segment may itself contain
+ * `/`, e.g. NVIDIA NIM `nvidia/minimaxai/minimax-m3`) and `provider/*`
+ * (wildcard — the parsed `model` is `undefined`; `*` is only valid as the
+ * entire model segment). Illegal selectors throw {@link SelectorError} —
  * the catchable "config warning" path; warn-and-continue lives in Task 3.
  * These modules never crash on their own.
  *
@@ -34,7 +36,8 @@ export function selectorKey(provider: string, model?: string): string {
  * Parse a chain key or entry selector.
  *
  * Accepts `provider/model` and `provider/*`; throws {@link SelectorError}
- * on anything else (missing separator, empty parts, extra separators).
+ * on anything else (missing separator, empty parts, wildcard inside the
+ * model segment).
  */
 export function parseSelector(input: string): Selector {
   if (typeof input !== 'string') {
@@ -53,8 +56,10 @@ export function parseSelector(input: string): Selector {
   if (!provider || !modelPart) {
     throw new SelectorError(`invalid selector "${input}": empty provider or model`)
   }
-  if (modelPart.includes('/')) {
-    throw new SelectorError(`invalid selector "${input}": unexpected extra separator`)
+  // `*` is only valid as the entire model segment (the `provider/*`
+  // wildcard); inside a model id it would blur the wildcard grammar.
+  if (modelPart !== '*' && modelPart.includes('*')) {
+    throw new SelectorError(`invalid selector "${input}": unexpected wildcard in model`)
   }
   const model = modelPart === '*' ? undefined : modelPart
   return { provider, model, raw: trimmed }

--- a/tests/chains.spec.ts
+++ b/tests/chains.spec.ts
@@ -78,6 +78,21 @@ describe('resolveChain — concatenation semantics (spec §7.2)', () => {
     })
   })
 
+  it('keeps a multi-slash model id entry as an exact candidate (regression pin, issue #74)', () => {
+    // Downstream chain matching treats the model id as an opaque string:
+    // a multi-slash model id must resolve as an exact candidate with the
+    // raw entry preserved, and must not be existence-filtered as an exact
+    // entry (only provider/*-origin candidates consult modelExists).
+    const roles = [role('coder', { chain: ['nvidia/minimaxai/minimax-m3'] })]
+    const candidates = resolveChain(roles, [], 'coder', 'openai', 'gpt-4o', undefined, () => false)
+    expect(candidates.map((c) => c.raw)).toEqual(['nvidia/minimaxai/minimax-m3'])
+    expect(candidates[0]).toEqual({
+      provider: 'nvidia',
+      model: 'minimaxai/minimax-m3',
+      raw: 'nvidia/minimaxai/minimax-m3',
+    })
+  })
+
   it('skips malformed entries without throwing (they do not take effect)', () => {
     const roles = [role('coder', { chain: ['bogus', 'provider/', 'openai/gpt-4o', ''] })]
     expect(resolveChain(roles, rootChain, 'coder', 'openai', 'gpt-4o').map((c) => c.raw)).toEqual([

--- a/tests/selectors.spec.ts
+++ b/tests/selectors.spec.ts
@@ -80,7 +80,9 @@ describe('parseSelector', () => {
   it('throws SelectorError when the model segment contains a wildcard', () => {
     // `provider/*` is the only legal wildcard form; `*` inside a model id
     // (e.g. after a slash, or embedded) would blur the wildcard grammar.
-    expect(() => parseSelector('provider/*/x')).toThrow(SelectorError)
+    for (const bad of ['provider/*/x', 'openai/gpt*', 'openai/*x']) {
+      expect(() => parseSelector(bad), `selector ${JSON.stringify(bad)}`).toThrow(SelectorError)
+    }
   })
 
   it('exposes a catchable error type for the config-warning path', () => {

--- a/tests/selectors.spec.ts
+++ b/tests/selectors.spec.ts
@@ -31,6 +31,14 @@ describe('parseSelector', () => {
     })
   })
 
+  it('parses a multi-slash model id (e.g. NVIDIA NIM, issue #74)', () => {
+    expect(parseSelector('nvidia/minimaxai/minimax-m3')).toEqual({
+      provider: 'nvidia',
+      model: 'minimaxai/minimax-m3',
+      raw: 'nvidia/minimaxai/minimax-m3',
+    })
+  })
+
   it('trims surrounding whitespace but keeps the canonical raw string', () => {
     expect(parseSelector('  openai/gpt-4o  ')).toEqual({
       provider: 'openai',
@@ -69,8 +77,9 @@ describe('parseSelector', () => {
     }
   })
 
-  it('throws SelectorError on extra separators', () => {
-    expect(() => parseSelector('provider/model/extra')).toThrow(SelectorError)
+  it('throws SelectorError when the model segment contains a wildcard', () => {
+    // `provider/*` is the only legal wildcard form; `*` inside a model id
+    // (e.g. after a slash, or embedded) would blur the wildcard grammar.
     expect(() => parseSelector('provider/*/x')).toThrow(SelectorError)
   })
 
@@ -93,6 +102,10 @@ describe('selectorKey', () => {
 
   it('builds the wildcard key when the model is missing', () => {
     expect(selectorKey('openai')).toBe('openai/*')
+  })
+
+  it('builds the canonical key for a multi-slash model id', () => {
+    expect(selectorKey('nvidia', 'minimaxai/minimax-m3')).toBe('nvidia/minimaxai/minimax-m3')
   })
 })
 


### PR DESCRIPTION
Fixes #74.

## Problem

Config validation rejected selectors whose model id contains `/` — NVIDIA NIM `nvidia/minimaxai/minimax-m3` failed with `invalid selector "nvidia/minimaxai/minimax-m3": unexpected extra separator`, so such providers could not be used in fallback chains.

## Root cause

`src/selectors.ts` `parseSelector` splits at the first `/` (unambiguous), but then explicitly rejected `modelPart.includes('/')`.

## Change

- `src/selectors.ts`: remove the `includes('/')` rejection; `*` remains legal only as the entire model segment (wildcard) — `provider/*/x` and embedded-`*` model ids still throw.
- `tests/selectors.spec.ts`: pin multi-slash parsing (`nvidia/minimaxai/minimax-m3`), `selectorKey` with a multi-slash model, and wildcard-in-model rejection (slash-following + embedded shapes).
- `tests/chains.spec.ts`: regression pin — a multi-slash exact chain entry resolves as an exact candidate (not existence-filtered), locking in that downstream chain matching treats model as an opaque string.
- `docs/configuration.md` + `.changes/unreleased/selector-multislash-models.md` (Fixed).

## Semantic change (intended, documented)

`provider/model/extra` is now a valid concrete selector (model = `model/extra`) instead of throwing. `provider/*` wildcard semantics are unchanged.

## Verification

- `pnpm test`: 108 files / 2291 tests passed
- `pnpm build`: host + client + verify-dist OK
- `pnpm typecheck`: clean
- QC single-seat review: Approve (0 Critical / 0 Warning), zero-residual