### PR TITLE
fix(client): register the settings.plugin.item card with id alongside key

### DIFF
--- a/.changes/unreleased/fix-plugin-item-slot-id.md
+++ b/.changes/unreleased/fix-plugin-item-slot-id.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+- Register the `settings.plugin.item` card with `id` alongside `key` so it mounts on dsh hosts that still declare the slot as a list (pre-rc.7) instead of failing with `list slot "settings.plugin.item" requires options.id`.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -12,8 +12,10 @@
  *   `/api/fallbacks/get|set|reset`), while `settings.describe` (writable +
  *   namespace directory) and the provider/model catalog stay on
  *   `connection.api` (see `fallbacks-store.ts`).
- * - Registers the `settings.plugin.item` card `key: 'fallbacks'` (the rc.7
- *   keyed slot — no `id`/`order`) with a business-only inject face
+ * - Registers the `settings.plugin.item` card `key: 'fallbacks'` with a
+ *   matching `id: 'fallbacks'` (the rc.7 keyed slot — no `order`; the id
+ *   keeps the card mountable on hosts that still declare the slot as a list,
+ *   which requires `options.id`) with a business-only inject face
  *   ({@link FallbacksSettingsController} + the snapshot-selector hook); the
  *   old Settings-nav section registration is removed — deleting the section
  *   registration deletes the nav entry.
@@ -200,14 +202,25 @@ export function apply(ctx: ClientContext): void {
   // registration (the "Fallbacks" nav entry) is removed — deleting the
   // section registration deletes the nav entry. rc.7 made the slot keyed:
   // `key` is the settings namespace the card edits, and the card renders in
-  // registration order — the old list-slot `id`/`order` options are gone.
+  // registration order. Pre-rc.7 hosts still declare `settings.plugin.item`
+  // as a list slot, whose loader requires `options.id` — passing `id`
+  // alongside `key` keeps the card mountable on both slot kinds (the keyed
+  // loader ignores the extra id).
   ctx.slots.inject('settings.plugin.item', function* () {
-    yield ctx.slots.register({
+    const cardOptions = {
       name: 'settings.plugin.item',
       key: 'fallbacks', // the settings namespace the card edits
+      id: 'fallbacks', // pre-rc.7 list-slot hosts require options.id
       locale: NS,
       inject: () => ({ controller, useSnapshot }),
-    }, FallbacksCard)
+    }
+    // The rc.7+ slot-contract types this half compiles against declare the
+    // slot keyed (no `id` in the options literal type); pre-rc.7 hosts
+    // declare it as a list slot whose loader throws without `options.id`.
+    // Both fields are passed — the keyed loader ignores the extra `id` — so
+    // the cast only widens the literal past the rc.7 contract, never past
+    // the runtime shape either host accepts.
+    yield ctx.slots.register(cardOptions as never, FallbacksCard)
   })
 
   // The General settings page status row (plan fallbacks-aux-seams T1): a

--- a/tests/client-slot-registration.spec.ts
+++ b/tests/client-slot-registration.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression: the `settings.plugin.item` card must register with BOTH the
+ * `key` (rc.7+ keyed-slot hosts) and `id` (pre-rc.7 list-slot hosts whose
+ * loader throws "list slot ... requires options.id"). Without the id, the
+ * card fails to load on pre-rc.7 dsh hosts and the plugin reports a loader
+ * entry failure.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import { apply as applyClient } from '../src/client/index.ts'
+
+let ctx: Context
+
+beforeEach(() => {
+  ctx = new Context()
+  // ConversationEvents service double: apply() registers the
+  // `fallbacks-switch` node Definition through it.
+  ctx.provide('conversationEvents', { register: () => () => {}, registerFallback: () => () => {} })
+  // Locale service double: register + bind (bind returns a translate thunk).
+  ctx.provide('locale', { register: () => () => {}, bind: () => () => '' })
+  // Sessions service double: no current session.
+  ctx.provide('sessions', {
+    list: { getSnapshot: () => ({ current: undefined }), subscribe: () => () => {} },
+  })
+  ctx.provide('connection', {
+    api: {
+      settings: { describe: vi.fn(), update: vi.fn(), replace: vi.fn(), mutate: vi.fn() },
+      llm: { providers: vi.fn(), models: vi.fn(), discoverModels: vi.fn() },
+      sessions: { history: vi.fn() },
+    },
+    rpc: { call: vi.fn() },
+  })
+  ctx.provide('remote', { $on: () => () => {} })
+})
+
+afterEach(async () => {
+  await ctx.fiber.dispose()
+})
+
+describe('client slot registration', () => {
+  it('registers the settings.plugin.item card with both key and id', () => {
+    const registered: Array<{ name: string; key?: string; id?: string }> = []
+    ctx.provide('slots', {
+      inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },
+      register: (options: { name: string; key?: string; id?: string }) => {
+        registered.push(options)
+        return {}
+      },
+    })
+    applyClient(ctx as unknown as ClientContext)
+    const card = registered.find((entry) => entry.name === 'settings.plugin.item')
+    expect(card).toBeDefined()
+    expect(card!.key).toBe('fallbacks')
+    expect(card!.id).toBe('fallbacks')
+  })
+})

--- a/tests/conversation-switch.spec.tsx
+++ b/tests/conversation-switch.spec.tsx
@@ -303,13 +303,14 @@ describe('conversation switch registration (D1 definition + D2 keyed seat)', () 
     expect(nodes[0].options.locale).toBe('fallbacks')
     expect(nodes[0].component).toBe(ConversationFallbackSwitch)
 
-    // The two settings registrations are untouched: plugin.item is the rc.7
-    // keyed slot (key only — the old list-slot id/order are absent),
+    // The two settings registrations are untouched: plugin.item carries the
+    // rc.7 keyed-slot `key` alongside the list-slot `id` (pre-rc.7 hosts
+    // require options.id; the keyed loader ignores the extra id), and
     // general.item keeps the list shape.
     const cards = slotsLedger['settings.plugin.item'] ?? []
     expect(cards).toHaveLength(1)
     expect(cards[0].options.key).toBe('fallbacks')
-    expect(cards[0].options).not.toHaveProperty('id')
+    expect(cards[0].options.id).toBe('fallbacks')
     expect(cards[0].options).not.toHaveProperty('order')
     const rows = slotsLedger['settings.general.item'] ?? []
     expect(rows).toHaveLength(1)

--- a/tests/fallbacks-card.spec.tsx
+++ b/tests/fallbacks-card.spec.tsx
@@ -571,9 +571,11 @@ describe('FallbacksCard registration (settings.plugin.item)', () => {
     const cards = ledger['settings.plugin.item'] ?? []
     expect(cards).toHaveLength(1)
     // rc.7 keyed slot: `key` is the settings namespace the card edits; the
-    // old list-slot `id` / `order` options must be absent.
+    // list-slot `id` rides along so pre-rc.7 hosts (which declare the slot
+    // as a list and require options.id) can mount the card — the keyed
+    // loader ignores the extra id.
     expect(cards[0].options.key).toBe('fallbacks')
-    expect(cards[0].options).not.toHaveProperty('id')
+    expect(cards[0].options.id).toBe('fallbacks')
     expect(cards[0].options).not.toHaveProperty('order')
     expect(cards[0].options.locale).toBe('fallbacks')
     // No nav-label thunk survives from the removed section registration.

--- a/tests/general-row.spec.tsx
+++ b/tests/general-row.spec.tsx
@@ -264,12 +264,13 @@ describe('GeneralFallbacksRow registration (settings.general.item)', () => {
     expect(typeof face.useSnapshot).toBe('function')
     expect(face).not.toHaveProperty('t')
 
-    // The plugin-config card registration is untouched (rc.7 keyed slot:
-    // key only — the old list-slot id/order are absent).
+    // The plugin-config card registration is untouched (rc.7 keyed-slot `key`
+    // alongside the list-slot `id` — pre-rc.7 hosts require options.id, the
+    // keyed loader ignores the extra id).
     const cards = ledger['settings.plugin.item'] ?? []
     expect(cards).toHaveLength(1)
     expect(cards[0].options.key).toBe('fallbacks')
-    expect(cards[0].options).not.toHaveProperty('id')
+    expect(cards[0].options.id).toBe('fallbacks')
     expect(cards[0].options).not.toHaveProperty('order')
 
     // The dictionary namespace registers with the en/zh pair.


### PR DESCRIPTION
## Problem

On dsh hosts at `0.1.0-rc.6` (and any host that still declares `settings.plugin.item` as a **list** slot), loading this plugin fails at startup:

```
Failed to load plugins
dsh-llm-fallbacks
failed to apply loader entry 758c51bc (dsh-llm-fallbacks): list slot "settings.plugin.item" requires options.id
```

Root cause: the card registers into `settings.plugin.item` with `key: 'fallbacks'` only. The slots runtime validates registrations against the slot's declared kind — `dsh-client-ui-slots/lib/index.js` throws `list slot "..." requires options.id` when the slot is declared as a list and `id` is missing. The rc.7+ snapshot moved this slot to **keyed** (hence the current key-only shape), but pre-rc.7 hosts are still in the wild (e.g. the `dsh web` profile of a host pinned to rc.6), and on those the whole plugin fails to mount — no fallbacks card, no settings row, no conversation switch.

## Fix

Pass `id: 'fallbacks'` **alongside** `key: 'fallbacks'`:

- keyed-slot loaders (rc.7+) require `key` and ignore the extra `id` — unchanged behaviour there;
- list-slot loaders (pre-rc.7) require `id` and ignore the extra `key` — the card now mounts.

The rc.7+ slot-contract types don't carry `id` in the options literal type, so the object is widened with a documented cast (`as never`) — the runtime shape is exactly what both host kinds accept.

## Changes

- `src/client/index.ts` — register with `key` + `id`, comments updated.
- `tests/client-slot-registration.spec.ts` — new regression pinning the `key`/`id` shape.
- `tests/fallbacks-card.spec.tsx`, `tests/general-row.spec.tsx`, `tests/conversation-switch.spec.tsx` — the three tests that asserted `id` must be **absent** now assert it must be present (they encoded the bug).
- `.changes/unreleased/fix-plugin-item-slot-id.md` — changelog fragment.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 918 passed (41 files)
- Full build (`tsc` → `tsdown` → `build-client` → `verify-dist`) — clean
- Manually verified on a real rc.6 host: the "list slot requires options.id" loader failure disappears after this change.

## Alternative for maintainers

If the support matrix is strictly rc.7+, the alternative is rejecting this and pointing rc.6 users at upgrading the host — but the one-field compat fix is zero-cost and keeps the card mountable on both.