### PR TITLE
fix: publish prereleases under their channel dist-tag instead of latest

### DIFF
--- a/.changes/unreleased/prerelease-dist-tags.md
+++ b/.changes/unreleased/prerelease-dist-tags.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+- Prereleases now publish to npm under their channel dist-tag (e.g. `alpha`) instead of `latest`; `latest` stays on the newest stable release.
+- Install a prerelease line via its channel tag, e.g. `npm i dsh-llm-fallbacks@alpha`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,39 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # `--tag latest`: npm >= 11 (bundled with Node 24) hard-throws when
-      # publishing a prerelease without an explicit --tag. The first release
-      # (0.1.0-alpha.2) lands on the default `latest` dist-tag so
-      # `npm i dsh-llm-fallbacks` resolves; a later stable 0.1.0 takes over
-      # `latest` naturally.
+      # The npm dist-tag is the channel signal and is derived from the
+      # version: stable `X.Y.Z` publishes under `latest`; prerelease
+      # `X.Y.Z-<channel>.N` publishes under `<channel>` (the identifier
+      # before the first dot, e.g. `0.4.0-alpha.1` -> `alpha`,
+      # `1.0.0-rc.1` -> `rc`), so a prerelease never steals `latest` from
+      # the newest stable. The `next` tag is not used.
+      - name: Resolve npm dist-tag
+        id: disttag
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          case "$VERSION" in
+            *-*)
+              # Prerelease: the channel is the part of the prerelease
+              # identifier before the first dot.
+              TAG="${VERSION#*-}"
+              TAG="${TAG%%.*}"
+              ;;
+            *)
+              TAG="latest"
+              ;;
+          esac
+          if [ -z "$TAG" ]; then
+            echo "::error::Could not derive an npm dist-tag from version \"${VERSION}\"."
+            exit 1
+          fi
+          echo "Resolved npm dist-tag: ${TAG} (version ${VERSION})"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      # `--tag "$TAG"`: npm >= 11 (bundled with Node 24) hard-throws when
+      # publishing a prerelease without an explicit --tag. The tag always
+      # comes from the "Resolve npm dist-tag" step above.
       #
       # Pure OIDC (Trusted Publishing): no NODE_AUTH_TOKEN/NPM_TOKEN anywhere.
       # npm exchanges the GitHub OIDC id-token (setup-node registry-url +
@@ -104,7 +132,9 @@ jobs:
       # Publisher entry; the first-publish bootstrap token mode was removed
       # on 2026-08-14 after the npm-side publisher was configured.
       - name: Publish to npm
-        run: npm publish --provenance --access public --tag latest
+        env:
+          TAG: ${{ steps.disttag.outputs.tag }}
+        run: npm publish --provenance --access public --tag "$TAG"
 
       - name: Configure git identity
         run: |
@@ -153,7 +183,8 @@ jobs:
           body_path: ${{ steps.changelog.outputs.notes_file }}
           draft: false
           # User decision (2026-08-14): alpha versions publish as regular
-          # GitHub Releases (no Pre-release marker) — the npm dist-tag
-          # (`latest`) is the real channel signal; the GitHub Release is the
-          # visible record.
+          # GitHub Releases (no Pre-release marker) — the channel signal is
+          # the version-derived npm dist-tag (`latest` for stable, the
+          # prerelease channel such as `alpha` for prereleases); the GitHub
+          # Release is the visible record.
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,14 @@ jobs:
             echo "::error::Could not derive an npm dist-tag from version \"${VERSION}\"."
             exit 1
           fi
+          # A digit-only channel (e.g. `1.0.0-1` -> `1`) is a valid SemVer range, which npm rejects as a dist-tag; use a named channel such as alpha/beta/rc.
+          case "$TAG" in
+            *[!0-9]*) ;;
+            *)
+              echo "::error::Dist-tag \"${TAG}\" (version ${VERSION}) is a valid SemVer range and cannot be an npm dist-tag; use a named channel such as alpha/beta/rc."
+              exit 1
+              ;;
+          esac
           echo "Resolved npm dist-tag: ${TAG} (version ${VERSION})"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 

--- a/.mstar/knowledge/best-practices/npm-release-pipeline.md
+++ b/.mstar/knowledge/best-practices/npm-release-pipeline.md
@@ -1,7 +1,7 @@
 ---
 module: npm-release-pipeline
 date: 2026-08-14
-last_updated: 2026-08-14
+last_updated: 2026-08-30
 problem_type: best_practice
 category: best-practices
 severity: low
@@ -47,8 +47,9 @@ dsh-llm-fallbacks 建立 npm 发布流水线（单包），参考 mstar-harness 
 ### 坑 3：npm ≥ 11 发布 prerelease 版本**必须**显式 `--tag`
 
 - npm 11.x（Node 24 自带）发布 `X.Y.Z-pre.N` 无 `--tag` → hard-throw「You must specify a tag using --tag when publishing a prerelease version」（npm 11 源码 v11.0.0-v11.6.2 验证；npm 10 无此 guard）。
-- 首发 prerelease 用 `--tag latest`：默认 dist-tag 是 latest，`npm i <pkg>` 能解析；正式版后续自然接管。
-- 对应地，GitHub Release 的 `prerelease` 标志按版本推导：prerelease=$(node -p "/-/.test(require('./package.json').version)")。
+- prerelease 发布到**版本推导的 channel dist-tag**：`X.Y.Z-<channel>.N` → `--tag <channel>`（如 `0.4.0-alpha.1` → `--tag alpha`、`1.0.0-rc.1` → `--tag rc`；stable `X.Y.Z` → `--tag latest`）——prerelease 永不抢占 `latest`，`latest` 始终留在最新 stable 上。
+- 纯数字 channel（如 `1.0.0-1` → `1`）是合法 SemVer range，npm 拒绝其作为 dist-tag：release.yml 的 Resolve npm dist-tag 步骤会 `::error::` + exit 1，**必须**用具名 channel（`alpha`/`beta`/`rc`）。
+- GitHub Release **永远是 regular release**（2026-08-14 用户决策：不加 Pre-release 标记）——channel 信号由 npm dist-tag 承载，GitHub Release 只是发布的可见记录。
 
 ### 坑 4：流水线重跑/版本一致性防护
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,10 @@ PR-driven, two steps — merging the release PR is the ONLY publish path
    version (the first release is `0.1.0-alpha.2`) or leave the input empty
    for an auto `--patch` bump.
 2. **Merge the PR** → `release.yml` runs on the merge commit: validate →
-   build → `npm publish --provenance --access public --tag latest` →
-   tag `vX.Y.Z` → GitHub Release (always a regular release — no Pre-release marker, user decision 2026-08-14; the npm `latest` dist-tag carries the channel semantics).
+   build → `npm publish --provenance --access public --tag <dist-tag>`
+   (the dist-tag is derived from the version: stable → `latest`,
+   prerelease → its channel tag such as `alpha`) → tag `vX.Y.Z` →
+   GitHub Release (always a regular release — no Pre-release marker, user decision 2026-08-14; the version-derived npm dist-tag carries the channel semantics).
 
 Secrets: **zero long-term secrets**. npm auth is Trusted Publishing (OIDC,
 tokenless) once the package exists; the one-time `NODE_AUTH_TOKEN` bootstrap

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,7 +51,7 @@ Registry install notes:
 - **Version**: follows the npm dist-tag (default `latest`); pinning an exact version `dsh-llm-fallbacks@<version>` prevents a later publish from silently changing the code that actually runs.
 - **Mount-only, no patch steps**: a registry install is complete as-is — the plugin makes zero modifications to the dsh source tree (bundle row insert + client inject + its own gateway), no apply/revert scripts, and nothing to re-patch after a dsh upgrade.
 
-> **Release status**: published as `dsh-llm-fallbacks@0.1.0-alpha.2` (latest). The first publish used a one-time `NODE_AUTH_TOKEN` bootstrap secret; Trusted Publishing is configured afterwards for tokenless releases. Release process → [docs/release.md](docs/release.md).
+> **Release channels**: stable releases publish under the `latest` dist-tag (the default for `npm i dsh-llm-fallbacks`); prereleases publish under their channel dist-tag — install a prerelease line via its channel, e.g. `npm i dsh-llm-fallbacks@alpha`. npm authentication is tokenless Trusted Publishing. Release process → [docs/release.md](docs/release.md).
 
 ## 3. npm / pnpm package install
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -88,9 +88,9 @@ Before merging, verify:
 After the merge, `release.yml` triggers (`pull_request: closed` + `merged == true` + title with the `release v` prefix):
 
 1. Checks out the merge commit → `release:validate` → `pnpm build`;
-2. `npm publish --provenance --access public --tag latest` — **explicit `--tag latest`**: npm ≥ 11 (bundled with Node 24) requires an explicit `--tag` when publishing a prerelease, otherwise it hard-throws; the first version (`0.1.0-alpha.2`) lands on the default `latest` dist-tag (`npm i dsh-llm-fallbacks` resolves), and the later stable `0.1.0` naturally takes over `latest`. npm authentication is pure OIDC (Trusted Publishing configured on the npm side; see the "npm authentication" section);
+2. `npm publish --provenance --access public --tag <dist-tag>` — **the dist-tag is derived from the version**: stable `X.Y.Z` publishes under `latest`; prerelease `X.Y.Z-<channel>.N` publishes under `<channel>` (e.g. `0.4.0-alpha.1` → `alpha`, `1.0.0-rc.1` → `rc`), so a prerelease never steals `latest` from the newest stable (an explicit `--tag` is also required by npm ≥ 11, bundled with Node 24, when publishing a prerelease). The `next` tag is not used. npm authentication is pure OIDC (Trusted Publishing configured on the npm side; see the "npm authentication" section);
 3. Tags `v<v>` and pushes (skipped if it exists);
-4. Creates the GitHub Release from the changelog section — **always a regular release** (no Pre-release marker, user decision 2026-08-14); the npm `latest` dist-tag is the channel signal, the GitHub Release is the visible record.
+4. Creates the GitHub Release from the changelog section — **always a regular release** (no Pre-release marker, user decision 2026-08-14); the channel signal is the version-derived npm dist-tag (`latest` for stable, the prerelease channel such as `alpha` for prereleases), the GitHub Release is the visible record.
 
 ## Changelog fragment format
 


### PR DESCRIPTION
## Why

v0.4.0-alpha.1 was published with a hardcoded `--tag latest` (release.yml), stealing the `latest` dist-tag from stable 0.3.5. Registry repair (re-pointing `latest`, adding `alpha`, removing stale `next`) is a separate ops task; this PR fixes the pipeline so it cannot happen again.

## What

- `.github/workflows/release.yml`: new **Resolve npm dist-tag** step derives the tag from the version — stable `X.Y.Z` → `latest`, prerelease `X.Y.Z-<channel>.N` → `<channel>` (e.g. `0.4.0-alpha.1` → `alpha`, `1.0.0-rc.1` → `rc`); fails loudly if the derived tag is empty. Publish step now runs `npm publish --provenance --access public --tag "$TAG"`. No `next` tag is ever created. Comment blocks above Publish and `prerelease: false` updated to the channel model.
- `docs/release.md` step 4, `AGENTS.md` Release flow, `docs/install.md` release-status line: describe the version-derived dist-tag channel model (stable via `latest`, prerelease via channel tag, e.g. `npm i dsh-llm-fallbacks@alpha`).
- New changelog fragment `.changes/unreleased/prerelease-dist-tags.md` (Changed).

## Validation

- Dist-tag shell logic executed locally: `0.4.0-alpha.1` → `alpha`, `0.3.5` → `latest`, `1.0.0-rc.1` → `rc`, `2.1.0-beta.12` → `beta`; empty channel (`1.0.0-`) fails loudly with `::error::`.
- `actionlint .github/workflows/release.yml` clean.

Plan: `.mstar/plans/fix-npm-prerelease-dist-tags.md`