### PR TITLE
fix(client): declare dotted remote namespace injects (dsh 0.1.2-rc.1)

### DIFF
--- a/.changes/unreleased/fix-client-dotted-remote-inject.md
+++ b/.changes/unreleased/fix-client-dotted-remote-inject.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+- Web settings surfaces no longer throw `cannot get property "remote.settings" without inject` on dsh 0.1.2-rc.1 (the client now declares the dotted `remote.llm` / `remote.settings` / `remote.session` namespace injects).

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -110,8 +110,15 @@ export { FallbacksSettingsController, FALLBACKS_SETTINGS_NS } from './fallbacks-
  * it reflectively and degrades to the switches empty state when absent
  * (`setCurrentSession` never called, `loadSwitches` ready with an empty
  * array, which the store already supports).
+ *
+ * rc.1 dotted-namespace contract: each client Remote namespace is a
+ * child-fiber service named `remote.<ns>` (upstream `remoteServiceKey`), and
+ * the traceable proxy forwards `ctx.remote.llm` / `.settings` / `.session`
+ * to those context properties — consumers MUST declare the dotted names
+ * here or the fiber walk throws `cannot get property "remote.llm" without
+ * inject`. `remote` stays for the `$on` invalidation face.
  */
-export const inject = ['slots', 'locale', 'connection', 'remote', 'uiConversation']
+export const inject = ['slots', 'locale', 'connection', 'remote', 'uiConversation', 'remote.llm', 'remote.settings', 'remote.session']
 
 /**
  * Register the `fallbacks` dictionaries and the plugin-config card once the
@@ -135,7 +142,13 @@ export function apply(ctx: ClientContext): void {
   // catalog, and the switch-history tail page ride `ctx.remote` (guide §9).
   // The generated namespace merge ships with the host build, so the boundary
   // casts once to the store's structural face — the session-controller
-  // client's `ctx.remote as unknown as SessionRemotes` pattern.
+  // client's `ctx.remote as unknown as SessionRemotes` pattern. The dotted
+  // namespace services `remote.llm` / `remote.settings` / `remote.session`
+  // are declared in `inject` (rc.1 dotted-namespace contract): the traceable
+  // proxy forwards `ctx.remote.<ns>` to the child-fiber service
+  // `remote.<ns>`, which the fiber walk only resolves when the dotted name
+  // is injected — dropping one throws `cannot get property "remote.settings"
+  // without inject` at card load.
   const controller = new FallbacksSettingsController(
     ctx.remote as unknown as FallbacksRemote,
     connection.rpc,

--- a/tests/client-slot-registration.spec.ts
+++ b/tests/client-slot-registration.spec.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
-import { apply as applyClient } from '../src/client/index.ts'
+import { apply as applyClient, inject } from '../src/client/index.ts'
 
 let ctx: Context
 
@@ -32,6 +32,13 @@ beforeEach(() => {
     },
     rpc: { call: vi.fn() },
   })
+  // rc.1 dotted-namespace contract: each client Remote namespace is a
+  // child-fiber service named `remote.<ns>` (upstream `remoteServiceKey`);
+  // provide the dotted services (empty faces — this spec never reads
+  // namespaces) so the declared injects resolve like production.
+  ctx.provide('remote.llm', {})
+  ctx.provide('remote.settings', {})
+  ctx.provide('remote.session', {})
   ctx.provide('remote', { $on: () => () => {} })
 })
 
@@ -40,6 +47,17 @@ afterEach(async () => {
 })
 
 describe('client slot registration', () => {
+  it('declares the dotted remote namespace injects (rc.1 contract)', () => {
+    // Regression pin (upstream apply.client.spec.ts asserts the array
+    // literally): each client Remote namespace is a child-fiber service
+    // named `remote.<ns>`; without the dotted names the fiber walk throws
+    // `cannot get property "remote.llm" without inject` at card load.
+    expect(inject).toEqual([
+      'slots', 'locale', 'connection', 'remote', 'uiConversation',
+      'remote.llm', 'remote.settings', 'remote.session',
+    ])
+  })
+
   it('registers the settings.plugin.item card with both key and id', () => {
     const registered: Array<{ name: string; key?: string; id?: string }> = []
     ctx.provide('slots', {

--- a/tests/conversation-switch.spec.tsx
+++ b/tests/conversation-switch.spec.tsx
@@ -208,6 +208,17 @@ function fakeRuntime() {
   const eventsLedger: unknown[] = []
   const disposers: Array<() => void> = []
   const locales: Record<string, unknown> = {}
+  // rc.1 dotted-namespace contract: each client Remote namespace is a
+  // child-fiber service named `remote.<ns>` (upstream `remoteServiceKey`);
+  // the fixture provides them as separate dotted services (empty faces —
+  // this spec never reads namespaces) so the declared injects resolve like
+  // production, and the assembly face forwards to them (mirror of the
+  // traceable proxy: `ctx.remote.llm` → `ctx['remote.llm']`).
+  const services: Record<string, unknown> = {
+    'remote.llm': {},
+    'remote.settings': {},
+    'remote.session': {},
+  }
   const slots = {
     register: (options: Record<string, unknown>, component: unknown): (() => void) => {
       const name = options.name as string
@@ -241,18 +252,19 @@ function fakeRuntime() {
       },
       bind: (): never => { throw new Error('test: apply must not bind t — the node t seat comes from PropsLocale') },
     },
-    get: (key: string): unknown => (
-      key === 'connection'
-        ? {
-            api: {
-              settings: { describe: vi.fn(), update: vi.fn(), replace: vi.fn(), mutate: vi.fn() },
-              llm: { providers: vi.fn(), models: vi.fn(), discoverModels: vi.fn() },
-              sessions: { history: vi.fn() },
-            },
-            rpc: { call: vi.fn() },
-          }
-        : undefined
-    ),
+    get: (key: string): unknown => {
+      if (key === 'connection') {
+        return {
+          api: {
+            settings: { describe: vi.fn(), update: vi.fn(), replace: vi.fn(), mutate: vi.fn() },
+            llm: { providers: vi.fn(), models: vi.fn(), discoverModels: vi.fn() },
+            sessions: { history: vi.fn() },
+          },
+          rpc: { call: vi.fn() },
+        }
+      }
+      return services[key]
+    },
     effect: (fn: () => unknown): (() => void) => {
       const disposer = fn()
       return typeof disposer === 'function' ? disposer as () => void : () => {}
@@ -270,6 +282,9 @@ function fakeRuntime() {
         }
         return () => {}
       },
+      get llm() { return services['remote.llm'] },
+      get settings() { return services['remote.settings'] },
+      get session() { return services['remote.session'] },
     },
   }
   return { ctx, slotsLedger, eventsLedger, locales }

--- a/tests/fallbacks-card.spec.tsx
+++ b/tests/fallbacks-card.spec.tsx
@@ -503,6 +503,17 @@ function fakeRuntime() {
   const ledger: Record<string, Array<{ name: string; options: Record<string, unknown>; component: unknown }>> = {}
   const disposers: Array<() => void> = []
   const locales: Record<string, unknown> = {}
+  // rc.1 dotted-namespace contract: each client Remote namespace is a
+  // child-fiber service named `remote.<ns>` (upstream `remoteServiceKey`);
+  // the fixture provides them as separate dotted services (empty faces —
+  // this spec never reads namespaces) so the declared injects resolve like
+  // production, and the assembly face forwards to them (mirror of the
+  // traceable proxy: `ctx.remote.llm` → `ctx['remote.llm']`).
+  const services: Record<string, unknown> = {
+    'remote.llm': {},
+    'remote.settings': {},
+    'remote.session': {},
+  }
   const slots = {
     register: (options: Record<string, unknown>, component: unknown): (() => void) => {
       const name = options.name as string
@@ -533,13 +544,12 @@ function fakeRuntime() {
       },
       bind: (): never => { throw new Error('test: apply must not bind t — the card t seat comes from PropsLocale') },
     },
-    get: (key: string): unknown => (
-      key === 'connection'
-        ? {
-            rpc: { call: vi.fn() },
-          }
-        : undefined
-    ),
+    get: (key: string): unknown => {
+      if (key === 'connection') {
+        return { rpc: { call: vi.fn() } }
+      }
+      return services[key]
+    },
     effect: (fn: () => unknown): (() => void) => {
       const disposer = fn()
       return typeof disposer === 'function' ? disposer as () => void : () => {}
@@ -565,6 +575,9 @@ function fakeRuntime() {
         }
         return () => {}
       },
+      get llm() { return services['remote.llm'] },
+      get settings() { return services['remote.settings'] },
+      get session() { return services['remote.session'] },
     },
   }
   return { ctx, ledger, locales }

--- a/tests/fallbacks-store.spec.ts
+++ b/tests/fallbacks-store.spec.ts
@@ -158,16 +158,28 @@ function followThrow(error: Error): AsyncIterable<SessionFollowFrame> {
 }
 
 /**
- * A `remote` service double for the client apply wiring: records `$on`
- * subscriptions (returning per-event disposers, tracked for teardown
- * assertions) and dispatches the forwarded remote events
- * (`settings/document-updated`, `llm/adapters-updated`) through the recorded
- * listener, mirroring the gateway's one-way delivery. One `Set` per event
- * (qc2 S-5 / qc3 S-3): `Map.set` silently overwrote an earlier listener, so
- * a regressed duplicate `$on` registration would pass; the Set plus the
- * single-listener emit guard make any double subscription fail loudly.
+ * A `remote` service double for the client apply wiring: provides the rc.1
+ * dotted namespace services (`remote.settings` / `remote.llm` /
+ * `remote.session` — upstream `remoteServiceKey`) so the declared injects
+ * resolve through the same fiber walk production uses, and provides the
+ * assembly face (`remote`) whose namespace getters forward to the dotted
+ * services (mirror of the traceable proxy: `ctx.remote.llm` →
+ * `ctx['remote.llm']`). Records `$on` subscriptions (returning per-event
+ * disposers, tracked for teardown assertions) and dispatches the forwarded
+ * remote events (`settings/document-updated`, `llm/adapters-updated`)
+ * through the recorded listener, mirroring the gateway's one-way delivery.
+ * One `Set` per event (qc2 S-5 / qc3 S-3): `Map.set` silently overwrote an
+ * earlier listener, so a regressed duplicate `$on` registration would pass;
+ * the Set plus the single-listener emit guard make any double subscription
+ * fail loudly.
  */
-function makeRemote(namespaces: { settings?: unknown; llm?: unknown; session?: unknown } = {}) {
+function makeRemote(ctx: Context, namespaces: { settings?: unknown; llm?: unknown; session?: unknown } = {}) {
+  // rc.1 dotted-namespace contract: each client Remote namespace is a
+  // child-fiber service named `remote.<ns>`; provide them as separate
+  // dotted services so the fiber walk resolves them exactly like production.
+  for (const [ns, value] of Object.entries(namespaces)) {
+    ctx.provide(`remote.${ns}`, value)
+  }
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
   const disposers: Array<{ invoked: boolean }> = []
   const $on = vi.fn((event: string, listener: (...args: unknown[]) => void): (() => void) => {
@@ -181,8 +193,16 @@ function makeRemote(namespaces: { settings?: unknown; llm?: unknown; session?: u
       entry.invoked = true
     }
   })
+  // The assembly face: `$on` invalidation seat + namespace getters
+  // forwarding to the dotted services (mirror of the traceable proxy).
+  const remote = {
+    $on,
+    get settings() { return ctx.get('remote.settings') },
+    get llm() { return ctx.get('remote.llm') },
+    get session() { return ctx.get('remote.session') },
+  }
+  ctx.provide('remote', remote)
   return {
-    remote: { $on, ...namespaces },
     $on,
     emit(event: string, ...args: unknown[]): void {
       const set = listeners.get(event)
@@ -2048,8 +2068,10 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
     // invalidations through `ctx.remote.$on` (20260811 remote events), and
     // the store reads the settings namespace through it (0.1.2:
     // `ConnectionHandle` dropped `api` — describe rides `ctx.remote`).
-    const { remote, disposers } = makeRemote({ settings: { describe } })
-    ctx.provide('remote', remote)
+    // makeRemote provides the rc.1 dotted namespace services
+    // (`remote.settings` / `remote.llm` / `remote.session`) + the assembly
+    // face, so the declared injects resolve like production.
+    const { disposers } = makeRemote(ctx, { settings: { describe } })
     // Slots service double: run the card-registration generator and capture the
     // injected controller — the seam apply() uses to hand the controller over.
     let controller: FallbacksSettingsController | undefined
@@ -2099,11 +2121,11 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
     ctx.provide('connection', {
       rpc: makeRpc().rpc,
     })
-    ctx.provide('remote', makeRemote({
+    makeRemote(ctx, {
       settings: { describe },
       llm: { listConfigurableProviders: providers },
       session: { modelCatalog: models, follow: history },
-    }).remote)
+    })
     let controller: FallbacksSettingsController | undefined
     ctx.provide('slots', {
       inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },
@@ -2159,12 +2181,11 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
     // Remote service double: the payload-free llm/adapters-updated event
     // (20260811 forwarding) is dispatched through the recorded listener; the
     // settings + llm + session namespaces ride it (0.1.2 remote face).
-    const { remote, emit } = makeRemote({
+    const { emit } = makeRemote(ctx, {
       settings: { describe },
       llm: { listConfigurableProviders: providers },
       session: { modelCatalog: models },
     })
-    ctx.provide('remote', remote)
     let controller: FallbacksSettingsController | undefined
     ctx.provide('slots', {
       inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },
@@ -2221,11 +2242,11 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
     })
     // Remote service double: the invalidation wiring subscribes through it;
     // `session/follow` is the status block's face (0.1.2 remote face).
-    ctx.provide('remote', makeRemote({
+    makeRemote(ctx, {
       settings: { describe: vi.fn() },
       llm: { listConfigurableProviders: vi.fn() },
       session: { modelCatalog: vi.fn(), follow: history },
-    }).remote)
+    })
     let controller: FallbacksSettingsController | undefined
     ctx.provide('slots', {
       inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },
@@ -2278,12 +2299,11 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
     })
     // Remote service double: describe + llm providers + session catalog/follow ride it
     // (0.1.2 remote face).
-    const { remote, emit } = makeRemote({
+    const { emit } = makeRemote(ctx, {
       settings: { describe },
       llm: { listConfigurableProviders: providers },
       session: { modelCatalog: models, follow: history },
     })
-    ctx.provide('remote', remote)
     let controller: FallbacksSettingsController | undefined
     ctx.provide('slots', {
       inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },
@@ -2331,12 +2351,11 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
       rpc: makeRpc().rpc,
     })
     // Remote service double: describe + session follow ride it (0.1.2 remote face).
-    const { remote, emit } = makeRemote({
+    const { emit } = makeRemote(ctx, {
       settings: { describe },
       llm: { listConfigurableProviders: vi.fn() },
       session: { modelCatalog: vi.fn(), follow: history },
     })
-    ctx.provide('remote', remote)
     let controller: FallbacksSettingsController | undefined
     ctx.provide('slots', {
       inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },
@@ -2377,12 +2396,11 @@ describe('client apply disposal wiring (F-006 / M-01)', () => {
     ctx.provide('connection', {
       rpc: makeRpc().rpc,
     })
-    const { remote } = makeRemote({
+    makeRemote(ctx, {
       settings: { describe },
       llm: { listConfigurableProviders: providers },
       session: { modelCatalog: models, follow: history },
     })
-    ctx.provide('remote', remote)
     let controller: FallbacksSettingsController | undefined
     ctx.provide('slots', {
       inject: (_name: string, thunk: () => Iterable<unknown>) => { for (const _dispose of thunk()) { /* run the registration generator */ } },

--- a/tests/general-row.spec.tsx
+++ b/tests/general-row.spec.tsx
@@ -191,6 +191,17 @@ function fakeRuntime() {
   const ledger: Record<string, Array<{ name: string; options: Record<string, unknown>; component: unknown }>> = {}
   const disposers: Array<() => void> = []
   const locales: Record<string, unknown> = {}
+  // rc.1 dotted-namespace contract: each client Remote namespace is a
+  // child-fiber service named `remote.<ns>` (upstream `remoteServiceKey`);
+  // the fixture provides them as separate dotted services (empty faces —
+  // this spec never reads namespaces) so the declared injects resolve like
+  // production, and the assembly face forwards to them (mirror of the
+  // traceable proxy: `ctx.remote.llm` → `ctx['remote.llm']`).
+  const services: Record<string, unknown> = {
+    'remote.llm': {},
+    'remote.settings': {},
+    'remote.session': {},
+  }
   const slots = {
     register: (options: Record<string, unknown>, component: unknown): (() => void) => {
       const name = options.name as string
@@ -218,13 +229,12 @@ function fakeRuntime() {
       },
       bind: (): never => { throw new Error('test: apply must not bind t — the row t seat comes from PropsLocale') },
     },
-    get: (key: string): unknown => (
-      key === 'connection'
-        ? {
-            rpc: { call: vi.fn() },
-          }
-        : undefined
-    ),
+    get: (key: string): unknown => {
+      if (key === 'connection') {
+        return { rpc: { call: vi.fn() } }
+      }
+      return services[key]
+    },
     effect: (fn: () => unknown): (() => void) => {
       const disposer = fn()
       return typeof disposer === 'function' ? disposer as () => void : () => {}
@@ -242,6 +252,9 @@ function fakeRuntime() {
         }
         return () => {}
       },
+      get llm() { return services['remote.llm'] },
+      get settings() { return services['remote.settings'] },
+      get session() { return services['remote.session'] },
     },
   }
   return { ctx, ledger, locales }


### PR DESCRIPTION
## Problem

dsh@next (0.1.2-rc.1) + dsh-llm-fallbacks: loading the fallbacks card on the web 插件配置 page throws `cannot get property "remote.settings" without inject` — the card never renders its config form or provider/model directory. Same failure class as omdsh-dev/dsh-advisor#76 (its scope note deferred this repo as a sibling follow-up).

## Root cause

Upstream dsh commit `5b2f679e4a` (shipped in the 0.1.2 alpha.2 → rc.1 line) split the client Remote assembly into **dotted per-namespace child-fiber services** (`remote.llm`, `remote.settings`, `remote.session` — child-fiber services named via upstream `remoteServiceKey`). Consumers must declare the dotted names in their cordis `inject`: reading `ctx.remote.settings` forwards through the traceable proxy to a context property read of `remote.settings`, and the fiber walk only resolves it when the consuming plugin declares the dotted name. #97 already bumped peers to 0.1.2-rc.1 (types compile — the merge landed upstream), so this only manifests at runtime. The unit fixtures stubbed `remote` as a plain object, so the real resolution path was never exercised.

## Fix

- `src/client/index.ts`: `inject` → `['slots','locale','connection','remote','uiConversation','remote.llm','remote.settings','remote.session']`; root `remote` stays (the `$on` invalidation face); rc.1 dotted-namespace contract documented in the docblock. Reference shape: `../dsh-advisor/src/client/index.ts`.
- Client-runtime fixtures (`fallbacks-store.spec.ts` `makeRemote` + 7 provide sites, `client-slot-registration.spec.ts`, `fallbacks-card.spec.tsx`, `general-row.spec.tsx`, `conversation-switch.spec.tsx`) now provide the dotted services through the same lookup the real fiber uses (advisor fixture pattern: `services` record + `get(key)` forwarding + assembly-face getters mirroring the traceable proxy).
- Exactly one literal inject-shape regression assertion (`tests/client-slot-registration.spec.ts`) — fails if any dotted name is dropped (verified by temporary removal during development).
- Changelog fragment: `.changes/unreleased/fix-client-dotted-remote-inject.md` (Fixed).

## Verification

- `pnpm typecheck` / `pnpm test` (48 files, 1044 tests) / `pnpm build` (incl. verify-dist client purity gate) — all green on `ab1c023`.
- QC (single seat, inline hotfix): **Approve** — 0 critical / 0 warning / 3 suggestions (`.mstar/sdd/hotfix-client-remote-dotted-inject/review/qc.md`, consolidated).
- QA (mandatory, live surface): **PASS** on dsh 0.1.2-rc.1 web profile with this branch's build mounted (scratch profile): fallbacks card listed + enabled config form populated (describe + provider/model directory), General settings status row renders, **zero `without inject` errors** in browser console and gateway log (screenshots + log in review bundle `qa.md` / `evidence/`).

## Scope

Web client half only (mirrors dsh-advisor#76). The TUI/headless halves do not read `remote.*`. No dsh-source changes — mount-only constraint intact.

## Residuals

3 non-blocking suggestions registered (docblock error-message disambiguation, explicit real-cordis-Context test, assertion split) — tracked in the local process register; none block this fix.