### PR TITLE
docs: add community health files (code of conduct, contributing, security)

### DIFF
--- a/.changes/unreleased/community-standard-files.md
+++ b/.changes/unreleased/community-standard-files.md
@@ -1,0 +1,4 @@
+---
+category: Changed
+---
+- Add `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md` at the repository root.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at tech@btang.cn. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing to dsh-llm-fallbacks
+
+Thanks for taking the time to contribute. `dsh-llm-fallbacks` is a TypeScript
+plugin for dsh (DeepSeek Harness) that builds automatic provider/model fallback
+chains so agent steps keep running when LLM requests fail — see
+[README.md](README.md) for what it does and
+[CONCEPTS.md](CONCEPTS.md) for how it is put together.
+
+This document covers the practical mechanics: prerequisites, setup, the build
+and test commands, the change workflow, and the code constraints this repository
+enforces.
+
+## Before you start
+
+- Participation in this project is covered by
+  [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) (Contributor Covenant v2.1).
+  Unacceptable behavior can be reported to tech@btang.cn.
+- Bug reports, feature requests, and questions go to
+  [the issue tracker](https://github.com/omdsh-dev/dsh-llm-fallbacks/issues).
+  This repository does not currently ship GitHub issue templates or a pull
+  request template, so open a plain issue or pull request and describe the
+  change directly.
+- **Security problems do not go through public issues.** Report them privately
+  as described in [SECURITY.md](SECURITY.md).
+
+## Prerequisites
+
+- **Node >= 22** — declared in `package.json` under `engines.node`.
+- **pnpm >= 10** — the project stack is pnpm 11.21+; CI installs with pnpm
+  11.21.0 (`.github/workflows/ci.yml`).
+- **Peer resolution at development time.** The `@deepseek-ai/*` packages are
+  private to the dsh host and declared as `peerDependencies` (`^0.1.5-rc.1`).
+  They resolve from the npm registry during development through
+  `autoInstallPeers: true` in `pnpm-workspace.yaml` plus an authentication token
+  in your user-level `~/.npmrc`. The full setup (including the pnpm 11
+  credential rule) is described in [docs/install.md](docs/install.md).
+
+## Setup
+
+```sh
+git clone https://github.com/omdsh-dev/dsh-llm-fallbacks.git
+cd dsh-llm-fallbacks
+pnpm install
+```
+
+CI installs with `pnpm install --frozen-lockfile`
+(`.github/workflows/ci.yml`), so when a change touches dependencies, commit the
+matching `pnpm-lock.yaml` update together with `package.json`.
+
+## Build and test commands
+
+| Command | What it does |
+|---|---|
+| `pnpm test` | vitest run — the full suite, including the release-script contract tests in `tests/release-scripts.spec.ts`. |
+| `pnpm build` | Full build: `tsc -p tsconfig.build.json` → `tsdown` → `build-client` → `tsc` → `verify-dist`. |
+| `pnpm typecheck` | TypeScript only (host build config + project emit check); faster than the full build. |
+| `pnpm release:prepare [-- <version> \| -- --patch]` | Release prep: bump the version, assemble `.changes/unreleased/` fragments into `CHANGELOG.md`, archive them, and open/update the `release vX.Y.Z` PR (normally run through the Release prep workflow). |
+| `pnpm release:validate -- v<version>` | Version/tag consistency check. |
+| `actionlint .github/workflows/*.yml` | Workflow lint for the ci, release-prep, and release workflows. Local-only — this step is not part of CI. |
+
+`pnpm test` covers the repair-script fixture suites; CI additionally installs
+the `zstd` binary for them (`.github/workflows/ci.yml`), so install `zstd`
+locally if those suites fail for you with a missing-binary error.
+
+## Change workflow
+
+1. **Branch from `main` and open a pull request.** All changes land through a
+   PR into `main`; never commit directly to `main`.
+2. **Keep the diff surgical** and match the patterns already in the codebase.
+   Prefer extending an existing module over introducing a second convention
+   beside it.
+3. **Write conventional English commit messages**: `feat:`, `fix:`, `docs:`,
+   `chore:`, and so on.
+4. **Run the checks before opening the PR**: `pnpm test`, `pnpm build`, and
+   `pnpm typecheck`. CI runs `pnpm test` and `pnpm build` on every PR
+   (`.github/workflows/ci.yml`).
+5. **Add a changelog fragment** for any user-visible change (next section).
+
+## Changelog fragments
+
+Every user-visible change ships with one fragment file in
+`.changes/unreleased/`. The fragments are what the changelog is made of:
+`pnpm release:prepare` assembles them into `CHANGELOG.md` and archives them to
+`.changes/archive/<version>/`.
+
+- **One file per change.** The filename is any slug ending in `.md`
+  (for example `add-foo.md`). `README.md` and `.gitkeep` are ignored.
+- **Optional frontmatter.** A `category:` key groups the fragment's bullets
+  under a `### <category>` heading in the changelog (`Added`, `Changed`,
+  `Fixed`, ...); one file carries exactly one category. The default is
+  `Changed`.
+- **Body: English `- ` bullet lines only.** The body is rendered verbatim into
+  `CHANGELOG.md`. Non-bullet lines are rendered verbatim too and garble the
+  changelog, so never put them in a fragment.
+
+```markdown
+---
+category: Added
+---
+- Describe the change in one concise English bullet.
+```
+
+A release with zero fragments fails at publish time — the changelog section
+would be empty and the Release workflow refuses to create an empty GitHub
+Release. Format reference: [.changes/unreleased/README.md](.changes/unreleased/README.md)
+and [docs/release.md](docs/release.md).
+
+## Code constraints
+
+- **Mount-only.** The plugin never modifies the dsh source tree — it works by
+  bundle insert + client inject + its own gateway, with no patch steps and no
+  `postinstall`. Keep it that way.
+- **`@deepseek-ai/*` packages are `peerDependencies` only.** Never add them to
+  `dependencies`, `devDependencies`, or `optionalDependencies`, and never
+  reintroduce a local link farm. `tests/peer-deps.test.ts` enforces this
+  contract: peer-only placement of every `@deepseek-ai/*` entry,
+  `autoInstallPeers: true`, and the absence of the retired `dsh:link` /
+  link-farm scripts.
+- **Match existing patterns and keep diffs surgical.**
+
+## Documentation language
+
+English only for docs and user-facing text (project decision 2026-08-14).
+`README.md` is the English main file and `README.zh-CN.md` is its Chinese
+translation; all files under `docs/` are English. Never add Chinese prose to
+`README.md`, `docs/`, `CHANGELOG.md`, or changelog fragments — new Chinese
+prose belongs in `README.zh-CN.md` only.
+
+## Release flow
+
+Releases are PR-driven and two-step, and **merging the release PR is the only
+publish path** — a manual `git tag` does not publish:
+
+1. **Release prep** (manual: Actions → Release prep → Run workflow) assembles
+   the fragments, bumps `package.json`, builds, and opens or updates a
+   `release vX.Y.Z` PR targeting `main`.
+2. **Merge that PR** → the Release workflow validates, builds, publishes to npm
+   with `--provenance --access public` and a version-derived dist-tag, tags
+   `vX.Y.Z`, and creates the GitHub Release.
+
+Publishing authenticates through npm Trusted Publishing (OIDC) with zero
+long-term secrets, and the workflows use only the built-in `GITHUB_TOKEN`.
+Contributions are accepted under the project's MIT license (see
+[LICENSE](LICENSE)). The full SOP — npm authentication, checklist, and
+rollback — is in [docs/release.md](docs/release.md).
+
+## Questions and getting help
+
+If something in this guide is unclear or appears to contradict the repository,
+open an issue at
+[https://github.com/omdsh-dev/dsh-llm-fallbacks/issues](https://github.com/omdsh-dev/dsh-llm-fallbacks/issues)
+and describe what you were trying to do.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Supported versions
+
+`dsh-llm-fallbacks` is a single, continuously released npm package. Only the
+**latest published version** is supported; older versions are not maintained
+and do not receive security fixes. Please reproduce a report against the latest
+published version (`dsh-llm-fallbacks` on npm) before sending it.
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities **privately by email to
+[tech@btang.cn](mailto:tech@btang.cn)**.
+
+**Do not open a public GitHub issue for a security problem** — a public issue
+exposes the problem before a fix exists.
+
+GitHub private vulnerability reporting (the *Report a vulnerability* button
+under **Security**) is not enabled on this repository; it may be enabled later
+as an additional channel alongside the email address above.
+
+Reports are acknowledged, and reporters are kept informed as the issue is
+investigated. There is no bug-bounty program.
+
+## What to include
+
+To make a report actionable, please include:
+
+- the affected version — the npm version (`dsh-llm-fallbacks@<version>`) or the
+  commit SHA you built from;
+- your environment and front end — the dsh **web** profile or the **dsh-tui**
+  terminal profile, with the dsh version if known;
+- reproduction steps — the configuration and request sequence that triggers the
+  problem;
+- observed behavior versus expected behavior;
+- your assessment of the impact (for example: leaked credential, request routed
+  to an unintended provider/model, unauthorized settings write);
+- any proof-of-concept, if you have one.
+
+Redact secrets and tokens from anything you send: API keys, npm tokens, and
+session logs that contain authorization headers.
+
+## Scope
+
+**In scope** — the code of this plugin:
+
+- fallback chain decisions (when and where a request is re-dispatched after a
+  retry-exhausted, auth, quota, or rate-limit failure);
+- the `fallbacks:` settings surface and how configuration layers are composed;
+- the `/api/fallbacks/get`, `/api/fallbacks/set`, and `/api/fallbacks/reset`
+  gateway channel;
+- the web settings card and the dsh-tui `/settings` fallbacks section;
+- role seeds and role resolution;
+- the repair script (`scripts/repair-fallbacks-switch-logs.ts`, run as
+  `pnpm repair:fallbacks-switch-logs`).
+
+**Out of scope**:
+
+- vulnerabilities in the **dsh host itself** or in the `@deepseek-ai/*`
+  packages — those belong upstream, with the DeepSeek Harness maintainers;
+- general support questions, setup problems, and feature requests — take those
+  to [the issue tracker](https://github.com/omdsh-dev/dsh-llm-fallbacks/issues)
+  instead.
+
+## Disclosure
+
+If you report a vulnerability, please allow time for it to be investigated and
+fixed before disclosing it publicly. Confirmed fixes ship as normal npm
+releases and are recorded in [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
## Why

The repository's [community profile](https://github.com/omdsh-dev/dsh-llm-fallbacks/community) reported **37%** health. Missing checklist rows: *Code of conduct*, *Contributing*, *Security policy*, *Issue templates*, *Pull request template*.

This PR fills the three **non-template** gaps. Issue templates and the pull request template are deliberately out of scope (maintainer decision) — those two checklist rows stay red by design.

## What

Four additive files, no source/test/config change:

| File | Content |
|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant v2.1, body verbatim, enforcement contact `tech@btang.cn` |
| `CONTRIBUTING.md` | prerequisites (Node >= 22, pnpm >= 10), setup, the real build/test/release scripts, branch → PR → `main` workflow, changelog-fragment rules, mount-only + `@deepseek-ai/*` peer-only constraints, English-only docs policy |
| `SECURITY.md` | supported versions (latest published only), private reporting by email, in-scope plugin surfaces vs out-of-scope upstream `@deepseek-ai/*` / host issues, coordinated disclosure |
| `.changes/unreleased/community-standard-files.md` | changelog fragment, `category: Changed` |

Root placement is deliberate: GitHub scans root / `.github/` / `docs/` for community health files.

`SECURITY.md` states the truth about the current settings: GitHub private vulnerability reporting is **disabled** on this repository, so the email channel is the one offered (with a note that advisories may be enabled later as an additional channel).

## Verification

- `git diff --stat origin/main...HEAD` → the four files only, 308 insertions, zero deletions.
- CJK scan over all four files → 0 matches; the files are English-only.
- `CODE_OF_CONDUCT.md` compared against the canonical markdown from <https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md>: after filling the single `[INSERT CONTACT METHOD]` placeholder with `tech@btang.cn`, the only difference is the canonical's leading and trailing blank line. `grep -c '\[INSERT'` → `0` — no placeholder survives and the body is not paraphrased.
- Every relative link target in the three documents resolves on this branch (`.changes/unreleased/README.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `CONCEPTS.md`, `LICENSE`, `README.md`, `SECURITY.md`, `docs/install.md`, `docs/release.md`).
- Every command listed in `CONTRIBUTING.md` exists in `package.json` scripts (or is the documented local-only `actionlint` step); the `zstd` CI note matches `.github/workflows/ci.yml`.
- No test/build run locally: documentation-only change, nothing the suite covers is touched. CI `build-and-test` passed.

## Post-merge result (observed, after merge as `41b42cf`)

`gh api repos/omdsh-dev/dsh-llm-fallbacks/community/profile`:

```json
{"health_percentage": 87, "missing": ["issue_template", "pull_request_template"]}
```

- `missing` dropped `code_of_conduct`, `code_of_conduct_file`, and `contributing` — the load-bearing criterion, met exactly.
- The rendered [checklist](https://github.com/omdsh-dev/dsh-llm-fallbacks/community) shows **Added** for Description, README, Code of conduct, Contributing, License, and **Security policy** — so the security-policy row did clear, and it is visible only in the UI: the profile API exposes no security-policy key, so `SECURITY.md` never appears in that JSON by design. Its absence there is expected, not a failure.
- Only *Issue templates* and *Pull request template* remain, as intended.

**Correction to an earlier prediction in this description.** This PR description previously claimed the score would be `75` — "3/8 rows → 6/8" — and that any other value was a real path error. Post-merge the observed value is **87**, i.e. **7/8**. GitHub's score counts one more satisfied row than the `files` keys suggest (the code-of-conduct *file* variant, and/or the security-policy row, weigh beyond the null-key list). The 8-row equal-weight model was **wrong**; the `missing` list carried the acceptance and behaved as documented. The prediction is left visible here rather than silently rewritten, so the next reader does not reuse that model.
